### PR TITLE
handle case of missing ValidYN attribute

### DIFF
--- a/app/models/pubmed_source_record.rb
+++ b/app/models/pubmed_source_record.rb
@@ -184,8 +184,8 @@ class PubmedSourceRecord < ActiveRecord::Base
       ##
       # Ignore an <Author> that contains only <CollectiveName>
       return if author.xpath('CollectiveName').present?
-      # Ignore an <Author ValidYN="N">
-      return if author.attributes['ValidYN'].value == 'N'
+      # Ignore an <Author ValidYN="N"> or missing ValidYN attribute
+      return if author.attributes['ValidYN'].blank? || author.attributes['ValidYN'].value == 'N'
       # Extract name elements
       lastname = author.xpath('LastName').text
       forename = author.xpath('ForeName').text

--- a/spec/models/pubmed_source_record_spec.rb
+++ b/spec/models/pubmed_source_record_spec.rb
@@ -89,6 +89,10 @@ describe PubmedSourceRecord, :vcr do
           xml: author_doc(' <Author ValidYN="N"> <LastName>Whitely</LastName> <ForeName>R J</ForeName> <Initials>RJ</Initials> </Author>'),
           hash: nil
         },
+        Whitely_Malformed: { # missing ValidYN attribute
+          xml: author_doc(' <Author> <LastName>Whitely</LastName> <ForeName>R J</ForeName> <Initials>RJ</Initials> </Author>'),
+          hash: nil
+        },
         Collective: {
           xml: author_doc(' <Author ValidYN="Y"> <CollectiveName>SBU-group. Swedish Council of Technology Assessment in Health Care</CollectiveName> </Author>'),
           hash: nil
@@ -103,6 +107,9 @@ describe PubmedSourceRecord, :vcr do
     end
     it 'extracts nothing for Whitely example' do
       check_author_hash(:Whitely)
+    end
+    it 'extracts nothing for malformed Whitely example' do
+      check_author_hash(:Whitely_Malformed)
     end
     it 'extracts nothing for Collective example' do
       check_author_hash(:Collective)


### PR DESCRIPTION
This PR fixes #74. I've made the assumption that if `ValidYN` is *missing* then we should ignore it.