### PR TITLE
inject the author identity (cap_profile_id) into the authorship data

### DIFF
--- a/lib/cap_authors_poller.rb
+++ b/lib/cap_authors_poller.rb
@@ -126,6 +126,11 @@ class CapAuthorsPoller
   end
 
   def update_existing_contributions(author, incoming_authorships)
+    # inject author identity into the authorship data
+    incoming_authorships = incoming_authorships.dup.map do |contrib|
+      contrib[:cap_profile_id] = author.cap_profile_id
+      contrib
+    end
     incoming_authorships.each do |authorship|
       if !Contribution.authorship_valid? authorship
         msg = "Invalid authorship: Author.find_by(cap_profile_id: #{author.cap_profile_id}); #{authorship.inspect}"


### PR DESCRIPTION
This PR fixes #75 by injecting the `cap_profile_id` into the `authorship` data we get from the CAP database before validating it for an existing author.