### PR TITLE
use valid_fields? only to check on CAP authorship attached to profile

### DIFF
--- a/lib/cap_authors_poller.rb
+++ b/lib/cap_authors_poller.rb
@@ -127,8 +127,8 @@ class CapAuthorsPoller
 
   def update_existing_contributions(author, incoming_authorships)
     incoming_authorships.each do |authorship|
-      if !Contribution.authorship_valid? authorship
-        msg = "Invalid authorship: Author.find_by(cap_profile_id: #{author.cap_profile_id}); #{authorship.inspect}"
+      if !Contribution.valid_fields? authorship
+        msg = "Invalid fields in authorship: Author.find_by(cap_profile_id: #{author.cap_profile_id}); #{authorship.inspect}"
         NotificationManager.error(ArgumentError.new(msg), msg, self)
         @invalid_contribs += 1
         next

--- a/spec/lib/cap_authors_poller_spec.rb
+++ b/spec/lib/cap_authors_poller_spec.rb
@@ -174,10 +174,10 @@ describe CapAuthorsPoller, :vcr do
 
     it 'handles when authorship is invalid submission' do
       authorship = authorship_record['authorship'].first
-      expect(Contribution.authorship_valid?(authorship)).to be true
+      expect(Contribution.valid_fields?(authorship)).to be true
       # Change the authorship so it fails to validate
       authorship.delete 'visibility'
-      expect(Contribution).to receive(:authorship_valid?).with(authorship).and_call_original
+      expect(Contribution).to receive(:valid_fields?).with(authorship).and_call_original
       # Test that an invalid authorship will generate error logging and notification
       expect(NotificationManager).to receive(:error)
       # Test that an invalid authorship will increment the counter


### PR DESCRIPTION
This PR fixes #75.