### PR TITLE
86 missing wos ids

### DIFF
--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -232,7 +232,7 @@ class Publication < ActiveRecord::Base
       if i.persisted?
         i.save
       else
-        publication_identifiers << i
+        publication_identifiers << i unless publication_identifiers.include? i
       end
     end
   end
@@ -326,15 +326,15 @@ class Publication < ActiveRecord::Base
   end
 
   def add_all_identifiers_in_db_to_pub_hash
-    pub_hash[:identifier] ||= []
     publication_identifiers.reload if persisted?
-    pub_hash[:identifier] = publication_identifiers.collect do |identifier|
+    db_ids = publication_identifiers.collect do |id|
       ident_hash = {}
-      ident_hash[:type] = identifier.identifier_type unless identifier.identifier_type.blank?
-      ident_hash[:id] = identifier.identifier_value unless identifier.identifier_value.blank?
-      ident_hash[:url] = identifier.identifier_uri unless identifier.identifier_uri.blank?
+      ident_hash[:type] = id.identifier_type unless id.identifier_type.blank?
+      ident_hash[:id] = id.identifier_value unless id.identifier_value.blank?
+      ident_hash[:url] = id.identifier_uri unless id.identifier_uri.blank?
       ident_hash
     end
+    pub_hash[:identifier] = db_ids
   end
 
   def add_all_db_contributions_to_my_pub_hash
@@ -346,7 +346,6 @@ class Publication < ActiveRecord::Base
 
   def update_formatted_citations
     h = PubHash.new(pub_hash)
-
     pub_hash[:apa_citation] = h.to_apa_citation
     pub_hash[:mla_citation] = h.to_mla_citation
     pub_hash[:chicago_citation] = h.to_chicago_citation

--- a/app/models/pubmed_source_record.rb
+++ b/app/models/pubmed_source_record.rb
@@ -177,11 +177,14 @@ class PubmedSourceRecord < ActiveRecord::Base
     # <AffiliationInfo> was added to <AuthorList> with the 2015 DTD. The <AffiliationInfo>
     #                   envelope element includes <Affliliation> and <Identifier>.
     #
+    # @param author [Nokogiri::XML::Element] an <Author> element
     # @return author_hash [Hash] with keys :firstname, :middlename and :lastname
     def author_to_hash(author)
       # <Author> examples provide many variations at No. 20 from
       # https://www.nlm.nih.gov/bsd/licensee/elements_descriptions.html
       ##
+      # Ignore an empty <Author/> element
+      return if author.children.empty?
       # Ignore an <Author> that contains only <CollectiveName>
       return if author.xpath('CollectiveName').present?
       # Ignore an <Author ValidYN="N"> or missing ValidYN attribute

--- a/app/models/sciencewire_source_record.rb
+++ b/app/models/sciencewire_source_record.rb
@@ -32,6 +32,20 @@ class SciencewireSourceRecord < ActiveRecord::Base
     @publication_xml ||= Nokogiri::XML(source_data)
   end
 
+  # Retrieve this PublicationItem from ScienceWire and update the pmid,
+  # is_active, source_data and the source_fingerprint fields.
+  # @return [Boolean] the return value from update_attributes!
+  def sciencewire_update
+    sw_record_doc = ScienceWireClient.new.get_sw_xml_source_for_sw_id(sciencewire_id)
+    sw_pub = ScienceWirePublication.new sw_record_doc
+    attrs = {}
+    attrs[:pmid] = sw_pub.pmid unless sw_pub.pmid.blank?
+    attrs[:is_active] = !sw_pub.obsolete?
+    attrs[:source_data] = sw_pub.to_xml
+    attrs[:source_fingerprint] = Digest::SHA2.hexdigest(sw_record_doc)
+    update_attributes! attrs
+  end
+
   ##
   # Class methods
 

--- a/app/models/sciencewire_source_record.rb
+++ b/app/models/sciencewire_source_record.rb
@@ -9,10 +9,31 @@ class SciencewireSourceRecord < ActiveRecord::Base
   @@sw_book_types ||= Settings.sw_doc_type_mappings.book.join('|')
 
   include ActionView::Helpers::DateHelper
-  # one instance method, the rest are class methods
+
+  ##
+  # Instance methods
+
   def source_as_hash
-    SciencewireSourceRecord.convert_sw_publication_doc_to_hash(Nokogiri::XML(source_data).xpath('//PublicationItem'))
+    SciencewireSourceRecord.convert_sw_publication_doc_to_hash(publication_item)
   end
+
+  # @return publication [ScienceWirePublication] PublicationItem object
+  def publication
+    @publication ||= ScienceWirePublication.new publication_item
+  end
+
+  # @return publication_item [Nokogiri::XML::Element] XML element for PublicationItem
+  def publication_item
+    @publication_item ||= publication_xml.at_xpath('//PublicationItem')
+  end
+
+  # @return publication_xml [Nokogiri::XML::Document] XML document
+  def publication_xml
+    @publication_xml ||= Nokogiri::XML(source_data)
+  end
+
+  ##
+  # Class methods
 
   def self.get_pub_by_pmid(pmid)
     sw_pub_hash = get_sciencewire_hash_for_pmid(pmid)

--- a/fixtures/vcr_cassettes/SciencewireSourceRecord/instance_methods/_sciencewire_update/updates_the_is_active_field.yml
+++ b/fixtures/vcr_cassettes/SciencewireSourceRecord/instance_methods/_sciencewire_update/updates_the_is_active_field.yml
@@ -1,0 +1,87 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sciencewirerest.discoverylogic.com/PublicationCatalog/PublicationItems?format=xml&publicationItemIDs=64367696
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Tue, 14 Jun 2016 22:25:55 GMT
+      Licenseid:
+      - Settings.SCIENCEWIRE.LICENSE_ID
+      Host:
+      - Settings.SCIENCEWIRE.HOST
+      Connection:
+      - Keep-Alive
+      Expect:
+      - 100-continue
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/xml; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Aspnetmvc-Version:
+      - '2.0'
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 14 Jun 2016 22:25:55 GMT
+      Content-Length:
+      - '3012'
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\"?>\r\n<ArrayOfPublicationItem xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
+        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\r\n  <PublicationItem>\r\n
+        \   <PublicationItemID>64367696</PublicationItemID>\r\n    <Title>Exploring
+        Patterns of Seafood Provision Revealed in the Global Ocean Health Index</Title>\r\n
+        \   <Abstract>Sustainable provision of seafood from wild-capture fisheries
+        and mariculture is a fundamental component of healthy marine ecosystems and
+        a major component of the Ocean Health Index. Here we critically review the
+        food provision model of the Ocean Health Index, and explore the implications
+        of knowledge gaps, scale of analysis, choice of reference points, measures
+        of sustainability, and quality of input data. Global patterns for fisheries
+        are positively related to human development and latitude, whereas patterns
+        for mariculture are most closely associated with economic importance of seafood.
+        Sensitivity analyses show that scores are robust to several model assumptions,
+        but highly sensitive to choice of reference points and, for fisheries, extent
+        of time series available to estimate landings. We show how results for sustainable
+        seafood may be interpreted and used, and we evaluate which modifications show
+        the greatest potential for improvements.</Abstract>\r\n    <AuthorList>Kleisner,Kristin,M|Longo,Catherine,|Coll,Marta,|Halpern,Ben,S|Hardy,Darren,|Katona,Steven,K|Le
+        Manach,Frederic,|Pauly,Daniel,|Rosenberg,Andrew,A|Samhouri,Jameal,F|Scarborough,Courtney,|Sumaila,U,Rashid|Watson,Reg,|Zeller,Dirk,</AuthorList>\r\n
+        \   <AuthorCount>14</AuthorCount>\r\n    <KeywordList>ECOSYSTEMS|FISHERIES|aquaculture|seafood|status|FAO|mariculture|assessment|fisheries|indicator</KeywordList>\r\n
+        \   <DocumentTypeList>Article</DocumentTypeList>\r\n    <DocumentCategory>Journal
+        Document</DocumentCategory>\r\n    <NumberOfReferences>27</NumberOfReferences>\r\n
+        \   <TimesCited>6</TimesCited>\r\n    <TimesNotSelfCited>1</TimesNotSelfCited>\r\n
+        \   <PMID>24213991</PMID>\r\n    <WoSItemID>000326892600002</WoSItemID>\r\n
+        \   <PublicationSourceTitle>AMBIO</PublicationSourceTitle>\r\n    <Volume>42</Volume>\r\n
+        \   <Issue>8</Issue>\r\n    <Pagination>910-922</Pagination>\r\n    <PublicationDate>2013-11-01T00:00:00</PublicationDate>\r\n
+        \   <PublicationYear>2013</PublicationYear>\r\n    <PublicationType>Journal</PublicationType>\r\n
+        \   <PublicationImpactFactor>2.973</PublicationImpactFactor>\r\n    <PublicationSubjectCategoryList>Engineering,
+        Environmental|Environmental Sciences</PublicationSubjectCategoryList>\r\n
+        \   <ISSN>0044-7447</ISSN>\r\n    <DOI>10.1007/s13280-013-0447-x</DOI>\r\n
+        \   <ConferenceStartDate xsi:nil=\"true\" />\r\n    <ConferenceEndDate xsi:nil=\"true\"
+        />\r\n    <Rank xsi:nil=\"true\" />\r\n    <OrdinalRank>1</OrdinalRank>\r\n
+        \   <NormalizedRank xsi:nil=\"true\" />\r\n    <NewPublicationItemID>64367696</NewPublicationItemID>\r\n
+        \   <IsObsolete>false</IsObsolete>\r\n    <CopyrightPublisher>SPRINGER</CopyrightPublisher>\r\n
+        \   <CopyrightCity>DORDRECHT</CopyrightCity>\r\n  </PublicationItem>\r\n</ArrayOfPublicationItem>"
+    http_version: 
+  recorded_at: Tue, 14 Jun 2016 22:25:55 GMT
+recorded_with: VCR 3.0.1

--- a/fixtures/vcr_cassettes/SciencewireSourceRecord/instance_methods/_sciencewire_update/updates_the_pmid_field.yml
+++ b/fixtures/vcr_cassettes/SciencewireSourceRecord/instance_methods/_sciencewire_update/updates_the_pmid_field.yml
@@ -1,0 +1,87 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sciencewirerest.discoverylogic.com/PublicationCatalog/PublicationItems?format=xml&publicationItemIDs=64367696
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Tue, 14 Jun 2016 22:25:54 GMT
+      Licenseid:
+      - Settings.SCIENCEWIRE.LICENSE_ID
+      Host:
+      - Settings.SCIENCEWIRE.HOST
+      Connection:
+      - Keep-Alive
+      Expect:
+      - 100-continue
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/xml; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Aspnetmvc-Version:
+      - '2.0'
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 14 Jun 2016 22:25:55 GMT
+      Content-Length:
+      - '3012'
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\"?>\r\n<ArrayOfPublicationItem xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
+        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\r\n  <PublicationItem>\r\n
+        \   <PublicationItemID>64367696</PublicationItemID>\r\n    <Title>Exploring
+        Patterns of Seafood Provision Revealed in the Global Ocean Health Index</Title>\r\n
+        \   <Abstract>Sustainable provision of seafood from wild-capture fisheries
+        and mariculture is a fundamental component of healthy marine ecosystems and
+        a major component of the Ocean Health Index. Here we critically review the
+        food provision model of the Ocean Health Index, and explore the implications
+        of knowledge gaps, scale of analysis, choice of reference points, measures
+        of sustainability, and quality of input data. Global patterns for fisheries
+        are positively related to human development and latitude, whereas patterns
+        for mariculture are most closely associated with economic importance of seafood.
+        Sensitivity analyses show that scores are robust to several model assumptions,
+        but highly sensitive to choice of reference points and, for fisheries, extent
+        of time series available to estimate landings. We show how results for sustainable
+        seafood may be interpreted and used, and we evaluate which modifications show
+        the greatest potential for improvements.</Abstract>\r\n    <AuthorList>Kleisner,Kristin,M|Longo,Catherine,|Coll,Marta,|Halpern,Ben,S|Hardy,Darren,|Katona,Steven,K|Le
+        Manach,Frederic,|Pauly,Daniel,|Rosenberg,Andrew,A|Samhouri,Jameal,F|Scarborough,Courtney,|Sumaila,U,Rashid|Watson,Reg,|Zeller,Dirk,</AuthorList>\r\n
+        \   <AuthorCount>14</AuthorCount>\r\n    <KeywordList>ECOSYSTEMS|FISHERIES|aquaculture|seafood|status|FAO|mariculture|assessment|fisheries|indicator</KeywordList>\r\n
+        \   <DocumentTypeList>Article</DocumentTypeList>\r\n    <DocumentCategory>Journal
+        Document</DocumentCategory>\r\n    <NumberOfReferences>27</NumberOfReferences>\r\n
+        \   <TimesCited>6</TimesCited>\r\n    <TimesNotSelfCited>1</TimesNotSelfCited>\r\n
+        \   <PMID>24213991</PMID>\r\n    <WoSItemID>000326892600002</WoSItemID>\r\n
+        \   <PublicationSourceTitle>AMBIO</PublicationSourceTitle>\r\n    <Volume>42</Volume>\r\n
+        \   <Issue>8</Issue>\r\n    <Pagination>910-922</Pagination>\r\n    <PublicationDate>2013-11-01T00:00:00</PublicationDate>\r\n
+        \   <PublicationYear>2013</PublicationYear>\r\n    <PublicationType>Journal</PublicationType>\r\n
+        \   <PublicationImpactFactor>2.973</PublicationImpactFactor>\r\n    <PublicationSubjectCategoryList>Engineering,
+        Environmental|Environmental Sciences</PublicationSubjectCategoryList>\r\n
+        \   <ISSN>0044-7447</ISSN>\r\n    <DOI>10.1007/s13280-013-0447-x</DOI>\r\n
+        \   <ConferenceStartDate xsi:nil=\"true\" />\r\n    <ConferenceEndDate xsi:nil=\"true\"
+        />\r\n    <Rank xsi:nil=\"true\" />\r\n    <OrdinalRank>1</OrdinalRank>\r\n
+        \   <NormalizedRank xsi:nil=\"true\" />\r\n    <NewPublicationItemID>64367696</NewPublicationItemID>\r\n
+        \   <IsObsolete>false</IsObsolete>\r\n    <CopyrightPublisher>SPRINGER</CopyrightPublisher>\r\n
+        \   <CopyrightCity>DORDRECHT</CopyrightCity>\r\n  </PublicationItem>\r\n</ArrayOfPublicationItem>"
+    http_version: 
+  recorded_at: Tue, 14 Jun 2016 22:25:55 GMT
+recorded_with: VCR 3.0.1

--- a/fixtures/vcr_cassettes/SciencewireSourceRecord/instance_methods/_sciencewire_update/updates_the_source_data_field.yml
+++ b/fixtures/vcr_cassettes/SciencewireSourceRecord/instance_methods/_sciencewire_update/updates_the_source_data_field.yml
@@ -1,0 +1,87 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sciencewirerest.discoverylogic.com/PublicationCatalog/PublicationItems?format=xml&publicationItemIDs=64367696
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Tue, 14 Jun 2016 22:20:31 GMT
+      Licenseid:
+      - Settings.SCIENCEWIRE.LICENSE_ID
+      Host:
+      - Settings.SCIENCEWIRE.HOST
+      Connection:
+      - Keep-Alive
+      Expect:
+      - 100-continue
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/xml; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Aspnetmvc-Version:
+      - '2.0'
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 14 Jun 2016 22:20:31 GMT
+      Content-Length:
+      - '3012'
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\"?>\r\n<ArrayOfPublicationItem xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
+        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\r\n  <PublicationItem>\r\n
+        \   <PublicationItemID>64367696</PublicationItemID>\r\n    <Title>Exploring
+        Patterns of Seafood Provision Revealed in the Global Ocean Health Index</Title>\r\n
+        \   <Abstract>Sustainable provision of seafood from wild-capture fisheries
+        and mariculture is a fundamental component of healthy marine ecosystems and
+        a major component of the Ocean Health Index. Here we critically review the
+        food provision model of the Ocean Health Index, and explore the implications
+        of knowledge gaps, scale of analysis, choice of reference points, measures
+        of sustainability, and quality of input data. Global patterns for fisheries
+        are positively related to human development and latitude, whereas patterns
+        for mariculture are most closely associated with economic importance of seafood.
+        Sensitivity analyses show that scores are robust to several model assumptions,
+        but highly sensitive to choice of reference points and, for fisheries, extent
+        of time series available to estimate landings. We show how results for sustainable
+        seafood may be interpreted and used, and we evaluate which modifications show
+        the greatest potential for improvements.</Abstract>\r\n    <AuthorList>Kleisner,Kristin,M|Longo,Catherine,|Coll,Marta,|Halpern,Ben,S|Hardy,Darren,|Katona,Steven,K|Le
+        Manach,Frederic,|Pauly,Daniel,|Rosenberg,Andrew,A|Samhouri,Jameal,F|Scarborough,Courtney,|Sumaila,U,Rashid|Watson,Reg,|Zeller,Dirk,</AuthorList>\r\n
+        \   <AuthorCount>14</AuthorCount>\r\n    <KeywordList>ECOSYSTEMS|FISHERIES|aquaculture|seafood|status|FAO|mariculture|assessment|fisheries|indicator</KeywordList>\r\n
+        \   <DocumentTypeList>Article</DocumentTypeList>\r\n    <DocumentCategory>Journal
+        Document</DocumentCategory>\r\n    <NumberOfReferences>27</NumberOfReferences>\r\n
+        \   <TimesCited>6</TimesCited>\r\n    <TimesNotSelfCited>1</TimesNotSelfCited>\r\n
+        \   <PMID>24213991</PMID>\r\n    <WoSItemID>000326892600002</WoSItemID>\r\n
+        \   <PublicationSourceTitle>AMBIO</PublicationSourceTitle>\r\n    <Volume>42</Volume>\r\n
+        \   <Issue>8</Issue>\r\n    <Pagination>910-922</Pagination>\r\n    <PublicationDate>2013-11-01T00:00:00</PublicationDate>\r\n
+        \   <PublicationYear>2013</PublicationYear>\r\n    <PublicationType>Journal</PublicationType>\r\n
+        \   <PublicationImpactFactor>2.973</PublicationImpactFactor>\r\n    <PublicationSubjectCategoryList>Engineering,
+        Environmental|Environmental Sciences</PublicationSubjectCategoryList>\r\n
+        \   <ISSN>0044-7447</ISSN>\r\n    <DOI>10.1007/s13280-013-0447-x</DOI>\r\n
+        \   <ConferenceStartDate xsi:nil=\"true\" />\r\n    <ConferenceEndDate xsi:nil=\"true\"
+        />\r\n    <Rank xsi:nil=\"true\" />\r\n    <OrdinalRank>1</OrdinalRank>\r\n
+        \   <NormalizedRank xsi:nil=\"true\" />\r\n    <NewPublicationItemID>64367696</NewPublicationItemID>\r\n
+        \   <IsObsolete>false</IsObsolete>\r\n    <CopyrightPublisher>SPRINGER</CopyrightPublisher>\r\n
+        \   <CopyrightCity>DORDRECHT</CopyrightCity>\r\n  </PublicationItem>\r\n</ArrayOfPublicationItem>"
+    http_version: 
+  recorded_at: Tue, 14 Jun 2016 22:20:31 GMT
+recorded_with: VCR 3.0.1

--- a/fixtures/vcr_cassettes/SciencewireSourceRecord/instance_methods/_sciencewire_update/updates_the_source_fingerprint_field.yml
+++ b/fixtures/vcr_cassettes/SciencewireSourceRecord/instance_methods/_sciencewire_update/updates_the_source_fingerprint_field.yml
@@ -1,0 +1,87 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sciencewirerest.discoverylogic.com/PublicationCatalog/PublicationItems?format=xml&publicationItemIDs=64367696
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Tue, 14 Jun 2016 22:25:18 GMT
+      Licenseid:
+      - Settings.SCIENCEWIRE.LICENSE_ID
+      Host:
+      - Settings.SCIENCEWIRE.HOST
+      Connection:
+      - Keep-Alive
+      Expect:
+      - 100-continue
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/xml; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Aspnetmvc-Version:
+      - '2.0'
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 14 Jun 2016 22:25:19 GMT
+      Content-Length:
+      - '3012'
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\"?>\r\n<ArrayOfPublicationItem xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
+        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\r\n  <PublicationItem>\r\n
+        \   <PublicationItemID>64367696</PublicationItemID>\r\n    <Title>Exploring
+        Patterns of Seafood Provision Revealed in the Global Ocean Health Index</Title>\r\n
+        \   <Abstract>Sustainable provision of seafood from wild-capture fisheries
+        and mariculture is a fundamental component of healthy marine ecosystems and
+        a major component of the Ocean Health Index. Here we critically review the
+        food provision model of the Ocean Health Index, and explore the implications
+        of knowledge gaps, scale of analysis, choice of reference points, measures
+        of sustainability, and quality of input data. Global patterns for fisheries
+        are positively related to human development and latitude, whereas patterns
+        for mariculture are most closely associated with economic importance of seafood.
+        Sensitivity analyses show that scores are robust to several model assumptions,
+        but highly sensitive to choice of reference points and, for fisheries, extent
+        of time series available to estimate landings. We show how results for sustainable
+        seafood may be interpreted and used, and we evaluate which modifications show
+        the greatest potential for improvements.</Abstract>\r\n    <AuthorList>Kleisner,Kristin,M|Longo,Catherine,|Coll,Marta,|Halpern,Ben,S|Hardy,Darren,|Katona,Steven,K|Le
+        Manach,Frederic,|Pauly,Daniel,|Rosenberg,Andrew,A|Samhouri,Jameal,F|Scarborough,Courtney,|Sumaila,U,Rashid|Watson,Reg,|Zeller,Dirk,</AuthorList>\r\n
+        \   <AuthorCount>14</AuthorCount>\r\n    <KeywordList>ECOSYSTEMS|FISHERIES|aquaculture|seafood|status|FAO|mariculture|assessment|fisheries|indicator</KeywordList>\r\n
+        \   <DocumentTypeList>Article</DocumentTypeList>\r\n    <DocumentCategory>Journal
+        Document</DocumentCategory>\r\n    <NumberOfReferences>27</NumberOfReferences>\r\n
+        \   <TimesCited>6</TimesCited>\r\n    <TimesNotSelfCited>1</TimesNotSelfCited>\r\n
+        \   <PMID>24213991</PMID>\r\n    <WoSItemID>000326892600002</WoSItemID>\r\n
+        \   <PublicationSourceTitle>AMBIO</PublicationSourceTitle>\r\n    <Volume>42</Volume>\r\n
+        \   <Issue>8</Issue>\r\n    <Pagination>910-922</Pagination>\r\n    <PublicationDate>2013-11-01T00:00:00</PublicationDate>\r\n
+        \   <PublicationYear>2013</PublicationYear>\r\n    <PublicationType>Journal</PublicationType>\r\n
+        \   <PublicationImpactFactor>2.973</PublicationImpactFactor>\r\n    <PublicationSubjectCategoryList>Engineering,
+        Environmental|Environmental Sciences</PublicationSubjectCategoryList>\r\n
+        \   <ISSN>0044-7447</ISSN>\r\n    <DOI>10.1007/s13280-013-0447-x</DOI>\r\n
+        \   <ConferenceStartDate xsi:nil=\"true\" />\r\n    <ConferenceEndDate xsi:nil=\"true\"
+        />\r\n    <Rank xsi:nil=\"true\" />\r\n    <OrdinalRank>1</OrdinalRank>\r\n
+        \   <NormalizedRank xsi:nil=\"true\" />\r\n    <NewPublicationItemID>64367696</NewPublicationItemID>\r\n
+        \   <IsObsolete>false</IsObsolete>\r\n    <CopyrightPublisher>SPRINGER</CopyrightPublisher>\r\n
+        \   <CopyrightCity>DORDRECHT</CopyrightCity>\r\n  </PublicationItem>\r\n</ArrayOfPublicationItem>"
+    http_version: 
+  recorded_at: Tue, 14 Jun 2016 22:25:19 GMT
+recorded_with: VCR 3.0.1

--- a/script/missing_wos_ids.rb
+++ b/script/missing_wos_ids.rb
@@ -1,0 +1,53 @@
+class MissingWosId
+
+  attr_reader :logger
+
+  def initialize
+    @logger = Logger.new(Rails.root.join('log', 'missing_wos_id_record.log'))
+  end
+
+  # Identify publications without a WosID
+  def missing_wos_id?(pub)
+    prov = pub.pub_hash[:provenance]
+    ids = pub.pub_hash[:identifier]
+    if prov =~ /sciencewire/i
+      return false if ids.any? {|id| id[:type] =~ /WoS/i }
+      authorship = pub.pub_hash[:authorship]
+      logger.warn "Publication #{pub.id} should be modified"
+      logger.warn "Publication #{pub.id} created_at: #{pub.created_at}"
+      logger.warn "Publication #{pub.id} updated_at: #{pub.updated_at}"
+      logger.warn "Publication #{pub.id} provenance: #{prov}"
+      logger.warn "Publication #{pub.id} identities: #{JSON.dump(ids)}"
+      logger.warn "Publication #{pub.id} authorship: #{JSON.dump(authorship)}"
+      if pub.publication_identifiers.any? {|id| id.identifier_type =~ /WoS/i }
+        logger.warn "Publication #{pub[:id]} has a WoSItemID identity"
+      else
+        src = SciencewireSourceRecord.find_by_sciencewire_id(pub.sciencewire_id)
+        if src.publication.wos_item_id.blank?
+          logger.warn "Publication #{pub[:id]} has no WoSItemID in SciencewireSourceRecord"
+        end
+      end
+      return true
+    end
+    false
+  rescue => e
+    msg = "Problem with publication: #{pub[:id]}\n"
+    msg += "#{e.inspect}\n"
+    msg += e.backtrace.join("\n")
+    logger.error msg
+  end
+
+  def diagnostics
+    ActiveRecord::Base.logger.level = 1
+    Publication.find_each(batch_size: 500) do |pub|
+      missing_wos_id? pub
+    end
+  rescue => e
+    msg = "#{e.inspect}\n"
+    msg += e.backtrace.join("\n")
+    logger.error msg
+  end
+end
+
+c = MissingWosId.new
+c.diagnostics

--- a/spec/models/sciencewire_source_record_spec.rb
+++ b/spec/models/sciencewire_source_record_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 SingleCov.covered!
 
-describe SciencewireSourceRecord do
+describe SciencewireSourceRecord, :vcr do
   describe '.lookup_sw_doc_type' do
     it 'maps document types to CAP inproceedings' do
       expect(SciencewireSourceRecord.lookup_sw_doc_type(['Meeting Abstract'])).to eq('inproceedings')
@@ -68,6 +68,58 @@ describe SciencewireSourceRecord do
       it 'parses the ScienceWire source XML' do
         expect(subject).to receive(:source_data).and_call_original
         subject.publication_xml
+      end
+    end
+
+    describe '#sciencewire_update' do
+      it 'updates the :pmid field' do
+        expect(subject.pmid).to eq 24_213_991
+        subject.pmid = 999
+        subject.save!
+        subject.reload
+        expect(subject.pmid).to eq 999
+        expect(subject.sciencewire_update).to be true
+        expect(subject.pmid).to eq 24_213_991
+      end
+
+      it 'updates the :is_active field' do
+        expect(subject.is_active).to be true
+        subject.is_active = false
+        subject.save!
+        subject.reload
+        expect(subject.is_active).to be false
+        expect(subject.sciencewire_update).to be true
+        expect(subject.is_active).to be true
+      end
+
+      it 'updates the :source_data field' do
+        expect(subject.source_data).not_to be_empty
+        subject.source_data = ''
+        subject.save!
+        subject.reload
+        expect(subject.source_data).to be_empty
+        expect(subject.sciencewire_update).to be true
+        expect(subject.source_data).not_to be_empty
+      end
+
+      it 'updates the :source_data field' do
+        expect(subject.source_data).not_to be_empty
+        subject.source_data = ''
+        subject.save!
+        subject.reload
+        expect(subject.source_data).to be_empty
+        expect(subject.sciencewire_update).to be true
+        expect(subject.source_data).not_to be_empty
+      end
+
+      it 'updates the :source_fingerprint field' do
+        expect(subject.source_fingerprint).not_to be_empty
+        subject.source_fingerprint = ''
+        subject.save!
+        subject.reload
+        expect(subject.source_fingerprint).to be_empty
+        expect(subject.sciencewire_update).to be true
+        expect(subject.source_fingerprint).not_to be_empty
       end
     end
   end

--- a/spec/models/sciencewire_source_record_spec.rb
+++ b/spec/models/sciencewire_source_record_spec.rb
@@ -38,6 +38,40 @@ describe SciencewireSourceRecord do
     end
   end
 
+  describe 'instance methods' do
+    subject { build_sciencewire_source_record_from_fixture(64_367_696) }
+
+    describe '#publication' do
+      it 'returns a ScienceWirePublication' do
+        expect(subject.publication).to be_an ScienceWirePublication
+      end
+      it 'parses the ScienceWire source XML' do
+        expect(subject).to receive(:source_data).and_call_original
+        subject.publication
+      end
+    end
+
+    describe '#publication_item' do
+      it 'returns a Nokogiri::XML::Element' do
+        expect(subject.publication_item).to be_an Nokogiri::XML::Element
+      end
+      it 'parses the ScienceWire source XML' do
+        expect(subject).to receive(:source_data).and_call_original
+        subject.publication_item
+      end
+    end
+
+    describe '#publication_xml' do
+      it 'returns a Nokogiri::XML::Document' do
+        expect(subject.publication_xml).to be_an Nokogiri::XML::Document
+      end
+      it 'parses the ScienceWire source XML' do
+        expect(subject).to receive(:source_data).and_call_original
+        subject.publication_xml
+      end
+    end
+  end
+
   describe '.source_as_hash' do
     describe 'parses one publication' do
       subject { build_sciencewire_source_record_from_fixture(64_367_696).source_as_hash }


### PR DESCRIPTION
This script will log some details for all the ScienceWire publications with a missing WoSItemID.  On a prod-db-dump, all of the identified publications did not have a WoSItemID in the ScienceWireSourceRecord.  No attempt is made to re-harvest the publications; if that is a requirement, it can be added, but that will be extra work to change this script from a read-only operation into an update operation.

This should fix #86 