### PR TITLE
notify Honeybadger when external service monitoring fails

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -24,10 +24,12 @@ class DelegateCheck < OkComputer::Check
     else
       mark_failure
       mark_message 'not working'
+      Honeybadger.notify(RuntimeError.new("#{delegate.name} is not working"))
     end
   rescue => e
     mark_failure
     mark_message "#{e.class.name} received: #{e.message}"
+    Honeybadger.notify(e)
   end
 end
 


### PR DESCRIPTION
@eefahy notifies Honeybadger when the following monitoring endpoints generate a failure:

- `/status/external-CapHttpClient`
- `/status/external-PubmedClient`
- `/status/external-ScienceWireClient`