### PR TITLE
set up a scheduled rake task for performing external monitor checks

### DIFF
--- a/config/deploy/cap-qa.rb
+++ b/config/deploy/cap-qa.rb
@@ -1,4 +1,4 @@
-server 'sul-pub-cap-qa.stanford.edu', user: fetch(:user), roles: %w(web db app harvester)
+server 'sul-pub-cap-qa.stanford.edu', user: fetch(:user), roles: %w(web db app harvester external_monitor)
 
 Capistrano::OneTimeKey.generate_one_time_key!
 

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,4 +1,4 @@
-server 'sul-pub-prod.stanford.edu', user: fetch(:user), roles: %w(web db app harvester)
+server 'sul-pub-prod.stanford.edu', user: fetch(:user), roles: %w(web db app harvester external_monitor)
 
 Capistrano::OneTimeKey.generate_one_time_key!
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -15,3 +15,8 @@ end
 every 1.day, at: stagger(4), roles: [:harvester] do
   rake 'cap:poll[1]'
 end
+
+# call a rake task that hits the OK computer external checks, triggering honeybadger notifications if there is an error
+every 30.minutes, roles: [:external_monitor] do
+  rake "sul:check_external_services[\"https://#{`hostname`.chomp!}\"]"
+end

--- a/lib/tasks/sul.rake
+++ b/lib/tasks/sul.rake
@@ -17,4 +17,14 @@ namespace :sul do
       .each(&:rebuild_pub_hash)
     # Publication.find_each {|pub| pub.rebuild_authorship }
   end
+
+  desc 'check external services'
+  task :check_external_services, [:server] => :environment do |_t, args|
+    conn = Faraday.new(:url=>args[:server])
+    external_checks=%w{external-CapHttpClient external-ScienceWireClient external-PubmedClient}
+    external_checks.each do |check_name|
+      response = conn.get "/status/#{check_name}"
+      puts "#{Time.now}: #{check_name}: #{response.status} - #{response.body}"
+    end
+  end
 end


### PR DESCRIPTION
Added a new rake task that calls the external okcomputer checks for a given URL.  Added a new role for the whenever gem that schedules this task every 30 minutes in cap-qa and production.

If an exception occurs during the checks, a honeybader notification will be sent out (this is already working in the code). 

With this, we can remove the nagios alerts for these three external checks.

Note I shelled out to 'hostname' to get the URL to check.  Since cap-qa and prod both run under Rails.env == production, you can't use a hostname that is configured in the Rails app.  I also couldn't find a way to pass a value from the cap script to the schedule.rb file.

fixes #119 
