### PR TITLE
Add pmc ID to pub hash

### DIFF
--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -312,6 +312,8 @@ class Publication < ActiveRecord::Base
 
     pub_hash[:mesh_headings] = pubmed_hash[:mesh_headings] unless pubmed_hash[:mesh_headings].blank?
     pub_hash[:abstract] = pubmed_hash[:abstract] unless pubmed_hash[:abstract].blank?
+    pmc_id = pubmed_hash[:identifier].detect {|id| id[:type] == 'pmc'}
+    pub_hash[:identifier] << pmc_id if pmc_id
   end
 
   def set_last_updated_value_in_hash

--- a/app/models/pubmed_source_record.rb
+++ b/app/models/pubmed_source_record.rb
@@ -149,7 +149,8 @@ class PubmedSourceRecord < ActiveRecord::Base
     doi = publication.at_xpath('//ArticleId[@IdType="doi"]')
     doi = publication.at_xpath('//ELocationID[@EIdType="doi"]') unless doi.present? && doi.text.present?
     record_as_hash[:identifier] << { type: 'doi', id: doi.text, url: "#{Settings.DOI.BASE_URI}#{doi.text}" } if doi.present? && doi.text.present?
-
+    pmc = publication.at_xpath('//ArticleId[@IdType="pmc"]')
+    record_as_hash[:identifier] << { type: 'pmc', id: pmc.text } if pmc.present? && pmc.text.present?
     record_as_hash
   end
 


### PR DESCRIPTION
Add PMC identifiers to pub_hash from pubmed source record when available.

Need to also rebuild all pub hashes