### PR TITLE
add a new method to repull pubmed record so we can update our source

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -66,6 +66,7 @@ Performance/RangeInclude:
 RSpec/AnyInstance:
   Exclude:
     - 'spec/models/publication_spec.rb'
+    - 'spec/models/pubmed_source_record_spec.rb'
 
 # Offense count: 49
 RSpec/DescribedClass:

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -200,6 +200,28 @@ class Publication < ActiveRecord::Base
     self
   end
 
+  def update_from_pubmed
+    if pmid.blank?
+      false
+    else
+      pm_source_record = PubmedSourceRecord.find_by_pmid(pmid)
+      pm_source_record.pubmed_update
+      rebuild_pub_hash
+      save
+    end
+  end
+
+  def update_from_sciencewire
+    if sciencewire_id.blank?
+      false
+    else
+      sw_source = SciencewireSourceRecord.find_by_sciencewire_id(sciencewire_id)
+      sw_source.sciencewire_update
+      rebuild_pub_hash
+      save
+    end
+  end
+
   def rebuild_pub_hash
     if sciencewire_id
       sw_source_record = SciencewireSourceRecord.find_by_sciencewire_id(sciencewire_id)

--- a/lib/tasks/sul.rake
+++ b/lib/tasks/sul.rake
@@ -37,12 +37,15 @@ namespace :sul do
         puts message
         logger.error message
         error_count += 1
-      end      
+      end
       if error_count > max_errors
-        raise "Halting: Maximum number of errors #{max_errors} reached"
+        message = "Halting: Maximum number of errors #{max_errors} reached"
+        logger.error message
+        raise message
       end
     end
-    message = "Total: #{number_with_delimiter(total_pubs)}.  Successful: #{success_count}.  Error: #{error_count}.  Ended at #{Time.now}"
+    end_time = Time.now
+    message = "Total: #{number_with_delimiter(total_pubs)}.  Successful: #{success_count}.  Error: #{error_count}.  Ended at #{end_time}. Total time: #{distance_of_time_in_words(end_time,start_time)}"
     puts message
     logger.info message
   end

--- a/spec/models/pubmed_source_record_spec.rb
+++ b/spec/models/pubmed_source_record_spec.rb
@@ -145,6 +145,29 @@ describe PubmedSourceRecord, :vcr do
     end
   end
 
+  describe '.pubmed_update' do
+    it 'updates the :source_data field' do
+      source_data = '<PubmedArticle><MedlineCitation Status="Publisher" Owner="NLM"><PMID Version="1">1</PMID><OriginalData/></PubmedArticle>'
+      new_source_data = '<PubmedArticle><MedlineCitation Status="Publisher" Owner="NLM"><PMID Version="1">1</PMID><SomeNewData/></PubmedArticle>'
+      pubmed_record = described_class.create(pmid: pmid_created_1999, source_data: source_data)
+      allow(described_class).to receive(:find_by_pmid).with(pmid_created_1999).and_return(pubmed_record)
+      expect(pubmed_record.source_data).to be_equivalent_to source_data
+      allow_any_instance_of(PubmedClient).to receive(:fetch_records_for_pmid_list).with(pmid_created_1999).and_return(new_source_data)
+      expect(pubmed_record.pubmed_update).to be true
+      expect(pubmed_record.source_data).to be_equivalent_to new_source_data
+    end
+    it 'does not update the :source_data field if no pubmed record is found' do
+      source_data = '<PubmedArticle><MedlineCitation Status="Publisher" Owner="NLM"><PMID Version="1">1</PMID><OriginalData/></PubmedArticle>'
+      new_source_data = '<?xml version="1.0" ?><!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2017//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_170101.dtd"><PubmedArticleSet></PubmedArticleSet>'
+      pubmed_record = described_class.create(pmid: pmid_created_1999, source_data: source_data)
+      allow(described_class).to receive(:find_by_pmid).with(pmid_created_1999).and_return(pubmed_record)
+      expect(pubmed_record.source_data).to be_equivalent_to source_data
+      allow_any_instance_of(PubmedClient).to receive(:fetch_records_for_pmid_list).with(pmid_created_1999).and_return(new_source_data)
+      expect(pubmed_record.pubmed_update).to be false
+      expect(pubmed_record.source_data).to be_equivalent_to source_data
+    end
+  end
+
   context '.source_as_hash' do
     context 'DOI extraction' do
       def doi(pmid)


### PR DESCRIPTION
also add a rake task to repull all pubmed records for given cap_profile_ids and then update the pub_hash

This is useful to refresh PMID based publications (for example, when we need to be sure we add PMCIDs to our source records where they have been added to PubMed after we first pulled)