### PR TITLE
Rakefile's turn for cleanup

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
 --require spec_helper
+--tag ~data-integration

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
+sudo: false
 language: ruby
 cache: bundler
 rvm:
   - 2.3.4
   - 2.4.1
-sudo: false
-script: bundle exec rake ci
 services: mysql
+script: bundle exec rake ci
+before_script:
+  - bundle exec rake db:create
 matrix:
   allow_failures:
     - rvm: 2.4.1

--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,6 @@ group :test do
   gem 'capybara'
   gem 'coveralls', require: false
   gem 'simplecov', require: false
-  gem 'single_cov'
   gem 'vcr'
   gem 'webmock'
   gem 'equivalent-xml'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -337,7 +337,6 @@ GEM
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
-    single_cov (0.4.0)
     slop (3.6.0)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
@@ -451,7 +450,6 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   simple_form
   simplecov
-  single_cov
   therubyracer
   thin
   turnout

--- a/Rakefile
+++ b/Rakefile
@@ -1,52 +1,41 @@
 #!/usr/bin/env rake
-# Add your own tasks in files placed in lib/tasks ending in .rake,
-# for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
-
-# If the config/database.yml file does not exist, use the example file
-# so that the config/application can load.
+# If the config/database.yml file does not exist, use the example file so that the config/application can load.
 File.exist?('config/database.yml') || FileUtils.copy('config/database.yml.example', 'config/database.yml')
 
 require File.expand_path('../config/application', __FILE__)
 
 Sulbib::Application.load_tasks
 
+task default: [:ci]
+
 desc 'Continuous integration task run on travis'
-task ci: [:environment] do
-  Rake::Task['rubocop'].invoke
+task ci: [:environment, :rubocop] do
   if Rails.env.test?
-    Rake::Task['db:create'].invoke
-    Rake::Task['db:migrate'].invoke
-    Rake::Task['spec:without-data-integration'].invoke
+    Rake::Task['db:setup'].invoke # not db:migrate, use the dang schema!
+    Rake::Task['spec'].invoke
   else
     system 'rake ci RAILS_ENV=test'
   end
 end
 
-namespace :spec do
-  begin
-    require 'rspec/core/rake_task'
-    desc 'spec task that runs only data-integration tests against live ScienceWire'
-    RSpec::Core::RakeTask.new('data-integration') do |t|
-      t.rspec_opts = '--tag data-integration'
-    end
-    desc 'spec task that ignores data-integration tests'
-    RSpec::Core::RakeTask.new('without-data-integration') do |t|
-      t.rspec_opts = '--tag ~data-integration'
-    end
-  rescue LoadError
-    puts 'Unable to load RSpec.'
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new
+  namespace :spec do
+    desc 'run only data-integration tests against live ScienceWire (excluded by default)'
+    RSpec::Core::RakeTask.new('data-integration') { |t| t.rspec_opts = '--tag data-integration' }
   end
+rescue LoadError
+  puts 'Unable to load RSpec.'
 end
 
 desc 'Run rubocop on ruby files in a patch on master'
 task :rubocop do
-  if Rails.env.test? || Rails.env.development?
-    begin
-      require 'rubocop/rake_task'
-      RuboCop::RakeTask.new
-    rescue LoadError
-      puts 'Unable to load RuboCop.'
-    end
+  begin
+    require 'rubocop/rake_task'
+    RuboCop::RakeTask.new
+  rescue LoadError
+    puts 'Unable to load RuboCop.'
   end
 end
 

--- a/spec/api/sul_bib/authorship_api_spec.rb
+++ b/spec/api/sul_bib/authorship_api_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered! file: 'app/api/sul_bib/authorship_api.rb'
 
 describe SulBib::API, :vcr do
   let(:headers) { { 'HTTP_CAPKEY' => Settings.API_KEY, 'CONTENT_TYPE' => 'application/json' } }

--- a/spec/api/sul_bib/publications_api_spec.rb
+++ b/spec/api/sul_bib/publications_api_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered! file: 'app/api/sul_bib/publications_api.rb'
 
 describe SulBib::API, :vcr do
   let(:publication) { FactoryGirl.create :publication }

--- a/spec/api/sul_bib/sourcelookup_spec.rb
+++ b/spec/api/sul_bib/sourcelookup_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered! file: 'app/controllers/publications_controller.rb'
 # TODO: move this file to spec/controllers/publications_controller_spec.rb
 
 describe SulBib::API, :vcr do

--- a/spec/controllers/authors_controller_spec.rb
+++ b/spec/controllers/authors_controller_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe AuthorsController do
   let(:author) { create(:author) }

--- a/spec/controllers/publications_controller_spec.rb
+++ b/spec/controllers/publications_controller_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 # See also spec/api/sul_bib/sourcelookup_spec.rb
 
 describe PublicationsController do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,1 +1,0 @@
-SingleCov.covered!

--- a/spec/jobs/author_harvest_job_spec.rb
+++ b/spec/jobs/author_harvest_job_spec.rb
@@ -1,1 +1,0 @@
-SingleCov.covered!

--- a/spec/lib/bibtex_ingester_spec.rb
+++ b/spec/lib/bibtex_ingester_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe BibtexIngester do
   let!(:author_with_bibtex) { create :author, sunetid: 'james', cap_profile_id: 333_333 }

--- a/spec/lib/cap_authors_poller_spec.rb
+++ b/spec/lib/cap_authors_poller_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe CapAuthorsPoller, :vcr do
   # The author is defined in /spec/factories/author.rb

--- a/spec/lib/cap_http_client_spec.rb
+++ b/spec/lib/cap_http_client_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe CapHttpClient do
   let(:token) { 'cool token' }

--- a/spec/lib/csl/author_name_spec.rb
+++ b/spec/lib/csl/author_name_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe Csl::AuthorName do
   let(:fn) { 'Amasa' }

--- a/spec/lib/doi_search_spec.rb
+++ b/spec/lib/doi_search_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe DoiSearch do
   let(:publication) { create :publication }

--- a/spec/lib/notification_manager_spec.rb
+++ b/spec/lib/notification_manager_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe NotificationManager do
   let(:message) { 'this is an error message' }

--- a/spec/lib/pubmed_client_spec.rb
+++ b/spec/lib/pubmed_client_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe PubmedClient do
   let(:pubmed_client) { PubmedClient.new }

--- a/spec/lib/pubmed_harvester_spec.rb
+++ b/spec/lib/pubmed_harvester_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe PubmedHarvester, :vcr do
   let(:author) { FactoryGirl.create :author }

--- a/spec/lib/science_wire/api/matched_publication_item_ids_for_author_spec.rb
+++ b/spec/lib/science_wire/api/matched_publication_item_ids_for_author_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe ScienceWire::API::MatchedPublicationItemIdsForAuthor do
   include ItemResponses

--- a/spec/lib/science_wire/api/publication_items_spec.rb
+++ b/spec/lib/science_wire/api/publication_items_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe ScienceWire::API::PublicationItems do
   let(:client) do

--- a/spec/lib/science_wire/api/publication_query_spec.rb
+++ b/spec/lib/science_wire/api/publication_query_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe ScienceWire::API::PublicationQuery do
   let(:client) do

--- a/spec/lib/science_wire/author_address_spec.rb
+++ b/spec/lib/science_wire/author_address_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe ScienceWire::AuthorAddress do
   let(:line1) { 'Stanford University' }

--- a/spec/lib/science_wire/author_attributes_spec.rb
+++ b/spec/lib/science_wire/author_attributes_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe ScienceWire::AuthorAttributes do
   describe '#initialize' do

--- a/spec/lib/science_wire/author_institution_spec.rb
+++ b/spec/lib/science_wire/author_institution_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe ScienceWire::AuthorInstitution do
   describe '#initialize' do

--- a/spec/lib/science_wire/author_name_spec.rb
+++ b/spec/lib/science_wire/author_name_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe ScienceWire::AuthorName do
   let(:fn) { 'Amasa' }

--- a/spec/lib/science_wire/client_spec.rb
+++ b/spec/lib/science_wire/client_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe ScienceWire::Client do
   describe '#initialize' do

--- a/spec/lib/science_wire/harvest_broker_spec.rb
+++ b/spec/lib/science_wire/harvest_broker_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe ScienceWire::HarvestBroker do
   let(:author) { create(:author) }

--- a/spec/lib/science_wire/id_suggestions_spec.rb
+++ b/spec/lib/science_wire/id_suggestions_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe ScienceWire::IdSuggestions do
   let(:author_attributes) { double 'author_attributes' }

--- a/spec/lib/science_wire/query/conference_proceeding_document_suggestion_spec.rb
+++ b/spec/lib/science_wire/query/conference_proceeding_document_suggestion_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe ScienceWire::Query::ConferenceProceedingDocumentSuggestion do
   include SuggestionQueries

--- a/spec/lib/science_wire/query/journal_document_suggestion_spec.rb
+++ b/spec/lib/science_wire/query/journal_document_suggestion_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe ScienceWire::Query::JournalDocumentSuggestion do
   include SuggestionQueries

--- a/spec/lib/science_wire/query/publication_query_by_author_name_spec.rb
+++ b/spec/lib/science_wire/query/publication_query_by_author_name_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe ScienceWire::Query::PublicationQueryByAuthorName do
   # import modules from spec/fixtures/queries

--- a/spec/lib/science_wire/query/suggestion_spec.rb
+++ b/spec/lib/science_wire/query/suggestion_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe ScienceWire::Query::Suggestion do
   include SuggestionQueries

--- a/spec/lib/science_wire/request_spec.rb
+++ b/spec/lib/science_wire/request_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe ScienceWire::Request do
   describe '#initialize' do

--- a/spec/lib/science_wire_client_spec.rb
+++ b/spec/lib/science_wire_client_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe ScienceWireClient, :vcr do
   let(:sw_client) { ScienceWireClient.new }

--- a/spec/lib/science_wire_harvester_spec.rb
+++ b/spec/lib/science_wire_harvester_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe ScienceWireHarvester, :vcr do
   let(:author_without_seed_data) { create :author, emails_for_harvest: '' }

--- a/spec/lib/science_wire_publication_spec.rb
+++ b/spec/lib/science_wire_publication_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe ScienceWirePublication do
   let(:wrong_element) do

--- a/spec/lib/science_wire_publications_spec.rb
+++ b/spec/lib/science_wire_publications_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe ScienceWirePublications do
   let(:array_publication_item_doctypes) do

--- a/spec/lib/sul_bib/bib_json_parser.rb
+++ b/spec/lib/sul_bib/bib_json_parser.rb
@@ -1,1 +1,0 @@
-SingleCov.covered!

--- a/spec/lib/sul_bib/year_check_spec.rb
+++ b/spec/lib/sul_bib/year_check_spec.rb
@@ -1,1 +1,0 @@
-SingleCov.covered!

--- a/spec/models/author_identity_spec.rb
+++ b/spec/models/author_identity_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 RSpec.describe AuthorIdentity, type: :model do
   subject { FactoryGirl.create :author_identity }

--- a/spec/models/author_spec.rb
+++ b/spec/models/author_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe Author do
   let(:auth_hash) do

--- a/spec/models/batch_uploaded_source_record_spec.rb
+++ b/spec/models/batch_uploaded_source_record_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe BatchUploadedSourceRecord do
   skip "add some examples to (or delete) #{__FILE__}"

--- a/spec/models/contribution_spec.rb
+++ b/spec/models/contribution_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe Contribution do
   ##

--- a/spec/models/pub_hash_spec.rb
+++ b/spec/models/pub_hash_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe PubHash do
   include CitationDocumentTypes # spec/fixtures/doc_types/working_paper.rb

--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe Publication do
   let(:publication) { FactoryGirl.create :publication }

--- a/spec/models/pubmed_source_record_spec.rb
+++ b/spec/models/pubmed_source_record_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe PubmedSourceRecord, :vcr do
   let(:pmid_created_1999) { 10_000_166 }

--- a/spec/models/sciencewire_source_record_spec.rb
+++ b/spec/models/sciencewire_source_record_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe SciencewireSourceRecord, :vcr do
   describe '.lookup_sw_doc_type' do

--- a/spec/models/user_submitted_source_record_spec.rb
+++ b/spec/models/user_submitted_source_record_spec.rb
@@ -1,4 +1,3 @@
-SingleCov.covered!
 
 describe UserSubmittedSourceRecord, type: :model do
   let(:user_submitted_source_record) { create :user_submitted_source_record }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,14 +3,7 @@ ENV['RAILS_ENV'] ||= 'test'
 
 require 'pry'  # for debugging specs
 
-require 'fixtures/doc_types/working_paper'
-require 'fixtures/queries/suggestion_queries'
-require 'fixtures/queries/suggestion_query_xsd'
-require 'fixtures/responses/item_responses'
-require 'fixtures/queries/author_date_queries'
-require 'fixtures/queries/author_name_queries'
-require 'fixtures/queries/institution_and_email_queries'
-require 'fixtures/queries/publication_query_xsd'
+Dir.glob(File.join(__dir__, 'fixtures', '**', '*.rb'), &method(:require)) # load all fixture files
 
 require 'rspec/matchers'
 require 'equivalent-xml'
@@ -55,14 +48,6 @@ RSpec.configure do |config|
   config.include RSpec::Rails::RequestExampleGroup, type: :request, file_path: %r{spec/lib}
 
   config.include FactoryGirl::Syntax::Methods
-
-  # ## Mock Framework
-  #
-  # If you prefer to use mocha, flexmock or RR, uncomment the appropriate line:
-  #
-  # config.mock_with :mocha
-  # config.mock_with :flexmock
-  # config.mock_with :rr
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   # config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,11 +11,9 @@ require 'fixtures/queries/author_date_queries'
 require 'fixtures/queries/author_name_queries'
 require 'fixtures/queries/institution_and_email_queries'
 require 'fixtures/queries/publication_query_xsd'
+
 require 'rspec/matchers'
 require 'equivalent-xml'
-
-require 'single_cov'
-SingleCov.setup :rspec
 
 require 'simplecov'
 require 'coveralls'


### PR DESCRIPTION
- use `.rspec` to filter out vendor integration tests (this allows `rspec` to work as expected from the command-line)
- don't protect the load attempt for rubocop per RAILS_ENV: there's no point, we already rescue the load error and you should be able to run rubocop-via-rake anywhere it successfully loads.  On that note: we have a subsequent task that unilaterally expects a `rubocop` executable on the system, so it obviously isn't important anyway.  *emoji_shrug*
- HAVE A REASONABLE DEFAULT TASK, namely `:ci`, which in turn allows us to rely on Travis-CI's default script.
- use Travis `before_install` and `db:setup` instead of explicit `create` and `migrate` calls.
- Remove `single_cov`: we already have two other coverage tools.

End result: a better `Rakefile`, better `rspec` behavior, better Travis config, same 788 specs run by default.

