### PR TITLE
[WIP] basic version of WebOfScience::Client class

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'delayed_job_active_record'
 gem 'dotiw'
 gem 'faraday'
 gem 'httpclient', '~> 2.7'
+gem 'net-http-persistent'
 gem 'high_voltage'
 # To use Jbuilder templates for JSON
 gem 'jbuilder'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,6 +208,7 @@ GEM
       enumerable-lazy
     mysql2 (0.3.18)
     namae (0.11.3)
+    net-http-persistent (2.9.4)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (4.1.0)
@@ -433,6 +434,7 @@ DEPENDENCIES
   kaminari
   libv8
   mysql2 (~> 0.3.18)
+  net-http-persistent
   nokogiri (>= 1.7.1)
   okcomputer
   paper_trail

--- a/app/models/web_of_science.rb
+++ b/app/models/web_of_science.rb
@@ -1,0 +1,1 @@
+require 'web_of_science/client'

--- a/app/models/web_of_science/client.rb
+++ b/app/models/web_of_science/client.rb
@@ -8,15 +8,40 @@ module WebOfScience
       @host = host
     end
 
+    def logger
+      @logger ||= ::Logger.new(STDOUT)
+    end
+
     def connection
       @conn ||= Faraday.new(:url => @host) do |f|
         f.adapter :net_http_persistent
+        f.response :logger, logger, :bodies => true # debugging on for now
         f.use Faraday::Response::RaiseError
       end
     end
 
+    # just a means of rendering layout/template
+    # @return [ApplicationController] cached controller for calling render_to_string on
+    def controller
+      @controller ||= ApplicationController.new
+    end
+
+    # @param [String] template
+    # @param [Hash] assigns key and value assignments to pass to the template
+    # @return [String] the rendered document
+    # @example render('web_of_science/search', search_params)
+    def render(template, assigns = {})
+      controller.render_to_string(
+        layout: 'wos_soap',
+        template: template,
+        locals: assigns # key becomes `assigns:` in rails 5
+      )
+    end
+
     # @param [String] auth_key base64-encoded username:password
     # @return [String] Session ID, if successful
+    # @note Unfortunately, search.webofknowledge.com returns status 500 (w/ stack trace) for bad Authorization string.
+    # Therefore, we cannot distinguish between actual server internal errors and failed auth.
     def authenticate(auth_key = Settings.web_of_science.auth_key)
       raise ArgumentError, 'required: pass auth_key or set Settings.web_of_science.auth_key' unless auth_key
       auth = connection.post do |req|
@@ -26,69 +51,86 @@ module WebOfScience
         req.body = '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:auth="http://auth.cxf.wokmws.thomsonreuters.com"><soapenv:Header/><soapenv:Body><auth:authenticate/></soapenv:Body></soapenv:Envelope>'
       end
       auth_xml_doc = Nokogiri::XML(auth.body).remove_namespaces!
-      auth_xml_doc.xpath('//authenticateResponse//return')[0].content
+      element = auth_xml_doc.xpath('//authenticateResponse//return')
+      raise "Failed to parse response response #{auth}\n#{auth_xml_doc}" unless element && element[0]
+      element[0].content
+    end
+
+    def session_id
+      @session_id ||= authenticate
     end
 
     # 6 Methods were exposed by ScienceWire::Client, of which we have to worry about only 5:
     # matched_publication_item_ids_for_author  **NOT called by consumers**
-    # matched_publication_item_ids_for_author_and_parse
+    # matched_publication_item_ids_for_author_and_parse (a terrible name)
     # publication_items
     # send_publication_query
     # retrieve_publication_query
     # id_suggestions
 
+    # @param [Symbol] request_method
+    # @param [String] path
+    # @param [String] body
+    # @param [Integer] timeout_period
+    # @yield [Faraday::Request] the prepared request object for further manipulation before sending
+    # @return [String] response body
+    def request(request_method: :get, path: '', body: '', timeout_period: 300)
+      response = connection.public_send(request_method) do |req|
+        req.url path
+        req.headers['Host'] = host
+        req.headers['Connection'] = 'Keep-Alive'
+        req.headers['Content-Type'] = 'text/xml'
+        req.headers['Cookie'] = "SID=\"#{session_id}\""
+        req.body = body
+        yield req if block_given?
+      end
+      return response.body if response.success?
+      @session_id = nil unless response.status = '200' # ideally we target session expiry more specifically
+    end
+
     # @param [String] body request body XML
     # @return [Array<Integer>] identifiers
     def pub_ids_for_author(body)
-      response = connection.send(:post) do |req|
-        req.url '/PublicationCatalog/MatchedPublicationItemIdsForAuthor?format=xml' # need new path
-        req.headers['Content-Type'] = 'text/xml'
-        req.body = body
-      end
-      Nokogiri::XML(response)
+      response_body = request(
+        request_method: :post,
+        path: '/PublicationCatalog/MatchedPublicationItemIdsForAuthor', # need new path
+        body: body
+      )
+      Nokogiri::XML(response_body)
         .xpath('/ArrayOfItemMatchResult/ItemMatchResult/PublicationItemID') # parse differently
         .map { |item| item.text.to_i }
     end
 
     alias_method :matched_publication_item_ids_for_author_and_parse, :pub_ids_for_author
 
-    # @param [String] ids CSV PublicationItemId values (no whitespace)
-    # @param [String] format desired response format, 'xml' or 'json'
+    # @param [Array<String>] ids PublicationItemId values (no whitespace)
     # @return [String] response body matching requested format
-    def publication_items(ids, format = 'xml')
-      raise ArgumentError, 'format must be "xml" or "json"' unless %w(xml json).include?(format)
+    def publication_items(ids)
       # previously had timeout_period: 500
-      response = connection.send(:get) do |req|
-        req.url "/PublicationCatalog/PublicationItems?format=#{format}&publicationItemIDs=#{ids}", # need new path
-        req.headers['Content-Type'] = 'text/xml'
-        req.body = body
-      end
-      response.body
+      request(
+        path: "/PublicationCatalog/PublicationItems?publicationItemIDs=#{ids}", # retreiveById?
+        body: render('web_of_science/retrieve_by_id', :@uids => ids)
+      )
     end
 
-    # @param [String] body request body
+    # @param [String] body XML request body
     # @return [String] response body matching requested format
     def send_publication_query(body)
-      response = connection.send(:post) do |req|
-        req.url '/PublicationCatalog/PublicationQuery?format=xml' # need new path
-        req.headers['Content-Type'] = 'text/xml'
-        req.body = body
-      end
-      response.body
+      request(
+        request_method: :post,
+        path: '/PublicationCatalog/PublicationQuery', # search?
+        body: body
+      )
     end
 
     # @param [Integer] queryId
     # @param [Integer] queryResultRows
-    # @param [String] format desired response format, 'xml' or 'json'
     # @return [String] response body matching requested format
-    def retrieve_publication_query(queryId, queryResultRows, format = 'xml')
-      raise ArgumentError, 'format must be "xml" or "json"' unless %w(xml json).include?(format)
-      response = connection.send(:get) do |req|
-        req.url "/PublicationCatalog/PublicationQuery/#{queryId}?format=#{format}&v=version/4&page=0&pageSize=#{queryResultRows}" # need new path
-        req.headers['Content-Type'] = 'text/xml'
-        req.body = body
-      end
-      response.body
+    def retrieve_publication_query(queryId, queryResultRows = 100)
+      raise ArgumentError, 'queryResultRows must be an Integer <= 100' if queryResultRows > 100
+      request(
+        path: "/PublicationCatalog/PublicationQuery/#{queryId}?format=#{format}&v=version/4&page=0&pageSize=#{queryResultRows}", # search?
+      )
     end
 
     # @param [ScienceWire::AuthorAttributes] attributes

--- a/app/models/web_of_science/client.rb
+++ b/app/models/web_of_science/client.rb
@@ -1,0 +1,102 @@
+module WebOfScience
+  class Client
+    attr_reader :host
+
+    # @param [String] host
+    # @note license_id not used in this version of API
+    def initialize(host: 'http://search.webofknowledge.com')
+      @host = host
+    end
+
+    def connection
+      @conn ||= Faraday.new(:url => @host) do |f|
+        f.adapter :net_http_persistent
+        f.use Faraday::Response::RaiseError
+      end
+    end
+
+    # @param [String] auth_key base64-encoded username:password
+    # @return [String] Session ID, if successful
+    def authenticate(auth_key = Settings.web_of_science.auth_key)
+      raise ArgumentError, 'required: pass auth_key or set Settings.web_of_science.auth_key' unless auth_key
+      auth = connection.post do |req|
+        req.url '/esti/wokmws/ws/WOKMWSAuthenticate'
+        req.headers['Content-Type'] = 'application/xml'
+        req.headers['Authorization'] = "Basic #{auth_key}"
+        req.body = '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:auth="http://auth.cxf.wokmws.thomsonreuters.com"><soapenv:Header/><soapenv:Body><auth:authenticate/></soapenv:Body></soapenv:Envelope>'
+      end
+      auth_xml_doc = Nokogiri::XML(auth.body).remove_namespaces!
+      auth_xml_doc.xpath('//authenticateResponse//return')[0].content
+    end
+
+    # 6 Methods were exposed by ScienceWire::Client, of which we have to worry about only 5:
+    # matched_publication_item_ids_for_author  **NOT called by consumers**
+    # matched_publication_item_ids_for_author_and_parse
+    # publication_items
+    # send_publication_query
+    # retrieve_publication_query
+    # id_suggestions
+
+    # @param [String] body request body XML
+    # @return [Array<Integer>] identifiers
+    def pub_ids_for_author(body)
+      response = connection.send(:post) do |req|
+        req.url '/PublicationCatalog/MatchedPublicationItemIdsForAuthor?format=xml' # need new path
+        req.headers['Content-Type'] = 'text/xml'
+        req.body = body
+      end
+      Nokogiri::XML(response)
+        .xpath('/ArrayOfItemMatchResult/ItemMatchResult/PublicationItemID') # parse differently
+        .map { |item| item.text.to_i }
+    end
+
+    alias_method :matched_publication_item_ids_for_author_and_parse, :pub_ids_for_author
+
+    # @param [String] ids CSV PublicationItemId values (no whitespace)
+    # @param [String] format desired response format, 'xml' or 'json'
+    # @return [String] response body matching requested format
+    def publication_items(ids, format = 'xml')
+      raise ArgumentError, 'format must be "xml" or "json"' unless %w(xml json).include?(format)
+      # previously had timeout_period: 500
+      response = connection.send(:get) do |req|
+        req.url "/PublicationCatalog/PublicationItems?format=#{format}&publicationItemIDs=#{ids}", # need new path
+        req.headers['Content-Type'] = 'text/xml'
+        req.body = body
+      end
+      response.body
+    end
+
+    # @param [String] body request body
+    # @return [String] response body matching requested format
+    def send_publication_query(body)
+      response = connection.send(:post) do |req|
+        req.url '/PublicationCatalog/PublicationQuery?format=xml' # need new path
+        req.headers['Content-Type'] = 'text/xml'
+        req.body = body
+      end
+      response.body
+    end
+
+    # @param [Integer] queryId
+    # @param [Integer] queryResultRows
+    # @param [String] format desired response format, 'xml' or 'json'
+    # @return [String] response body matching requested format
+    def retrieve_publication_query(queryId, queryResultRows, format = 'xml')
+      raise ArgumentError, 'format must be "xml" or "json"' unless %w(xml json).include?(format)
+      response = connection.send(:get) do |req|
+        req.url "/PublicationCatalog/PublicationQuery/#{queryId}?format=#{format}&v=version/4&page=0&pageSize=#{queryResultRows}" # need new path
+        req.headers['Content-Type'] = 'text/xml'
+        req.body = body
+      end
+      response.body
+    end
+
+    # @param [ScienceWire::AuthorAttributes] attributes
+    # @return [Array<Integer>]
+    # @todo Replace ScienceWire::Query::Suggestion? Or maybe not?
+    def id_suggestions(attributes)
+      pub_ids_for_author(ScienceWire::Query::Suggestion.new(attributes, 'Journal Document')) +
+        pub_ids_for_author(ScienceWire::Query::Suggestion.new(attributes, 'Conference Proceeding Document'))
+    end
+  end
+end

--- a/app/models/web_of_science/request.rb
+++ b/app/models/web_of_science/request.rb
@@ -1,0 +1,37 @@
+module WebOfScience
+  # A base class for request functionality
+  # Needs to retain the HTTP response and response document for debugging
+  # and establish a pattern for an individual request class to provide a more semantic interface.
+  # For example, a consumer of a request class really wants IDs or Records, not XML.
+  class Request
+    attr_reader :client, :template
+    attr_accessor :request_body, :response
+
+    # @param [WebOfScience::Client] client
+    # @param [String] template
+    def initialize(client, template)
+      @client = client
+      @template = template
+    end
+
+    # @param [String] body request body XML
+    # @return [Array<Integer>] identifiers
+    def pub_ids_for_author(body)
+      response = request(
+        body: body # path: '/PublicationCatalog/MatchedPublicationItemIdsForAuthor'
+      )
+      response
+        .xpath('/ArrayOfItemMatchResult/ItemMatchResult/PublicationItemID') # parse differently
+        .map { |item| item.text.to_i }
+    end
+
+    alias matched_publication_item_ids_for_author_and_parse pub_ids_for_author
+
+    # @param [Array<String>] ids PublicationItemId values (no whitespace)
+    # @return [Nokogiri::XML::Document] response body
+    # @note previously had timeout_period: 500, but probably unneccessary w/ new API limits
+    def publication_items(ids)
+      request(body: render('web_of_science/retrieve_by_id', :@uids => ids))
+    end
+  end
+end

--- a/app/views/layouts/wos_soap.xml.erb
+++ b/app/views/layouts/wos_soap.xml.erb
@@ -1,0 +1,7 @@
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+ xmlns:woksearch="http://woksearch.v3.wokmws.thomsonreuters.com">
+ <soapenv:Header/>
+ <soapenv:Body>
+<%= yield %>
+ </soapenv:Body>
+</soapenv:Envelope>

--- a/app/views/layouts/wos_soap.xml.erb
+++ b/app/views/layouts/wos_soap.xml.erb
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
  xmlns:woksearch="http://woksearch.v3.wokmws.thomsonreuters.com">
  <soapenv:Header/>

--- a/app/views/web_of_science/retrieve_by_id.xml.erb
+++ b/app/views/web_of_science/retrieve_by_id.xml.erb
@@ -1,15 +1,19 @@
 <woksearch:retrieveById>
   <databaseId>WOS</databaseId>
-  <queryLanguage>en</queryLanguage>
 <% @uids.each do |uid| %>
   <uid><%= uid %></uid>
 <% end %>
+  <queryLanguage>en</queryLanguage>
   <retrieveParameters>
     <firstRecord>1</firstRecord>
-    <count><%= @uids.count %></count>
+    <count>100</count>
     <option>
       <key>RecordIDs</key>
       <value>On</value>
+    </option>
+    <option>
+      <key>targetNamespace</key>
+      <value>http://scientific.thomsonreuters.com/schema/wok5.4/public/FullRecord</value>
     </option>
   </retrieveParameters>
 </woksearch:retrieveById>

--- a/app/views/web_of_science/retrieve_by_id.xml.erb
+++ b/app/views/web_of_science/retrieve_by_id.xml.erb
@@ -1,0 +1,15 @@
+<woksearch:retrieveById>
+  <databaseId>WOS</databaseId>
+  <queryLanguage>en</queryLanguage>
+<% @uids.each do |uid| %>
+  <uid><%= uid %></uid>
+<% end %>
+  <retrieveParameters>
+    <firstRecord>1</firstRecord>
+    <count><%= @uids.count %></count>
+    <option>
+      <key>RecordIDs</key>
+      <value>On</value>
+    </option>
+  </retrieveParameters>
+</woksearch:retrieveById>

--- a/app/views/web_of_science/search.xml.erb
+++ b/app/views/web_of_science/search.xml.erb
@@ -1,0 +1,27 @@
+<woksearch:search>
+  <queryParameters>
+    <databaseId>WOS</databaseId>
+    <userQuery>TS=(cadmium OR lead)</userQuery>
+    <editions>
+      <collection>WOS</collection>
+      <edition>SCI</edition>
+    </editions>
+    <timeSpan>
+      <begin>2000-01-01</begin>
+      <end>2011-12-31</end>
+    </timeSpan>
+    <queryLanguage>en</queryLanguage>
+  </queryParameters>
+  <retrieveParameters>
+    <firstRecord>1</firstRecord>
+    <count>5</count>
+    <option>
+      <key>RecordIDs</key>
+      <value>On</value>
+    </option>
+    <option>
+      <key>targetNamespace</key>
+      <value>http://scientific.thomsonreuters.com/schema/wok5.4/public/FullRecord</value>
+    </option>
+  </retrieveParameters>
+</woksearch:search>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -57,6 +57,9 @@ HARVESTER:
       state: CA
       country: USA
 
+web_of_science:
+  auth_key: X
+
 ## Ported from application.yml
 sw_doc_type_mappings:
   conference:


### PR DESCRIPTION
This pulls from Peter's script and basically pulls up the various
components that went into the Sciencewire client and request classes.

Once fully conformant to the new API, including limits and such, I
believe this class signature would be sufficient to stand in for the existing
ScienceWire client (and some related classes).

### Related code
- https://github.com/sul-dlss/sul_pub/blob/rialto-search/bin/faculty_wos_search.rb#L28-L110
