### PR TITLE
Savon WSDL client for WOS SOAP API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ gem 'paper_trail'
 gem 'pry-rails'
 gem 'pubmed_search'
 gem 'rest-client'
+gem 'savon', '~> 2.11'
 gem 'simple_form'
 gem 'whenever', require: false
 gem 'yaml_db'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,9 @@ GEM
     addressable (2.4.0)
     airbrussh (1.1.2)
       sshkit (>= 1.6.1, != 1.7.0)
+    akami (1.3.1)
+      gyoku (>= 0.4.0)
+      nokogiri
     arel (6.0.4)
     ast (2.3.0)
     autoprefixer-rails (5.2.1)
@@ -166,6 +169,8 @@ GEM
       rack (>= 1.3.0)
       rack-accept
       virtus (>= 1.0.0)
+    gyoku (1.3.1)
+      builder (>= 2.1.2)
     hashdiff (0.2.3)
     hashie (3.5.6)
     high_voltage (2.3.0)
@@ -173,6 +178,9 @@ GEM
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     httpclient (2.7.1)
+    httpi (2.4.2)
+      rack
+      socksify
     i18n (0.8.6)
     ice_nine (0.11.2)
     jbuilder (2.3.0)
@@ -213,6 +221,7 @@ GEM
     netrc (0.10.3)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
+    nori (2.6.0)
     okcomputer (1.13.0)
     paper_trail (4.0.0)
       activerecord (>= 3.0, < 6.0)
@@ -328,6 +337,14 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    savon (2.11.2)
+      akami (~> 1.2)
+      builder (>= 2.1.2)
+      gyoku (~> 1.2)
+      httpi (~> 2.3)
+      nokogiri (>= 1.4.0)
+      nori (~> 2.4)
+      wasabi (~> 3.4)
     simple_form (3.2.1)
       actionpack (> 4, < 5.1)
       activemodel (> 4, < 5.1)
@@ -337,6 +354,7 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
     slop (3.6.0)
+    socksify (1.7.1)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -379,6 +397,9 @@ GEM
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
+    wasabi (3.5.0)
+      httpi (~> 2.0)
+      nokogiri (>= 1.4.2)
     web-console (2.3.0)
       activemodel (>= 4.0)
       binding_of_caller (>= 0.7.2)
@@ -446,6 +467,7 @@ DEPENDENCIES
   retina_tag
   rspec-rails (~> 3.0)
   sass-rails (~> 5.0)
+  savon (~> 2.11)
   simple_form
   simplecov (~> 0.13)
   therubyracer

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -42,6 +42,11 @@ SCIENCEWIRE:
   TMPDIR: /tmp
   ARTICLE_BASE_URI: https://ws.isiknowledge.com/cps/openurl/service?url_ver=Z39.88-2004&rft_id=info:ut/
 
+## Web Of Science Auth Config
+WOS:
+  AUTH_CODE: secret
+  LOG_LEVEL: info
+
 DOI:
   BASE_URI: https://dx.doi.org/
 

--- a/lib/wos_client.rb
+++ b/lib/wos_client.rb
@@ -1,0 +1,68 @@
+require 'savon'
+
+# A Web of Science (or Web of Knowledge) client
+# It uses the WSDL service definitions from WOS
+# It uses the savon gem for SOAP, see http://savonrb.com/version2/client.html
+class WosClient
+
+  AUTH_WSDL = 'http://search.webofknowledge.com/esti/wokmws/ws/WOKMWSAuthenticate?wsdl'.freeze
+  SEARCH_WSDL = 'http://search.webofknowledge.com/esti/wokmws/ws/WokSearch?wsdl'.freeze
+
+  def initialize(auth_code, log_level = :info)
+    @auth_code = auth_code
+    @log_level = log_level
+  end
+
+  # A client for the authorization endpoint, using WSDL
+  # @return [Savon::Client]
+  def auth
+    @auth ||= Savon.client(
+      wsdl: AUTH_WSDL,
+      headers: { 'Authorization' => "Basic #{@auth_code}", 'SOAPAction' => [''] },
+      env_namespace: :soapenv,
+      log: true,
+      log_level: @log_level,
+      pretty_print_xml: true
+    )
+  end
+
+  # Calls authenticate on the authentication endpoint
+  # @return [Savon::Response]
+  def authenticate
+    auth.call(:authenticate)
+  end
+
+  # A client for the search endpoint, using WSDL
+  # @return [Savon::Client]
+  def search
+    @search ||= Savon.client(
+      wsdl: SEARCH_WSDL,
+      headers: { 'Cookie' => "SID=\"#{session_id}\"", 'SOAPAction' => '' },
+      env_namespace: :soapenv,
+      log: true,
+      log_level: @log_level,
+      pretty_print_xml: true
+    )
+  end
+
+  # Authenticates the session and returns the SID value
+  # @return [String] a session ID
+  def session_id
+    @session_id ||= begin
+      response = authenticate
+      response.body[:authenticate_response][:return]
+    end
+  end
+
+  # Calls close_session on the authentication endpoint
+  # Resets the session_id and the search client
+  # @return [nil]
+  def session_close
+    auth.globals[:headers]['Cookie'] = "SID=\"#{session_id}\""
+    auth.call(:close_session)
+    @auth = nil
+    @session_id = nil
+    @search = nil
+  end
+
+end

--- a/spec/fixtures/wos_client/authenticate.xml
+++ b/spec/fixtures/wos_client/authenticate.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <ns2:authenticateResponse xmlns:ns2="http://auth.cxf.wokmws.thomsonreuters.com">
+      <return>2F669ZtP6fRizIymX8V</return>
+    </ns2:authenticateResponse>
+  </soap:Body>
+</soap:Envelope>

--- a/spec/lib/wos_client_spec.rb
+++ b/spec/lib/wos_client_spec.rb
@@ -1,0 +1,65 @@
+# http://savonrb.com/version2/testing.html
+# require the helper module
+require 'savon/mock/spec_helper'
+
+describe WosClient do
+  include Savon::SpecHelper
+
+  # set Savon in and out of mock mode
+  before(:all) { savon.mock!   }
+  after(:all)  { savon.unmock! }
+
+  let(:wos_auth) { 'secret' }
+  let(:wos_client) { described_class.new(wos_auth) }
+  let(:auth_xml) { File.read('spec/fixtures/wos_client/authenticate.xml') }
+
+  describe '#new' do
+    it 'works' do
+      expect(wos_client).to be_an described_class
+    end
+  end
+
+  describe '#auth' do
+    it 'works' do
+      result = wos_client.auth
+      expect(result).to be_an Savon::Client
+    end
+  end
+
+  describe '#authenticate' do
+    it 'authenticates with the service' do
+      savon.expects(:authenticate).returns(auth_xml)
+      response = wos_client.authenticate
+      expect(response).to be_successful
+    end
+  end
+
+  describe '#search' do
+    it 'works' do
+      savon.expects(:authenticate).returns(auth_xml)
+      result = wos_client.search
+      expect(result).to be_an Savon::Client
+    end
+  end
+
+  describe '#session_id' do
+    it 'works' do
+      savon.expects(:authenticate).returns(auth_xml)
+      result = wos_client.session_id
+      expect(result).to be_an String
+      expect(result).to eq '2F669ZtP6fRizIymX8V'
+    end
+  end
+
+  describe '#session_close' do
+    before do
+      savon.expects(:authenticate).returns(auth_xml)
+      wos_client.session_id
+    end
+    it 'works' do
+      savon.expects(:close_session).returns('')
+      result = wos_client.session_close
+      expect(result).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
This explores using the ruby savon gem for SOAP.

- it can authenticate to the new SOAP API for Web of Science
- it initializes a search SOAP client

Use in `rails c`
```ruby
[2] pry(main)> wos = WosClient.new(Settings.WOS.AUTH_CODE);
I, [2017-09-27T08:58:32.938193 #12354]  INFO -- : SOAP request: http://search.webofknowledge.com/esti/wokmws/ws/WOKMWSAuthenticate
I, [2017-09-27T08:58:32.938383 #12354]  INFO -- : Authorization: Basic {{SECRET_SNIPPED}}, SOAPAction: , Content-Type: text/xml;charset=UTF-8, Content-Length: 397
I, [2017-09-27T08:58:33.238701 #12354]  INFO -- : SOAP response (status 200)
[3] pry(main)> wos.session_id
=> "1F28d8jTIRdrY9Oi4aF"
[4] pry(main)> wos.auth.class
=> Savon::Client
[5] pry(main)> wos.search.class
=> Savon::Client
[6] pry(main)> wos.search.operations
=> [:cited_references_retrieve, :related_records, :cited_references, :retrieve, :search, :citing_articles, :retrieve_by_id]
[7] pry(main)> wos.auth.operations
=> [:authenticate, :close_session]
```

I use this with a `config/settings.local.yml` file that contains the actual auth-token.

TODO:
- [x] specs on the `WosClient.search` functionality (see #223)

Related issues:
- https://github.com/sul-dlss/sul_pub/issues/171
