### PR TITLE
Enable simplecov

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,7 @@ group :test do
   gem 'capybara'
   gem 'coveralls', '~> 0.8', require: false
   gem 'simplecov', '~> 0.13', require: false
+  gem 'single_cov'
   gem 'vcr'
   gem 'webmock'
   gem 'equivalent-xml'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -353,6 +353,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    single_cov (0.4.0)
     slop (3.6.0)
     socksify (1.7.1)
     sprockets (3.7.1)
@@ -470,6 +471,7 @@ DEPENDENCIES
   savon (~> 2.11)
   simple_form
   simplecov (~> 0.13)
+  single_cov
   therubyracer
   thin
   turnout

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,9 @@ Dir.glob(File.join(__dir__, 'fixtures', '**', '*.rb'), &method(:require)) # load
 require 'rspec/matchers'
 require 'equivalent-xml'
 
+require 'single_cov'
+SingleCov.setup :rspec
+
 require 'simplecov'
 require 'coveralls'
 Coveralls.wear!('rails')


### PR DESCRIPTION
This PR also makes the SingleCov utility available for more immediate feedback on coverage when running specs.  It is not enabled on every file now, but can be enabled just by adding the `SingleCov.covered!` to any spec file that your working on.