### PR TITLE
Coveralls.wear only on CI builds

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,8 @@ require 'equivalent-xml'
 
 require 'simplecov'
 require 'coveralls'
-Coveralls.wear!('rails')
+# Coveralls interferes with coverage reports on a laptop, only wear it on CI builds
+Coveralls.wear!('rails') if ENV['TRAVIS']
 
 require 'webmock/rspec'
 WebMock.enable!
@@ -30,10 +31,12 @@ SimpleCov.profiles.define 'sul_pub' do
   # dataset for comparison, so it can't fail a travis build.
   maximum_coverage_drop 0.1
 end
-SimpleCov::Formatter::MultiFormatter.new([
-  SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter
-])
+SimpleCov::Formatter::MultiFormatter.new(
+  [
+    SimpleCov::Formatter::HTMLFormatter,
+    Coveralls::SimpleCov::Formatter
+  ]
+)
 SimpleCov.start 'sul_pub'
 
 require File.expand_path('../../config/environment', __FILE__)


### PR DESCRIPTION
The `Coveralls.wear!` disables the simplecov report on a dev laptop.  This PR enables the `Coveralls.wear!` on CI builds only, which allows SimpleCov to generate reports on a dev laptop, which can opened in a browser from
- `sul_pub/coverage/index.html`