### PR TITLE
capistrano-shell

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -4,6 +4,9 @@ require 'capistrano/setup'
 # Includes default deployment tasks
 require 'capistrano/deploy'
 
+require 'capistrano/scm/git'
+install_plugin Capistrano::SCM::Git
+
 # Includes tasks from other gems included in your Gemfile
 #
 # For documentation on these, see for example:

--- a/Capfile
+++ b/Capfile
@@ -25,6 +25,7 @@ require 'capistrano/bundler'
 require 'capistrano/rails'
 require 'capistrano/passenger'
 require 'capistrano/shared_configs'
+require 'capistrano/shell'
 require 'dlss/capistrano'
 require 'whenever/capistrano'
 

--- a/Gemfile
+++ b/Gemfile
@@ -84,5 +84,6 @@ group :deployment do
   gem 'capistrano'
   gem 'capistrano-passenger'
   gem 'capistrano-rails'
+  gem 'capistrano-shell'
   gem 'dlss-capistrano'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,8 @@ GEM
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
     capistrano-shared_configs (0.1.2)
+    capistrano-shell (0.2.0)
+      capistrano (~> 3.1)
     capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -430,6 +432,7 @@ DEPENDENCIES
   capistrano
   capistrano-passenger
   capistrano-rails
+  capistrano-shell
   capybara
   citeproc-ruby (~> 1.0)
   config


### PR DESCRIPTION
This enables easy shell sessions for deployment targets, e.g.
```
$ bundle exec cap prod shell
Pseudo-terminal will not be allocated because stdin is not a terminal.
Executing ssh -t -A pub@sul-pub-prod.stanford.edu cd /opt/app/pub/sul-pub/current && $SHELL --login
[pub@sul-pub-prod current]$ 
```

This PR also addresses the deprecation warning about explicit requirements to use the git SCM plugin.