### PR TITLE
Require cleanup

### DIFF
--- a/app/models/pubmed_source_record.rb
+++ b/app/models/pubmed_source_record.rb
@@ -1,5 +1,4 @@
 require 'nokogiri'
-require 'nokogiri'
 
 class PubmedSourceRecord < ActiveRecord::Base
   # validates_uniqueness_of :pmid

--- a/app/models/sciencewire_source_record.rb
+++ b/app/models/sciencewire_source_record.rb
@@ -1,6 +1,5 @@
 require 'nokogiri'
 require 'activerecord-import'
-require 'dotiw'
 
 class SciencewireSourceRecord < ActiveRecord::Base
   # validates_uniqueness_of :sciencewire_id

--- a/lib/bibtex_ingester.rb
+++ b/lib/bibtex_ingester.rb
@@ -1,6 +1,5 @@
 require 'bibtex'
 require 'citeproc'
-require 'dotiw'
 
 class BibtexIngester
   @@book_type_mapping = %w(book booklet inbook incollection manual techreport)

--- a/lib/science_wire_harvester.rb
+++ b/lib/science_wire_harvester.rb
@@ -1,4 +1,3 @@
-require 'dotiw'
 require 'parallel'
 
 class ScienceWireHarvester


### PR DESCRIPTION
A very simple subset of #235.  Remove `require` statements that are not useful for anything.