### PR TITLE
SingleCov enabled by running with env SINGLECOV=true

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,8 +8,10 @@ Dir.glob(File.join(__dir__, 'fixtures', '**', '*.rb'), &method(:require)) # load
 require 'rspec/matchers'
 require 'equivalent-xml'
 
-require 'single_cov'
-SingleCov.setup :rspec
+if ENV['SINGLECOV']
+  require 'single_cov'
+  SingleCov.setup :rspec
+end
 
 require 'simplecov'
 require 'coveralls'


### PR DESCRIPTION
Disable the requires for SingleCov by default.  It can interfere with RubyMine IDE test coverage because the IDE loads it's own copy of SimpleCov before running specs, which triggers an exception in SingleCov because it detects that SimpleCov is already loaded.