### PR TITLE
Normalize DOI, ISBN & PMID in PublicationIdentifiers & Publication.pub_hash

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,8 @@ gem 'faraday'
 gem 'high_voltage'
 gem 'htmlentities', '~> 4.3'
 gem 'httpclient', '~> 2.8'
+# Altmetric utilities related to the extraction, validation and normalization of various scholarly identifiers
+gem 'identifiers', '~> 0.9'
 # To use Jbuilder templates for JSON
 gem 'jbuilder'
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,6 +216,8 @@ GEM
     i18n (0.9.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
+    identifiers (0.9.1)
+      urn (~> 2.0)
     inflecto (0.0.2)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
@@ -435,6 +437,7 @@ GEM
     unf_ext (0.0.7.1)
     unicode (0.4.4.4)
     unicode-display_width (0.3.1)
+    urn (2.0.2)
     vcr (3.0.1)
     virtus (1.0.5)
       axiom-types (~> 0.1)
@@ -493,6 +496,7 @@ DEPENDENCIES
   honeybadger (~> 2.0)
   htmlentities (~> 4.3)
   httpclient (~> 2.8)
+  identifiers (~> 0.9)
   jbuilder
   jquery-rails
   kaminari

--- a/lib/parse_identifier.rb
+++ b/lib/parse_identifier.rb
@@ -1,0 +1,177 @@
+require 'identifiers'
+
+# https://github.com/altmetric/identifiers
+#
+# Identifiers::DOI.extract('example: 10.123/abcd.efghi')
+# # => ["10.123/abcd.efghi"]
+#
+# It can support many identifiers:
+# Identifiers::AdsBibcode.extract('')
+# Identifiers::ArxivId.extract('')
+# Identifiers::DOI.extract('')
+# Identifiers::Handle.extract('')
+# Identifiers::ISBN.extract('')
+# Identifiers::NationalClinicalTrialId.extract('')
+# Identifiers::ORCID.extract('')
+# Identifiers::PubmedId.extract('')
+# Identifiers::RepecId.extract('')
+# Identifiers::URN.extract('')
+
+# Parse the identifiers in a PublicationIdentifier
+#
+# This class should try to work with the input parameter as a read-only object.
+# It should only modify it when explicitly asked to `update` it.  If it's
+# an active record object, assign new values to it, but don't save it, leave
+# that persistence action to the consumer; see the runner script in
+# @see script/publication_identifier_normalization.rb
+class ParseIdentifier
+
+  URI_PREFIX_DOI = 'http://dx.doi.org/'.freeze
+  # URI_PREFIX_ISBN = ''.freeze # maybe there is no such thing?
+  URI_PREFIX_PMID = 'https://www.ncbi.nlm.nih.gov/pubmed/'.freeze
+
+  attr_reader :pub_id
+
+  # The pub_id parameter should respond to these fields:
+  # pub_id[:identifier_type]
+  # pub_id[:identifier_value]
+  # pub_id[:identifier_uri]
+  # @param pub_id [PublicationIdentifier|Hash]
+  def initialize(pub_id)
+    @pub_id = pub_id
+    raise "#{pub_info} is blank" if value.blank? && uri.blank?
+  end
+
+  def type
+    pub_id[:identifier_type]
+  end
+
+  def value
+    pub_id[:identifier_value]
+  end
+
+  def uri
+    pub_id[:identifier_uri]
+  end
+
+  # Update the pub_id with parsed data
+  # @return pub_id [PublicationIdentifier|Hash]
+  def update
+    if type_doi
+      pub_id[:identifier_value] = doi
+      pub_id[:identifier_uri] = doi_uri
+    elsif type_isbn
+      pub_id[:identifier_value] = isbn
+      pub_id[:identifier_uri] = isbn_uri
+    elsif type_pmid
+      pub_id[:identifier_value] = pmid
+      pub_id[:identifier_uri] = pmid_uri
+    end
+    pub_id
+  end
+
+  # ---
+  # DOI
+
+  # Extract a DOI value
+  # @return doi [String|nil]
+  def doi
+    @doi ||= begin
+      return nil unless type_doi
+      extract_value
+    end
+  end
+
+  # Extract a DOI URI
+  # @return doi_uri [String|nil]
+  def doi_uri
+    @doi_uri ||= begin
+      return nil unless type_doi
+      URI_PREFIX_DOI + doi
+    end
+  end
+
+  # ---
+  # ISBN
+
+  # Extract an ISBN value
+  # @return isbn [String|nil]
+  def isbn
+    @isbn ||= begin
+      return nil unless type_isbn
+      extract_value
+    end
+  end
+
+  # Extract an ISBN URI
+  # @return isbn_uri [String|nil]
+  def isbn_uri
+    nil # there is no URI
+  end
+
+  # ---
+  # PMID
+
+  # Extract a PMID value
+  # @return pmid [String|nil]
+  def pmid
+    @pmid ||= begin
+      return nil unless type_pmid
+      extract_value
+    end
+  end
+
+  # Extract an PMID URI
+  # @return pmid_uri [String|nil]
+  def pmid_uri
+    @pmid_uri ||= begin
+      return nil unless type_pmid
+      URI_PREFIX_PMID + pmid
+    end
+  end
+
+  private
+
+    def extractor
+      @extractor ||= if type_doi
+                       Identifiers::DOI
+                     elsif type_isbn
+                       Identifiers::ISBN
+                     elsif type_pmid
+                       Identifiers::PubmedId
+                     end
+    end
+
+    def extract_value
+      extract = extractor.extract(value).first
+      extract = extractor.extract(uri).first if extract.blank?
+      msg = "#{type}: #{pub_info} '#{extract}' extracted from '#{value}' or '#{uri}'"
+      extract.blank? ? logger.error(msg) : logger.info(msg)
+      extract
+    end
+
+    def logger
+      @logger ||= Logger.new(Rails.root.join('log', 'parse_identifier.log'))
+    end
+
+    def pub_info
+      @pub_info ||= begin
+        id = pub_id[:id] || ''
+        pub = pub_id[:publication_id] || 'n/a'
+        "#{pub_id.class} #{id}: SulPubID #{pub}:"
+      end
+    end
+
+    def type_doi
+      type =~ /\Adoi\z/i
+    end
+
+    def type_isbn
+      type =~ /\Aisbn\z/i
+    end
+
+    def type_pmid
+      type =~ /\Apmid\z/i
+    end
+
+end

--- a/lib/parse_identifier_doi.rb
+++ b/lib/parse_identifier_doi.rb
@@ -1,0 +1,39 @@
+require_relative 'parse_identifier'
+
+# Parse the DOI identifiers in a PublicationIdentifier
+class ParseIdentifierDOI < ParseIdentifier
+
+  URI_PREFIX = 'http://dx.doi.org/'.freeze
+
+  # Does the data validate?
+  def valid?
+    value.present? && uri.present?
+  end
+
+  # Extract a DOI value
+  # @return [String|nil]
+  def value
+    @value ||= extract_value
+  end
+
+  private
+
+    # Compose a URI
+    # @return [String|nil]
+    def compose_uri
+      return nil if value.blank?
+      URI_PREFIX + value
+    end
+
+    def extractor
+      @extractor ||= Identifiers::DOI
+    end
+
+    def logger
+      @logger ||= Logger.new(Rails.root.join('log', 'parse_identifier_doi.log'))
+    end
+
+    def match_type
+      type =~ /\Adoi\z/i
+    end
+end

--- a/lib/parse_identifier_isbn.rb
+++ b/lib/parse_identifier_isbn.rb
@@ -1,0 +1,36 @@
+require_relative 'parse_identifier'
+
+# Parse the ISBN identifiers in a PublicationIdentifier
+class ParseIdentifierISBN < ParseIdentifier
+
+  # Does the data validate?
+  def valid?
+    value.present? # ISBN has no URI
+  end
+
+  # Extract a value
+  # @return [String|nil]
+  def value
+    @value ||= extract_value
+  end
+
+  private
+
+    # Compose a URI
+    # @return [String|nil]
+    def compose_uri
+      nil # ISBN has no URI
+    end
+
+    def extractor
+      @extractor ||= Identifiers::ISBN
+    end
+
+    def logger
+      @logger ||= Logger.new(Rails.root.join('log', 'parse_identifier_isbn.log'))
+    end
+
+    def match_type
+      type =~ /\Aisbn\z/i
+    end
+end

--- a/lib/parse_identifier_pmid.rb
+++ b/lib/parse_identifier_pmid.rb
@@ -1,0 +1,46 @@
+require_relative 'parse_identifier'
+
+# Parse the PMID identifiers in a PublicationIdentifier
+class ParseIdentifierPMID < ParseIdentifier
+
+  URI_PREFIX = 'https://www.ncbi.nlm.nih.gov/pubmed/'.freeze
+
+  # Does the data validate?
+  def valid?
+    value.present? && uri.present?
+  end
+
+  # Extract a PMID value
+  # @return [String|nil]
+  def value
+    @value ||= extract_value
+  end
+
+  private
+
+    # Compose a URI
+    # @return [String|nil]
+    def compose_uri
+      return nil if value.blank?
+      URI_PREFIX + value
+    end
+
+    def extractor
+      @extractor ||= Identifiers::PubmedId
+    end
+
+    def extract_value_from_uri
+      # TO work around https://github.com/altmetric/identifiers/issues/19
+      uri = pub_id[:identifier_uri]
+      match = uri.nil? ? nil : uri.match(/(\d+)\z/)
+      match.nil? ? nil : extractor.extract(match[1]).first
+    end
+
+    def logger
+      @logger ||= Logger.new(Rails.root.join('log', 'parse_identifier_pmid.log'))
+    end
+
+    def match_type
+      type =~ /\Apmid\z/i
+    end
+end

--- a/script/publication_identifier_normalization.rb
+++ b/script/publication_identifier_normalization.rb
@@ -1,0 +1,98 @@
+class PublicationIdentifierNormalization
+
+  attr_reader :logger
+
+  def initialize
+    @logger = Logger.new(Rails.root.join('log', 'publication_identifier_normalization.log'))
+  end
+
+  # Choose a parser that can handle the PublicationIdentifier.identifier_type
+  # @param pub_id [PublicationIdentifier]
+  # @return parser [ParseIdentifier] a kind of ParseIdentifier to handle the pub_id
+  def identifier_parser(pub_id)
+    case pub_id[:identifier_type]
+    when /\Adoi\z/i
+      ParseIdentifierDOI.new(pub_id)
+    when /\Aisbn\z/i
+      ParseIdentifierISBN.new(pub_id)
+    when /\Apmid\z/i
+      ParseIdentifierPMID.new(pub_id)
+    else
+      # this default parser will not normalize any data, but it can detect blank data
+      ParseIdentifier.new(pub_id)
+    end
+  end
+
+  # @param pub [Publication] the Publication associated with a PublicationIdentifier
+  def pub_hash_update(pub)
+    pub.publication_identifiers.reload # force a reload
+    pub.add_all_identifiers_in_db_to_pub_hash
+    pub.save!
+  rescue => e
+    logger.error e.inspect
+  end
+
+  # > select distinct identifier_type from publication_identifiers;
+  # doi
+  # isbn
+  # legacy_cap_pub_id
+  # pmc
+  # PMID
+  # PublicationItemID
+  # SULPubId
+  # WoSItemID
+  # @param type [String] any PublicationIdentifier.identifier_type
+  # @param save_changes [Boolean] save changes
+  # @param delete_blanks [Boolean] delete empty identifiers
+  def normalize(type, save_changes = false, delete_blanks = false)
+    PublicationIdentifier.where(identifier_type: type).order(:created_at).find_each(batch_size: 200) do |pub_id|
+      begin
+        pub_id = identifier_parser(pub_id).update
+        if pub_id.changed? && save_changes
+          pub_id.save!
+          pub_hash_update(pub_id.publication)
+        end
+      rescue ParseIdentifierTypeError => e
+        # Move along, these are not the identifiers your looking for
+        logger.error e.inspect
+      rescue ParseIdentifierInvalidError => e
+        # The identifier_value and identifier_uri are blank or invalid
+        # TODO: Try to discover the identifier in a source publication?
+        logger.error e.inspect
+        if delete_blanks
+          pub_id.destroy!
+          pub_hash_update(pub_id.publication)
+        end
+      rescue => e
+        # Luke, you don't know the POWER of the dark side!
+        logger.error e.inspect
+      end
+    end
+  end
+
+  def log_only
+    ActiveRecord::Base.logger.level = 1
+    normalize('doi')
+    normalize('isbn')
+    normalize('pmid')
+  end
+
+  def test_doi
+    ActiveRecord::Base.logger.level = 1
+    normalize('doi', true, true)
+  end
+
+  def work
+    ActiveRecord::Base.logger.level = 1
+    save_changes = true
+    delete_blanks = true
+    normalize('doi', save_changes, delete_blanks)
+    normalize('isbn', save_changes, delete_blanks)
+    normalize('pmid', save_changes, delete_blanks)
+  end
+end
+
+# ---
+# Runner main
+c = PublicationIdentifierNormalization.new
+c.work

--- a/spec/factories/publication_identifier.rb
+++ b/spec/factories/publication_identifier.rb
@@ -1,4 +1,11 @@
 FactoryGirl.define do
   factory :publication_identifier do
+    publication
+  end
+
+  factory :blank_publication_identifier, parent: :publication_identifier do
+    identifier_type 'blank'
+    identifier_value ''
+    identifier_uri ''
   end
 end

--- a/spec/lib/parse_identifier_doi_spec.rb
+++ b/spec/lib/parse_identifier_doi_spec.rb
@@ -1,0 +1,29 @@
+# Load Shared Examples
+require Rails.root.join('spec', 'support', 'parse_identifier_shared_examples.rb')
+
+describe ParseIdentifierDOI do
+  let(:identifier_type) { 'doi' }
+  let(:identifier_value) { '10.1038/ncomms3199' }
+  let(:identifier_uri) { "http://dx.doi.org/#{identifier_value}" }
+  let(:identifier) do
+    FactoryGirl.create(:publication_identifier,
+                       identifier_type: identifier_type,
+                       identifier_value: identifier_value,
+                       identifier_uri: identifier_uri
+                      )
+  end
+  let(:parser) { described_class.new(identifier) }
+
+  # Happy paths
+  it_behaves_like 'parser_new_works'
+  it_behaves_like 'valid_identifier'
+  it_behaves_like 'update_works_with_only_valid_uri'
+  it_behaves_like 'update_works_with_only_valid_value'
+  it_behaves_like 'update_works_with_only_valid_value_in_uri'
+
+  # Un-happy paths
+  it_behaves_like 'blank_identifiers_raise_exception'
+  it_behaves_like 'other_identifiers_raise_exception'
+  let(:invalid_value) { '10.1038/' }
+  it_behaves_like 'invalid_value'
+end

--- a/spec/lib/parse_identifier_isbn_spec.rb
+++ b/spec/lib/parse_identifier_isbn_spec.rb
@@ -1,0 +1,59 @@
+# Load Shared Examples
+require Rails.root.join('spec', 'support', 'parse_identifier_shared_examples.rb')
+
+describe ParseIdentifierISBN do
+  let(:identifier_type) { 'isbn' }
+  let(:identifier_value) { '9781904842781' }
+  let(:identifier_uri) { nil }
+  let(:identifier) do
+    FactoryGirl.create(:publication_identifier,
+                       identifier_type: identifier_type,
+                       identifier_value: identifier_value,
+                       identifier_uri: identifier_uri
+                      )
+  end
+  let(:parser) { described_class.new(identifier) }
+
+  # Happy paths
+  it_behaves_like 'parser_new_works'
+  it_behaves_like 'valid_identifier'
+
+  # Un-happy paths
+  it_behaves_like 'blank_identifiers_raise_exception'
+  it_behaves_like 'other_identifiers_raise_exception'
+  let(:invalid_value) { '978' }
+  it_behaves_like 'invalid_value'
+
+  # ---
+  # ISBN Identifiers on the happy path
+  # - this differs from DOI & PMID because it has no URI
+
+  context '#update using only a valid value' do
+    let(:identifier) do
+      FactoryGirl.create(:publication_identifier,
+                         identifier_type: identifier_type,
+                         identifier_value: identifier_value
+                        )
+    end
+
+    it_behaves_like 'parser_works'
+    it_behaves_like 'it_does_not_change_identifier'
+    it_behaves_like 'it_does_not_change_value'
+    it_behaves_like 'it_does_not_change_uri'
+  end
+
+  context '#update using a valid value, but in the URI' do
+    let(:identifier) do
+      FactoryGirl.create(:publication_identifier,
+                         identifier_type: identifier_type,
+                         identifier_uri: identifier_value
+                        )
+    end
+    let(:parser) { described_class.new(identifier) }
+
+    it_behaves_like 'parser_works'
+    it_behaves_like 'it_does_not_change_identifier'
+    it_behaves_like 'it_changes_uri'
+    it_behaves_like 'it_changes_value'
+  end
+end

--- a/spec/lib/parse_identifier_pmid_spec.rb
+++ b/spec/lib/parse_identifier_pmid_spec.rb
@@ -1,0 +1,29 @@
+# Load Shared Examples
+require Rails.root.join('spec', 'support', 'parse_identifier_shared_examples.rb')
+
+describe ParseIdentifierPMID do
+  let(:identifier_type) { 'PMID' }
+  let(:identifier_value) { '10002407' }
+  let(:identifier_uri) { "https://www.ncbi.nlm.nih.gov/pubmed/#{identifier_value}" }
+  let(:identifier) do
+    FactoryGirl.create(:publication_identifier,
+                       identifier_type: identifier_type,
+                       identifier_value: identifier_value,
+                       identifier_uri: identifier_uri
+                      )
+  end
+  let(:parser) { described_class.new(identifier) }
+
+  # Happy paths
+  it_behaves_like 'parser_new_works'
+  it_behaves_like 'valid_identifier'
+  it_behaves_like 'update_works_with_only_valid_uri'
+  it_behaves_like 'update_works_with_only_valid_value'
+  it_behaves_like 'update_works_with_only_valid_value_in_uri'
+
+  # Un-happy paths
+  it_behaves_like 'blank_identifiers_raise_exception'
+  it_behaves_like 'other_identifiers_raise_exception'
+  let(:invalid_value) { '101-038' }
+  it_behaves_like 'invalid_value'
+end

--- a/spec/lib/parse_identifier_spec.rb
+++ b/spec/lib/parse_identifier_spec.rb
@@ -1,177 +1,34 @@
+# Load Shared Examples
+require Rails.root.join('spec', 'support', 'parse_identifier_shared_examples.rb')
+
 describe ParseIdentifier do
-  let(:blank_identifier) do
+  let(:identifier_type) { 'other' }
+  let(:identifier_value) { 'a value' }
+  let(:identifier_uri) { 'a uri' }
+  let(:identifier) do
     FactoryGirl.create(:publication_identifier,
-                       identifier_type: 'some-blank-identifier',
-                       identifier_value: '',
-                       identifier_uri: ''
+                       identifier_type: identifier_type,
+                       identifier_value: identifier_value,
+                       identifier_uri: identifier_uri
                       )
   end
+  let(:parser) { described_class.new(identifier) }
 
-  let(:doi_value) { '10.1038/ncomms3199' }
-  let(:doi_uri) { "http://dx.doi.org/#{doi_value}" }
-  let(:doi_identifier) do
-    FactoryGirl.create(:publication_identifier,
-                       identifier_type: 'doi',
-                       identifier_value: doi_value,
-                       identifier_uri: doi_uri
-                      )
-  end
+  # Happy paths
+  # - the base class does not extract or modify anything
+  it_behaves_like 'parser_new_works'
+  it_behaves_like 'valid_identifier'
+  it_behaves_like 'it_changes_nothing'
 
-  describe '#new' do
-    it 'works' do
-      parser = described_class.new(doi_identifier)
-      expect(parser).not_to be_nil
-    end
-    it 'raises RuntimeError when value and uri are blank' do
-      expect { described_class.new(blank_identifier) }.to raise_error(RuntimeError)
-    end
-  end
-
-  describe '#update' do
-    it 'works' do
-      parser = described_class.new(doi_identifier)
-      expect(parser.update).to be_an PublicationIdentifier
-    end
-  end
+  # Un-happy paths
+  # - the base class allows anything except blank data
+  it_behaves_like 'blank_identifiers_raise_exception'
 
   # ---
-  # Shared Examples
-
-  shared_examples 'DOI_works' do
-    it '#doi works' do
-      expect(parser.doi).to eq doi_value
-    end
-    it '#doi_uri works' do
-      expect(parser.doi_uri).to eq doi_uri
-    end
-  end
-
-  shared_examples 'DOI_nil' do
-    it '#doi is blank' do
-      expect(parser.doi).to be_nil
-    end
-    it '#doi_uri is blank' do
-      expect(parser.doi_uri).to be_nil
-    end
-  end
-
-  shared_examples 'it_does_not_change_identifier' do
-    # By design, the parser should preserve the input identifier
-    it 'update does not change identifier' do
-      expect { parser.update }.not_to change { identifier }
-    end
-  end
-
-  shared_examples 'it_changes_value' do
-    it 'updates the value' do
-      expect { parser.update }.to change { parser.value }
-    end
-  end
-
-  shared_examples 'it_changes_uri' do
-    it 'updates the uri' do
-      expect { parser.update }.to change { parser.uri }
-    end
-  end
-
-  shared_examples 'it_does_not_change_value' do
-    it 'does not change value' do
-      expect { parser.update }.not_to change { parser.value }
-    end
-  end
-
-  shared_examples 'it_does_not_change_uri' do
-    it 'does not change the uri' do
-      expect { parser.update }.not_to change { parser.uri }
-    end
-  end
-
-  shared_examples 'it_changes_nothing' do
-    it_behaves_like 'it_does_not_change_identifier'
-    it_behaves_like 'it_does_not_change_value'
-    it_behaves_like 'it_does_not_change_uri'
-  end
-
-  # ---
-  # DOI Identifiers that require no changes
-
-  context 'DOI is valid' do
-    let(:identifier) do
-      FactoryGirl.create(:publication_identifier,
-                         identifier_type: 'doi',
-                         identifier_value: doi_value,
-                         identifier_uri: doi_uri
-                        )
-    end
-    let(:parser) { described_class.new(identifier) }
-
-    it_behaves_like 'DOI_works'
-    it_behaves_like 'it_changes_nothing'
-  end
-
-  # ---
-  # DOI Identifiers that are changed in some way
-
-  context '#update using only a valid DOI URI' do
-    let(:identifier) do
-      FactoryGirl.create(:publication_identifier,
-                         identifier_type: 'doi',
-                         identifier_uri: doi_uri
-                        )
-    end
-    let(:parser) { described_class.new(identifier) }
-
-    it_behaves_like 'DOI_works'
-    it_behaves_like 'it_does_not_change_identifier'
-    it_behaves_like 'it_does_not_change_uri'
-    it_behaves_like 'it_changes_value'
-  end
-
-  context '#update using only a valid DOI value' do
-    let(:identifier) do
-      FactoryGirl.create(:publication_identifier,
-                         identifier_type: 'doi',
-                         identifier_value: doi_value
-                        )
-    end
-    let(:parser) { described_class.new(identifier) }
-
-    it_behaves_like 'DOI_works'
-    it_behaves_like 'it_does_not_change_identifier'
-    it_behaves_like 'it_does_not_change_value'
-    it_behaves_like 'it_changes_uri'
-  end
-
-  context '#update using a valid DOI value, but in the URI' do
-    let(:identifier) do
-      FactoryGirl.create(:publication_identifier,
-                         identifier_type: 'doi',
-                         identifier_uri: doi_value
-                        )
-    end
-    let(:parser) { described_class.new(identifier) }
-
-    it_behaves_like 'DOI_works'
-    it_behaves_like 'it_does_not_change_identifier'
-    it_behaves_like 'it_changes_uri'
-    it_behaves_like 'it_changes_value'
-  end
-
-  # ---
-  # Other identifiers that are not changed in any way
+  # Identifiers that are not changed in any way
 
   context '#update using an identifier it does not handle' do
-    let(:identifier) do
-      FactoryGirl.create(:publication_identifier,
-                         identifier_type: 'Huh?',
-                         identifier_value: 'some-value',
-                         identifier_uri: 'some-uri'
-                        )
-    end
-    let(:parser) { described_class.new(identifier) }
-
     it_behaves_like 'it_changes_nothing'
-    it_behaves_like 'DOI_nil'
   end
 
   context '#update using a WoSItemID' do
@@ -182,10 +39,8 @@ describe ParseIdentifier do
                          identifier_uri:   'https://ws.isiknowledge.com/cps/openurl/service?url_ver=Z39.88-2004&rft_id=info:ut/A1976CM52800051'
                         )
     end
-    let(:parser) { described_class.new(identifier) }
 
     it_behaves_like 'it_changes_nothing'
-    it_behaves_like 'DOI_nil'
   end
 
   context '#update using a PublicationItemID' do
@@ -196,9 +51,20 @@ describe ParseIdentifier do
                          identifier_uri:   nil
                         )
     end
-    let(:parser) { described_class.new(identifier) }
 
     it_behaves_like 'it_changes_nothing'
-    it_behaves_like 'DOI_nil'
+  end
+
+  # ---
+  # Base class behavior
+
+  context '#extractor' do
+    it 'is not called' do
+      expect(parser).not_to receive(:extractor)
+      parser.update
+    end
+    it 'if called - it raises NotImplementedError' do
+      expect { parser.send(:extractor) }.to raise_error(NotImplementedError)
+    end
   end
 end

--- a/spec/lib/parse_identifier_spec.rb
+++ b/spec/lib/parse_identifier_spec.rb
@@ -1,0 +1,204 @@
+describe ParseIdentifier do
+  let(:blank_identifier) do
+    FactoryGirl.create(:publication_identifier,
+                       identifier_type: 'some-blank-identifier',
+                       identifier_value: '',
+                       identifier_uri: ''
+                      )
+  end
+
+  let(:doi_value) { '10.1038/ncomms3199' }
+  let(:doi_uri) { "http://dx.doi.org/#{doi_value}" }
+  let(:doi_identifier) do
+    FactoryGirl.create(:publication_identifier,
+                       identifier_type: 'doi',
+                       identifier_value: doi_value,
+                       identifier_uri: doi_uri
+                      )
+  end
+
+  describe '#new' do
+    it 'works' do
+      parser = described_class.new(doi_identifier)
+      expect(parser).not_to be_nil
+    end
+    it 'raises RuntimeError when value and uri are blank' do
+      expect { described_class.new(blank_identifier) }.to raise_error(RuntimeError)
+    end
+  end
+
+  describe '#update' do
+    it 'works' do
+      parser = described_class.new(doi_identifier)
+      expect(parser.update).to be_an PublicationIdentifier
+    end
+  end
+
+  # ---
+  # Shared Examples
+
+  shared_examples 'DOI_works' do
+    it '#doi works' do
+      expect(parser.doi).to eq doi_value
+    end
+    it '#doi_uri works' do
+      expect(parser.doi_uri).to eq doi_uri
+    end
+  end
+
+  shared_examples 'DOI_nil' do
+    it '#doi is blank' do
+      expect(parser.doi).to be_nil
+    end
+    it '#doi_uri is blank' do
+      expect(parser.doi_uri).to be_nil
+    end
+  end
+
+  shared_examples 'it_does_not_change_identifier' do
+    # By design, the parser should preserve the input identifier
+    it 'update does not change identifier' do
+      expect { parser.update }.not_to change { identifier }
+    end
+  end
+
+  shared_examples 'it_changes_value' do
+    it 'updates the value' do
+      expect { parser.update }.to change { parser.value }
+    end
+  end
+
+  shared_examples 'it_changes_uri' do
+    it 'updates the uri' do
+      expect { parser.update }.to change { parser.uri }
+    end
+  end
+
+  shared_examples 'it_does_not_change_value' do
+    it 'does not change value' do
+      expect { parser.update }.not_to change { parser.value }
+    end
+  end
+
+  shared_examples 'it_does_not_change_uri' do
+    it 'does not change the uri' do
+      expect { parser.update }.not_to change { parser.uri }
+    end
+  end
+
+  shared_examples 'it_changes_nothing' do
+    it_behaves_like 'it_does_not_change_identifier'
+    it_behaves_like 'it_does_not_change_value'
+    it_behaves_like 'it_does_not_change_uri'
+  end
+
+  # ---
+  # DOI Identifiers that require no changes
+
+  context 'DOI is valid' do
+    let(:identifier) do
+      FactoryGirl.create(:publication_identifier,
+                         identifier_type: 'doi',
+                         identifier_value: doi_value,
+                         identifier_uri: doi_uri
+                        )
+    end
+    let(:parser) { described_class.new(identifier) }
+
+    it_behaves_like 'DOI_works'
+    it_behaves_like 'it_changes_nothing'
+  end
+
+  # ---
+  # DOI Identifiers that are changed in some way
+
+  context '#update using only a valid DOI URI' do
+    let(:identifier) do
+      FactoryGirl.create(:publication_identifier,
+                         identifier_type: 'doi',
+                         identifier_uri: doi_uri
+                        )
+    end
+    let(:parser) { described_class.new(identifier) }
+
+    it_behaves_like 'DOI_works'
+    it_behaves_like 'it_does_not_change_identifier'
+    it_behaves_like 'it_does_not_change_uri'
+    it_behaves_like 'it_changes_value'
+  end
+
+  context '#update using only a valid DOI value' do
+    let(:identifier) do
+      FactoryGirl.create(:publication_identifier,
+                         identifier_type: 'doi',
+                         identifier_value: doi_value
+                        )
+    end
+    let(:parser) { described_class.new(identifier) }
+
+    it_behaves_like 'DOI_works'
+    it_behaves_like 'it_does_not_change_identifier'
+    it_behaves_like 'it_does_not_change_value'
+    it_behaves_like 'it_changes_uri'
+  end
+
+  context '#update using a valid DOI value, but in the URI' do
+    let(:identifier) do
+      FactoryGirl.create(:publication_identifier,
+                         identifier_type: 'doi',
+                         identifier_uri: doi_value
+                        )
+    end
+    let(:parser) { described_class.new(identifier) }
+
+    it_behaves_like 'DOI_works'
+    it_behaves_like 'it_does_not_change_identifier'
+    it_behaves_like 'it_changes_uri'
+    it_behaves_like 'it_changes_value'
+  end
+
+  # ---
+  # Other identifiers that are not changed in any way
+
+  context '#update using an identifier it does not handle' do
+    let(:identifier) do
+      FactoryGirl.create(:publication_identifier,
+                         identifier_type: 'Huh?',
+                         identifier_value: 'some-value',
+                         identifier_uri: 'some-uri'
+                        )
+    end
+    let(:parser) { described_class.new(identifier) }
+
+    it_behaves_like 'it_changes_nothing'
+    it_behaves_like 'DOI_nil'
+  end
+
+  context '#update using a WoSItemID' do
+    let(:identifier) do
+      FactoryGirl.create(:publication_identifier,
+                         identifier_type:  'WoSItemID',
+                         identifier_value: 'A1976CM52800051',
+                         identifier_uri:   'https://ws.isiknowledge.com/cps/openurl/service?url_ver=Z39.88-2004&rft_id=info:ut/A1976CM52800051'
+                        )
+    end
+    let(:parser) { described_class.new(identifier) }
+
+    it_behaves_like 'it_changes_nothing'
+    it_behaves_like 'DOI_nil'
+  end
+
+  context '#update using a PublicationItemID' do
+    let(:identifier) do
+      FactoryGirl.create(:publication_identifier,
+                         identifier_type:  'PublicationItemID',
+                         identifier_value: '13276514',
+                         identifier_uri:   nil
+                        )
+    end
+    let(:parser) { described_class.new(identifier) }
+
+    it_behaves_like 'it_changes_nothing'
+    it_behaves_like 'DOI_nil'
+  end
+end

--- a/spec/support/parse_identifier_shared_examples.rb
+++ b/spec/support/parse_identifier_shared_examples.rb
@@ -1,0 +1,197 @@
+
+# ---
+# Shared Examples for ParseIdentifier* specs
+
+shared_examples 'parser_new_works' do
+  describe '#new' do
+    it 'works' do
+      expect(parser).to be_an described_class
+    end
+  end
+end
+
+shared_examples 'parser_works' do
+  it '#value works' do
+    expect(parser.value).to eq identifier_value
+  end
+  it '#uri works' do
+    expect(parser.uri).to eq identifier_uri
+  end
+  it '#validates OK' do
+    expect(parser.valid?).to be true
+  end
+  it '#update works' do
+    expect(parser.update).to be_an PublicationIdentifier
+  end
+end
+
+shared_examples 'valid_identifier' do
+  it_behaves_like 'parser_works'
+  it_behaves_like 'it_changes_nothing'
+  it_behaves_like 'it_is_impervious_to_outside_changes'
+end
+
+shared_examples 'it_is_impervious_to_outside_changes' do
+  it 'memoises value data on init and cannot change it otherwise' do
+    parser.value # initialize it with valid data
+    expect do
+      identifier.identifier_value = 'ha ha, now here is something different'
+    end.not_to change { parser.value }
+  end
+  it 'cannot change value after init' do
+    expect { parser.value = 'try me' }.to raise_error(NoMethodError)
+  end
+end
+
+shared_examples 'it_does_not_change_identifier' do
+  # By design, the parser should preserve the input identifier
+  it 'update does not change identifier' do
+    expect { parser.update }.not_to change { identifier }
+  end
+end
+
+shared_examples 'it_changes_value' do
+  it 'updates the value' do
+    expect(parser.value).not_to eq identifier['identifier_value']
+  end
+end
+
+shared_examples 'it_changes_uri' do
+  it 'updates the uri' do
+    expect(parser.uri).not_to eq identifier['identifier_uri']
+  end
+end
+
+shared_examples 'it_does_not_change_value' do
+  it 'does not change value' do
+    expect(parser.value).to eq identifier['identifier_value']
+  end
+end
+
+shared_examples 'it_does_not_change_uri' do
+  it 'does not change the uri' do
+    expect(parser.uri).to eq identifier['identifier_uri']
+  end
+end
+
+shared_examples 'it_changes_nothing' do
+  it_behaves_like 'it_does_not_change_identifier'
+  it_behaves_like 'it_does_not_change_value'
+  it_behaves_like 'it_does_not_change_uri'
+end
+
+shared_examples 'invalid_type' do
+  it 'raises ParseIdentifierTypeError' do
+    expect { parser }.to raise_error(ParseIdentifierTypeError)
+  end
+end
+
+shared_examples 'invalid_value' do
+  context 'identifier is invalid' do
+    let(:invalid_identifier) do
+      FactoryGirl.create(:publication_identifier,
+                         identifier_type: identifier_type,
+                         identifier_value: invalid_value
+                        )
+    end
+
+    it 'raises ParseIdentifierInvalidError when value and uri do not validate' do
+      expect { described_class.new(invalid_identifier) }.to raise_error(ParseIdentifierInvalidError)
+    end
+  end
+end
+
+shared_examples 'blank_identifiers_raise_exception' do
+  let(:blank_identifier) { FactoryGirl.create(:blank_publication_identifier, identifier_type: identifier_type) }
+
+  it 'raises ParseIdentifierInvalidError when value and uri are blank' do
+    expect { described_class.new(blank_identifier) }.to raise_error(ParseIdentifierInvalidError)
+  end
+end
+
+shared_examples 'other_identifiers_raise_exception' do
+  context '#update using an identifier it does not handle' do
+    let(:identifier) do
+      FactoryGirl.create(:publication_identifier,
+                         identifier_type: 'Huh?',
+                         identifier_value: 'some-value',
+                         identifier_uri: 'some-uri'
+                        )
+    end
+
+    it_behaves_like 'invalid_type'
+  end
+
+  context '#update using a WoSItemID' do
+    let(:identifier) do
+      FactoryGirl.create(:publication_identifier,
+                         identifier_type:  'WoSItemID',
+                         identifier_value: 'A1976CM52800051',
+                         identifier_uri:   'https://ws.isiknowledge.com/cps/openurl/service?url_ver=Z39.88-2004&rft_id=info:ut/A1976CM52800051'
+                        )
+    end
+
+    it_behaves_like 'invalid_type'
+  end
+
+  context '#update using a PublicationItemID' do
+    let(:identifier) do
+      FactoryGirl.create(:publication_identifier,
+                         identifier_type:  'PublicationItemID',
+                         identifier_value: '13276514',
+                         identifier_uri:   nil
+                        )
+    end
+
+    it_behaves_like 'invalid_type'
+  end
+end
+
+shared_examples 'update_works_with_only_valid_uri' do
+  context '#update using only a valid URI' do
+    let(:identifier) do
+      FactoryGirl.create(:publication_identifier,
+                         identifier_type: identifier_type,
+                         identifier_uri: identifier_uri
+                        )
+    end
+
+    it_behaves_like 'parser_works'
+    it_behaves_like 'it_does_not_change_identifier'
+    it_behaves_like 'it_does_not_change_uri'
+    it_behaves_like 'it_changes_value'
+  end
+end
+
+shared_examples 'update_works_with_only_valid_value' do
+  context '#update using only a valid value' do
+    let(:identifier) do
+      FactoryGirl.create(:publication_identifier,
+                         identifier_type: identifier_type,
+                         identifier_value: identifier_value
+                        )
+    end
+
+    it_behaves_like 'parser_works'
+    it_behaves_like 'it_does_not_change_identifier'
+    it_behaves_like 'it_does_not_change_value'
+    it_behaves_like 'it_changes_uri'
+  end
+end
+
+shared_examples 'update_works_with_only_valid_value_in_uri' do
+  context '#update using a valid value, but in the URI' do
+    let(:identifier) do
+      FactoryGirl.create(:publication_identifier,
+                         identifier_type: identifier_type,
+                         identifier_uri: identifier_value
+                        )
+    end
+
+    it_behaves_like 'parser_works'
+    it_behaves_like 'it_does_not_change_identifier'
+    it_behaves_like 'it_changes_uri'
+    it_behaves_like 'it_changes_value'
+  end
+end
+


### PR DESCRIPTION
Fix #241 

Connected to #285 
Could be revised if https://github.com/altmetric/identifiers/pull/20 works out.

This PR adds a script to use the Altmetrics identifiers gem to extract DOI, ISBN & PMID from the PublicationIdentifiers.  The runner script can be used in a read-only mode to log the results or it can be used in a read-write mode to remediate the db-data.  In the read-write mode, it should update the PublicationIdentifier and the Publication.pub_hash['identifiers'].

On my laptop, I have a prod-db dump from early Oct, 2017.  I can run the following to test the identifier normalization and then review the log file output:
```
RAILS_ENV=production bundle exec rails runner script/publication_identifier_normalization.rb
```

It logs to `log/parse_identifier*`; the log files from a prod-db dump (2017-10-04) normalization are available from this git-lfs repo - https://github.com/darrenleeweber/sul_pub_logs

A quick grep of the log files gets some numbers on the results.

### Normalization success
```
$ grep -c 'INFO' log/parse_identifier_doi.log
192376
$ grep -c 'INFO' log/parse_identifier_isbn.log
539
$ grep -c 'INFO' log/parse_identifier_pmid.log
260024
```

### Normalization failure
```
$ grep -c 'ERROR' log/parse_identifier_doi.log
3850
$ grep -c 'ERROR' log/parse_identifier_isbn.log
32
$ grep -c 'ERROR' log/parse_identifier_pmid.log
0
```

### Blanks
```
$ grep -E -c 'ERROR.*BLANK.*doi' log/parse_identifier_exceptions.log 
111
$ grep -E -c 'ERROR.*BLANK.*isbn' log/parse_identifier_exceptions.log 
1876
$ grep -E -c 'ERROR.*BLANK.*PMID' log/parse_identifier_exceptions.log 
0
```

### PMID note
The PMID values have no blanks and the values are good.  @peetucket mentioned that he did a batch change to them and most of them have an updated date in May 7, 2017.  

While working on the specs for the PMID, discovered the identifers gem cannot extract a PMID from an URI that contains the PMID, see
- https://github.com/altmetric/identifiers/issues/19

The PMID normalization works around that by trying to extract a number from the end of a URI.  I did spot check a few of our PMID identifiers and also added specs to ensure that this normalization script does not change anything that is already good to start with (i.e. the runner script must be idempotent once an identifier is already normalized).