### PR TITLE
WosRecords#empty?

### DIFF
--- a/lib/wos_records.rb
+++ b/lib/wos_records.rb
@@ -9,6 +9,9 @@ class WosRecords
   # @return [Integer] WOS record count
   def_delegators :rec_nodes, :count
 
+  # @return [Boolean] WOS records empty?
+  def_delegators :rec_nodes, :empty?
+
   # @return xml [String] WOS records in XML
   def_delegators :doc, :to_xml
 

--- a/spec/lib/wos_records_spec.rb
+++ b/spec/lib/wos_records_spec.rb
@@ -67,6 +67,19 @@ describe WosRecords do
     end
   end
 
+  describe '#empty?' do
+    it 'delegates to rec_nodes.empty?' do
+      expect(wos_records_encoded.empty?).to eq wos_records_encoded.rec_nodes.empty?
+    end
+    it 'returns false when records exist' do
+      expect(wos_records_encoded.empty?).to be false
+    end
+    it 'returns true when records are missing' do
+      wos_records = described_class.new(records: '<records/>')
+      expect(wos_records.empty?).to be true
+    end
+  end
+
   describe 'Enumerable mixin' do
     it 'is_a? Enumerable' do
       expect(wos_records_decoded).to be_an Enumerable


### PR DESCRIPTION
Simply adds an `WosRecords#empty?` method.