### PR TITLE
WosClient#session_close fault handing

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -45,6 +45,7 @@ SCIENCEWIRE:
 ## Web Of Science Auth Config
 WOS:
   AUTH_CODE: secret
+  LOG: log/web_of_science.log
   LOG_LEVEL: info
 
 DOI:

--- a/lib/notification_manager.rb
+++ b/lib/notification_manager.rb
@@ -17,6 +17,8 @@ class NotificationManager
         log_exception(pubmed_logger, log_message, e)
       when CapAuthorsPoller, CapHttpClient
         log_exception(cap_logger, log_message, e)
+      when WosClient
+        log_exception(wos_logger, log_message, e)
       else
         log_exception(Rails.logger, log_message, e)
       end
@@ -41,6 +43,12 @@ class NotificationManager
     # rubocop:disable Style/ClassVars
     def sciencewire_logger
       @@sciencewire_logger ||= Logger.new(Settings.SCIENCEWIRE.LOG)
+    end
+    # rubocop:enable Style/ClassVars
+
+    # rubocop:disable Style/ClassVars
+    def wos_logger
+      @@wos_logger ||= Logger.new(Settings.WOS.LOG)
     end
     # rubocop:enable Style/ClassVars
 

--- a/lib/wos_client.rb
+++ b/lib/wos_client.rb
@@ -62,11 +62,22 @@ class WosClient
   # Resets the session_id and the search client
   # @return [nil]
   def session_close
-    auth.globals[:headers]['Cookie'] = "SID=\"#{session_id}\""
-    auth.call(:close_session)
+    begin
+      auth.globals[:headers]['Cookie'] = "SID=\"#{session_id}\""
+      auth.call(:close_session)
+    rescue Savon::SOAPFault => fault
+      # Savon::SOAPFault: (soap:Server) No matches returned for SessionID
+      logger.warn(fault.inspect)
+    end
     @auth = nil
-    @session_id = nil
     @search = nil
+    @session_id = nil
   end
+
+  private
+
+    def logger
+      @logger ||= NotificationManager.wos_logger
+    end
 
 end

--- a/spec/fixtures/wos_client/wos_session_close_fault_response.xml
+++ b/spec/fixtures/wos_client/wos_session_close_fault_response.xml
@@ -1,0 +1,11 @@
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <soap:Fault>
+      <faultcode>soap:Server</faultcode>
+      <faultstring>No matches returned for SessionID</faultstring>
+      <detail>
+        <ns2:SessionException xmlns:ns2="http://auth.cxf.wokmws.thomsonreuters.com"/>
+      </detail>
+    </soap:Fault>
+  </soap:Body>
+</soap:Envelope>

--- a/spec/lib/notification_manager_spec.rb
+++ b/spec/lib/notification_manager_spec.rb
@@ -66,4 +66,19 @@ describe NotificationManager do
       described_class.error(exception, message, ScienceWireClient.new)
     end
   end
+  context '.wos_logger' do
+    let(:wos_client) { WosClient.new(Settings.WOS.AUTH_CODE) }
+
+    before do
+      described_class.class_variable_set(:@@wos_logger, nil)
+    end
+    it 'creates a single logger' do
+      expect(Logger).to receive(:new).with(Settings.WOS.LOG).once
+      described_class.error(exception, message, wos_client)
+    end
+    it 'logs errors' do
+      expect(null_logger).to receive(:error).exactly(3)
+      described_class.error(exception, message, wos_client)
+    end
+  end
 end


### PR DESCRIPTION
While testing something is a stale console session, I ran into a rejected request because the SID had expired, so when I tried to reset it I couldn’t because the WosClient wasn’t handling the SOAP fault.  This PR will fix that.

This handles SOAP faults in the WosClient#session_close to ensure that it resets the session_id and other client objects.  It doesn't matter whether the session_close is successful or not, really, the session will expire after 4 hours of inactivity anyway.

- Adds exception handling for SOAP fault when closing a session that is not found
- Adds `NotificationManager.wos_logger`
  - configuration added to `Settings.WOS.LOG`
  - used in `WosClient#logger` private method
