### PR TITLE
HarvestBroker also has methods that should be private

### DIFF
--- a/lib/science_wire/harvest_broker.rb
+++ b/lib/science_wire/harvest_broker.rb
@@ -23,35 +23,6 @@ module ScienceWire
     end
 
     ##
-    # The traditional Author only harvest approach
-    # @return [Array<Integer>]
-    def ids_for_author
-      name = author_name(author)
-      institution = sciencewire_harvester.default_institution
-      if seed_list.size < 50
-        sciencewire_harvester.increment_authors_with_limited_seed_data_count
-        author_attributes = AuthorAttributes.new(name, '', [], institution)
-        ids_from_dumb_query(author_attributes)
-      else
-        author_attributes = AuthorAttributes.new(name, author.email, seed_list, institution)
-        ids_from_smart_query(author_attributes)
-      end
-    end
-
-    ##
-    # Generates alternate name ids using the "dumb" query
-    # @return [Array<Integer>]
-    def ids_for_alternate_names
-      if alternate_name_query
-        author.alternative_identities.select { |author_identity| required_data_for_alt_names_search(author_identity) }.map do |author_identity|
-          ids_from_dumb_query(author_identity.to_author_attributes).flatten
-        end.flatten.uniq
-      else
-        []
-      end
-    end
-
-    ##
     # @param [AuthorAttributes] author_attributes
     # @return [Array<Integer>]
     def ids_from_dumb_query(author_attributes)
@@ -67,17 +38,6 @@ module ScienceWire
 
     private
 
-      ##
-      # Accessors for custom Author information. Eventually could migrate to
-      # AuthorAttributes as the client changes underneath.
-      def seed_list
-        @seed_list ||= author.approved_sciencewire_ids
-      end
-
-      def author_pub_swids
-        @author_pub_swids ||= author.publications.where.not(sciencewire_id: nil).pluck(:sciencewire_id).uniq
-      end
-
       def author_name(person)
         ScienceWire::AuthorName.new(
           person.last_name,
@@ -86,17 +46,48 @@ module ScienceWire
         )
       end
 
-      def required_data_for_alt_names_search(author_identity)
-        #don't search unless first name, last name, and institution are provided
-        #and when the institution is NOT "all", blank, null, or *
-        return true if author_identity.first_name.present? && author_identity.last_name.present? && inst_valid_for_alt_names_search(author_identity.institution)
-        false
+      def author_pub_swids
+        @author_pub_swids ||= author.publications.where.not(sciencewire_id: nil).pluck(:sciencewire_id).uniq
       end
 
-      def inst_valid_for_alt_names_search(inst)
-        #don't search when institution is "all", blank, null, or *
-        return true if inst.present? && inst != 'all' && inst != '*'
-        false
+      # Generates alternate name ids using the "dumb" query
+      # @return [Array<Integer>]
+      def ids_for_alternate_names
+        return [] unless alternate_name_query
+        author.alternative_identities.select { |author_identity| required_data_for_alt_names_search?(author_identity) }.map do |author_identity|
+          ids_from_dumb_query(author_identity.to_author_attributes).flatten
+        end.flatten.uniq
+      end
+
+      # The traditional Author only harvest approach
+      # @return [Array<Integer>]
+      def ids_for_author
+        name = author_name(author)
+        institution = sciencewire_harvester.default_institution
+        if seed_list.size < 50
+          sciencewire_harvester.increment_authors_with_limited_seed_data_count
+          author_attributes = AuthorAttributes.new(name, '', [], institution)
+          ids_from_dumb_query(author_attributes)
+        else
+          author_attributes = AuthorAttributes.new(name, author.email, seed_list, institution)
+          ids_from_smart_query(author_attributes)
+        end
+      end
+
+      # Institution is valid if not "all", blank, null, or *
+      def inst_valid_for_alt_names_search?(inst)
+        inst.present? && inst != 'all' && inst != '*'
+      end
+
+      # Don't search unless first name, last name, and (valid) institution are provided
+      def required_data_for_alt_names_search?(author_identity)
+        author_identity.first_name.present? && author_identity.last_name.present? && inst_valid_for_alt_names_search?(author_identity.institution)
+      end
+
+      # Accessors for custom Author information. Eventually could migrate to
+      # AuthorAttributes as the client changes underneath.
+      def seed_list
+        @seed_list ||= author.approved_sciencewire_ids
       end
   end
 end

--- a/spec/lib/science_wire/harvest_broker_spec.rb
+++ b/spec/lib/science_wire/harvest_broker_spec.rb
@@ -1,4 +1,3 @@
-
 describe ScienceWire::HarvestBroker do
   let(:author) { create(:author) }
   let(:author_name) do
@@ -64,7 +63,7 @@ describe ScienceWire::HarvestBroker do
       it 'calls the dumb query' do
         expect(harvester).to receive(:increment_authors_with_limited_seed_data_count)
         expect(subject).to receive(:ids_from_dumb_query).and_return([1])
-        expect(subject.ids_for_author).to eq [1]
+        expect(subject.send(:ids_for_author)).to eq [1]
       end
     end
     context 'with seed_list > 50' do
@@ -73,14 +72,10 @@ describe ScienceWire::HarvestBroker do
         author_attributes = ScienceWire::AuthorAttributes.new(
           author_name, author.email, seed_list, default_institution
         )
-        expect(ScienceWire::AuthorAttributes).to receive(:new)
-          .and_return(author_attributes)
-        expect(subject).to receive(:seed_list).twice
-          .and_return(seed_list)
-        expect(subject).to receive(:ids_from_smart_query)
-          .with(author_attributes)
-          .and_return([1])
-        expect(subject.ids_for_author).to eq [1]
+        expect(ScienceWire::AuthorAttributes).to receive(:new).and_return(author_attributes)
+        expect(subject).to receive(:seed_list).twice.and_return(seed_list)
+        expect(subject).to receive(:ids_from_smart_query).with(author_attributes).and_return([1])
+        expect(subject.send(:ids_for_author)).to eq [1]
       end
     end
   end
@@ -88,8 +83,7 @@ describe ScienceWire::HarvestBroker do
     context 'when "alternate_name_query" is disabled' do
       subject { described_class.new(alt_author, harvester, alternate_name_query: false) }
       it 'returns an array' do
-        expect(subject.ids_for_alternate_names).to be_an Array
-        expect(subject.ids_for_alternate_names).to be_empty
+        expect(subject.send(:ids_for_alternate_names)).to eq []
       end
     end
     context 'when "alternate_name_query" is enabled' do
@@ -97,21 +91,21 @@ describe ScienceWire::HarvestBroker do
       it 'returns an array of unique alternate name query ids' do
         expect(subject).to receive(:ids_from_dumb_query).exactly(3).times
           .and_return([1, 2], [2, 3], [3, 4])
-        expect(subject.ids_for_alternate_names).to eq [1, 2, 3, 4]
+        expect(subject.send(:ids_for_alternate_names)).to eq [1, 2, 3, 4]
       end
     end
     context 'when "alternate_name_query" is enabled and varying institution (blank, all, *)' do
       subject { described_class.new(alt_author_varying_institution, harvester, alternate_name_query: true) }
       it 'returns an empty array' do
         expect(subject).not_to receive(:ids_from_dumb_query)
-        expect(subject.ids_for_alternate_names).to eq []
+        expect(subject.send(:ids_for_alternate_names)).to eq []
       end
     end
     context 'when "alternate_name_query" is enabled and name pieces blank' do
       subject { described_class.new(alt_author_missing_name_pieces, harvester, alternate_name_query: true) }
       it 'returns an empty array' do
         expect(subject).not_to receive(:ids_from_dumb_query)
-        expect(subject.ids_for_alternate_names).to eq []
+        expect(subject.send(:ids_for_alternate_names)).to eq []
       end
     end
   end


### PR DESCRIPTION
Same principles as before.  Move internal methods to private and sort by alphanumeric order.

I also collapsed one test case that tested if the return value was an Array and Empty separately, to just test `.eq []` in one go.  No need to execute twice.