### PR TITLE
WosRecords - select records by database prefix

### DIFF
--- a/lib/wos_records.rb
+++ b/lib/wos_records.rb
@@ -27,6 +27,13 @@ class WosRecords
     @doc = Nokogiri::XML(@records) { |config| config.strict.noblanks }
   end
 
+  # Select records by the database prefix in the UID
+  # @param database [String] the UID database prefix (defaults to 'WOS')
+  # @return [Nokogiri::XML::NodeSet]
+  def by_database(database = 'WOS')
+    rec_nodes.select { |rec| record_uid(rec).start_with? database }
+  end
+
   # Iterate over the REC nodes
   # @yield rec [Nokogiri::XML::Element]
   def each

--- a/lib/wos_records.rb
+++ b/lib/wos_records.rb
@@ -27,11 +27,19 @@ class WosRecords
     @doc = Nokogiri::XML(@records) { |config| config.strict.noblanks }
   end
 
-  # Select records by the database prefix in the UID
-  # @param database [String] the UID database prefix (defaults to 'WOS')
-  # @return [Nokogiri::XML::NodeSet]
-  def by_database(database = 'WOS')
-    rec_nodes.select { |rec| record_uid(rec).start_with? database }
+  # Group records by the database prefix in the UID
+  #  - where a database prefix is missing, groups records into 'MISSING_DB'
+  # @return [Hash<String => WosRecords>]
+  def by_database
+    db_recs = rec_nodes.group_by do |rec|
+      uid_split = record_uid(rec).split(':')
+      uid_split.length > 1 ? uid_split[0] : 'MISSING_DB'
+    end
+    db_recs.each_key do |db|
+      rec_doc = Nokogiri::XML("<records>#{db_recs[db].map(&:to_xml).join}</records>")
+      db_recs[db] = WosRecords.new(records: rec_doc.to_xml)
+    end
+    db_recs
   end
 
   # Iterate over the REC nodes

--- a/spec/lib/wos_records_spec.rb
+++ b/spec/lib/wos_records_spec.rb
@@ -187,6 +187,31 @@ describe WosRecords do
     end
   end
 
+  describe '#records_by_database' do
+    let(:records_by_db) do
+      <<-XML_DBS
+        <records>
+          <REC><UID>WOS:123</UID></REC>
+          <REC><UID>MEDLINE:456</UID></REC>
+        </records>
+      XML_DBS
+    end
+    let(:db_records) { described_class.new(records: records_by_db) }
+    let(:nodes_wos) { db_records.by_database }
+    let(:nodes_medline) { db_records.by_database('MEDLINE') }
+    let(:nodes_missing) { db_records.by_database('MISSING-DB') }
+
+    it 'extracts WOS records' do
+      expect(nodes_wos.count).to eq 1
+    end
+    it 'extracts MEDLINE records' do
+      expect(nodes_medline.count).to eq 1
+    end
+    it 'returns an empty node set when no database records exist' do
+      expect(nodes_missing).to be_empty
+    end
+  end
+
   # ---
   # XML specs
 

--- a/spec/lib/wos_records_spec.rb
+++ b/spec/lib/wos_records_spec.rb
@@ -191,24 +191,39 @@ describe WosRecords do
     let(:records_by_db) do
       <<-XML_DBS
         <records>
+          <REC><UID>WOS:012</UID></REC>
           <REC><UID>WOS:123</UID></REC>
-          <REC><UID>MEDLINE:456</UID></REC>
+          <REC><UID>MEDLINE:234</UID></REC>
+          <REC><UID>MEDLINE:345</UID></REC>
+          <!-- no db identifier -->
+          <REC><UID>456</UID></REC>
+          <REC><UID>567</UID></REC>
         </records>
       XML_DBS
     end
     let(:db_records) { described_class.new(records: records_by_db) }
-    let(:nodes_wos) { db_records.by_database }
-    let(:nodes_medline) { db_records.by_database('MEDLINE') }
-    let(:nodes_missing) { db_records.by_database('MISSING-DB') }
+    let(:nodes_wos) { db_records.by_database['WOS'] }
+    let(:nodes_medline) { db_records.by_database['MEDLINE'] }
+    let(:nodes_missing_db) { db_records.by_database['MISSING_DB'] }
+    let(:nodes_none) { db_records.by_database['BIO-XX'] }
 
+    it 'returns a Hash<String => WosRecords>' do
+      by_db = db_records.by_database
+      expect(by_db).to be_an Hash
+      expect(by_db.keys.first).to be_an String
+      expect(by_db['WOS']).to be_an described_class
+    end
     it 'extracts WOS records' do
-      expect(nodes_wos.count).to eq 1
+      expect(nodes_wos.count).to eq 2
     end
     it 'extracts MEDLINE records' do
-      expect(nodes_medline.count).to eq 1
+      expect(nodes_medline.count).to eq 2
     end
-    it 'returns an empty node set when no database records exist' do
-      expect(nodes_missing).to be_empty
+    it 'returns MISSING_DB for records without a database prefix in the UID' do
+      expect(nodes_missing_db.count).to eq 2
+    end
+    it 'returns nil when no matching database exists' do
+      expect(nodes_none).to be_nil
     end
   end
 


### PR DESCRIPTION
WIP related to #264 

```ruby
wos_client = WosClient.new(Settings.WOS.AUTH_CODE, :info);
wos_queries = WosQueries.new(wos_client);
records = wos_queries.search_by_name('Altman, Russ');
records.count
#=> 464
records.by_database['WOS'].count
#=> 411
> records.by_database['MEDLINE'].count
#=> 53
# it seems this record set only contains WOS & MEDLINE, 53 should be correct
```