### PR TITLE
remove scheduling of external services check

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -15,8 +15,3 @@ end
 every 1.day, at: stagger(4), roles: [:harvester] do
   rake 'cap:poll[1]'
 end
-
-# call a rake task that hits the OK computer external checks, triggering honeybadger notifications if there is an error
-every 30.minutes, roles: [:external_monitor] do
-  rake "sul:check_external_services[\"https://#{`hostname`.chomp!}\"]"
-end


### PR DESCRIPTION
We don't need this rake task to run on an automated schedule anymore since nagios is configured to do these checks and email the appropriate person.  Leaving the underlying rake task in for now in case it is useful in the future.