### PR TITLE
Links AMR client and associated request template

### DIFF
--- a/app/views/pages/clarivate_links.xml.erb
+++ b/app/views/pages/clarivate_links.xml.erb
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<request xmlns="http://www.isinet.com/xrpc41" src="app.id=API Demo">
+  <fn name="LinksAMR.retrieve">
+    <list>
+      <map>
+        <val name="username"><%= client.username %></val>
+        <val name="password"><%= client.password %></val>
+      </map>
+      <map>
+        <list name="WOS">
+          <% return_fields.each do |val| %>
+            <val><%= val %></val>
+          <% end %>
+        </list>
+      </map>
+      <map>
+        <% cites.first(50).each do |id| %>
+          <map name="cite_<%= id %>">
+            <val name="ut"><%= id %></val>
+          </map>
+        <% end %>
+      </map>
+    </list>
+  </fn>
+</request>

--- a/lib/clarivate/links_client.rb
+++ b/lib/clarivate/links_client.rb
@@ -1,0 +1,69 @@
+module Clarivate
+  # Links AMR (Article Match Retrieval) Service
+  # @see http://ipscience-help.thomsonreuters.com/LAMRService/WebServicesOverviewGroup/overview.html Service documentation
+  class LinksClient
+    attr_reader :username, :password, :host
+
+    # @param [String] username
+    # @param [String] password
+    # @param [String] host
+    def initialize(username: nil, password: nil, host: 'https://ws.isiknowledge.com')
+      @host = host
+      @username = username
+      @password = password
+      (@username, @password) = Base64.decode64(Settings.WOS.AUTH_CODE).split(':', 2) unless username
+    end
+
+    # limited to 50 ids
+    # @param [Array<String>] ids
+    # @return [Hash<String => Hash>]
+    def links(ids)
+      raise ArgumentError, "1-50 ids required" unless ids.present? && ids.count <= 50
+      response = connection.send(:post) do |req|
+        req.path = '/cps/xrpc'
+        req.body = request_body(ids.uniq)
+      end
+      ng = Nokogiri::XML(response.body) { |config| config.strict.noblanks }.remove_namespaces!
+      pairs = ng.xpath('response/fn/map/map').map do |node|
+        [node.attr('name').split('_').last, vals_to_hash(node.children.xpath('val'))]
+      end
+      pairs.to_h
+    end
+
+    private
+
+      # @return [Faraday::Connection]
+      def connection
+        @connection ||= Faraday.new(url: host) do |faraday|
+          faraday.use Faraday::Response::RaiseError
+          faraday.adapter :httpclient
+        end
+      end
+
+      # @return [ActionView::Base] used to render as though in an rails controller
+      def renderer
+        @renderer ||= ActionView::Base.new(ActionController::Base.view_paths, {})
+      end
+
+      # @return [String]
+      def request_body(ids)
+        renderer.render(
+          file: 'pages/clarivate_links.xml',
+          layout: false,
+          locals: {
+            client: self,
+            return_fields: %w(ut doi pmid),
+            cites: ids
+          }
+        )
+      end
+
+      # @param [Nokogiri::XML::Nodeset] vals
+      # @return [Hash<Symbol => String>] namespace to value
+      # Nodeset for [<val name="ut">UT value</val>, <val name="doi">DOI</val>]
+      # becomes { ut: 'UT value', doi: 'DOI'}
+      def vals_to_hash(vals)
+        vals.map { |val| [val.attr("name").downcase.to_sym, val.text.strip] }.to_h
+      end
+  end
+end

--- a/lib/clarivate/links_client.rb
+++ b/lib/clarivate/links_client.rb
@@ -19,13 +19,13 @@ module Clarivate
     # @return [Hash<String => Hash>]
     def links(ids)
       raise ArgumentError, "1-50 ids required" unless ids.present? && ids.count <= 50
-      response = connection.send(:post) do |req|
+      response = connection.post do |req|
         req.path = '/cps/xrpc'
         req.body = request_body(ids.uniq)
       end
       ng = Nokogiri::XML(response.body) { |config| config.strict.noblanks }.remove_namespaces!
       pairs = ng.xpath('response/fn/map/map').map do |node|
-        [node.attr('name').split('_').last, vals_to_hash(node.children.xpath('val'))]
+        [node.attr('name').split('_', 2).last, vals_to_hash(node.children.xpath('val'))]
       end
       pairs.to_h
     end

--- a/spec/fixtures/clarivate/links_response.xml
+++ b/spec/fixtures/clarivate/links_response.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<response src="app.id=API Demo">
+<fn name="LinksAMR.retrieve" rc="OK">
+  <map>
+    <map name="cite_000346594100007">
+      <map name="WOS">
+        <val name="ut">000346594100007</val>
+        <val name="doi">10.1002/2013GB004790</val>
+      </map>
+    </map>
+    <map name="cite_000081515000015">
+      <map name="WOS">
+        <val name="pmid">10435530</val>
+        <val name="ut">000081515000015</val>
+        <val name="doi">10.1118/1.598623</val>
+      </map>
+    </map>
+  </map>
+</fn>
+</response>

--- a/spec/lib/clarivate/links_client_spec.rb
+++ b/spec/lib/clarivate/links_client_spec.rb
@@ -1,0 +1,45 @@
+describe Clarivate::LinksClient do
+  before do
+    allow(Settings.WOS).to receive(:AUTH_CODE).and_return("YXR6OmZvb2Jhcg==\n") # atz:foobar
+  end
+  subject { described_class.new }
+
+  describe '#initialize' do
+    context 'with no params' do
+      it 'has defaults, including auth from Settings' do
+        expect(subject.host).to eq 'https://ws.isiknowledge.com'
+        expect(subject.username).to eq 'atz'
+        expect(subject.password).to eq 'foobar'
+      end
+    end
+    context 'with params' do
+      subject { described_class.new(username: 'leland', password: 'sunflower', host: 'http://proxy.us') }
+      it 'accepts overrides' do
+        expect(subject.host).to eq 'http://proxy.us'
+        expect(subject.username).to eq 'leland'
+        expect(subject.password).to eq 'sunflower'
+      end
+    end
+  end
+
+  describe '#links' do
+    it 'requires param' do
+      expect { subject.links }.to raise_error ArgumentError
+    end
+
+    context 'with param' do
+      let(:response_xml) { File.read('spec/fixtures/clarivate/links_response.xml') }
+      let(:wos_ids) { %w(000081515000015 000346594100007) }
+      let(:links) { subject.links(wos_ids) }
+      before do
+        allow(subject.send(:connection)).to receive(:post).with(any_args).and_return(double(body: response_xml))
+      end
+
+      it 'returns matching identifiers' do
+        expect(links).to match a_hash_including(*wos_ids)
+        expect(links[wos_ids[0]]).to match a_hash_including(pmid: '10435530', ut: '000081515000015', doi: '10.1118/1.598623')
+        expect(links[wos_ids[1]]).to match a_hash_including(ut: '000346594100007', doi: '10.1002/2013GB004790')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Example usage:
```ruby
client = Clarivate::LinksClient.new
=> #<Clarivate::LinksClient:0x007fdc8c54e640 @host="https://ws.isiknowledge.com", @password="xxxxx", @username="StanfordU_SW">
resp = client.links(['000346594100007', '000081515000015'])
  Rendered pages/clarivate_links.xml.erb (0.1ms)
=> {
"000081515000015"=>{:pmid=>"10435530", :ut=>"000081515000015", :doi=>"10.1118/1.598623"}, 
"000346594100007"=>{:ut=>"000346594100007", :doi=>"10.1002/2013GB004790"}
}
```
TODO: 
- tests
- uncap limit of incoming ids, batch 50 per request

Fixes #193 
Fixes #252 
Fixes #247 