### PR TITLE
WosQueries - refactor to provide institutions parameter

### DIFF
--- a/lib/tasks/sw.rake
+++ b/lib/tasks/sw.rake
@@ -62,13 +62,16 @@ namespace :sw do
   task :wos_publications_for_name, [:last, :first, :middle] => :environment do |_t, args|
     fail "last name argument is required" unless args[:last].present?
     fail "first name argument is required" unless args[:first].present?
+    sciencewire_harvester = ScienceWireHarvester.new
+    institution = sciencewire_harvester.default_institution
     author_name = ScienceWire::AuthorName.new(args[:last], args[:first], args[:middle])
-    attribs = ScienceWire::AuthorAttributes.new(author_name, '', [], ScienceWireHarvester.new.default_institution)
+    attribs = ScienceWire::AuthorAttributes.new(author_name, '', [], institution)
     puts "Querying ScienceWire for #{author_name.inspect}"
-    ids = ScienceWire::HarvestBroker.new(nil, ScienceWireHarvester.new).ids_from_dumb_query(attribs)
+    ids = ScienceWire::HarvestBroker.new(nil, sciencewire_harvester).ids_from_dumb_query(attribs)
     puts "\n" << ids.sort.join("\n") if ids.count > 0
     puts "\nQuerying WebOfScience for #{author_name.full_name}"
-    records = WosQueries.new(WosClient.new(Settings.WOS.AUTH_CODE)).search_by_name(author_name.full_name)
+    wos_queries = WosQueries.new(WosClient.new(Settings.WOS.AUTH_CODE))
+    records = wos_queries.search_by_name(author_name.full_name, [institution])
     uids = records.uids.sort
     puts uids.join("\n")
     puts "\n#{ids.count} ScienceWire IDs"

--- a/lib/wos_queries.rb
+++ b/lib/wos_queries.rb
@@ -70,9 +70,10 @@ class WosQueries
   end
 
   # @param name [String] a CSV name pattern: {last name}, {first_name} [{middle_name} | {middle initial}]
+  # @param institutions [Array<String>] a set of institutions the author belongs to
   # @return [WosRecords]
-  def search_by_name(name)
-    message = search_by_name_params(name)
+  def search_by_name(name, institutions = [])
+    message = search_by_name_params(name, institutions)
     retrieve_records(:search, message)
   end
 
@@ -158,12 +159,6 @@ class WosQueries
       name_query = "#{last_name} #{first_name} OR #{last_name} #{first_name[0]}"
       name_query += " OR #{last_name} #{first_name[0]}#{middle_name[0]} OR #{last_name} #{first_name} #{middle_name[0]}" unless middle_name.blank?
       name_query
-    end
-
-    # Search authors from these institutions
-    # @return [Array<String>] institution names
-    def institutions
-      ['Stanford University']
     end
 
     ###################################################################
@@ -263,9 +258,11 @@ class WosQueries
     end
 
     # @param name [String] a CSV name pattern: {last name}, {first_name} [{middle_name} | {middle initial}]
+    # @param institutions [Array<String>] a set of institutions the author belongs to
     # @return [Hash] search query parameters
-    def search_by_name_params(name)
-      user_query = "AU=(#{name_query(name)}) AND AD=(#{institutions.join(' OR ')})"
+    def search_by_name_params(name, institutions)
+      user_query = "AU=(#{name_query(name)})"
+      user_query += " AND AD=(#{institutions.join(' OR ')})" unless institutions.empty?
       search_params(user_query)
     end
 

--- a/spec/lib/wos_queries_spec.rb
+++ b/spec/lib/wos_queries_spec.rb
@@ -24,7 +24,7 @@ describe WosQueries do
   let(:name) { "#{ln}, #{fn}" }
   let(:ln) { 'Lastname' }
   let(:fn) { 'Firstname' }
-  let(:institutions) { wos_queries.send(:institutions) }
+  let(:institutions) { ['Stanford University'] }
 
   describe '#new' do
     it 'works' do
@@ -127,15 +127,8 @@ describe WosQueries do
     end
   end
 
-  describe '#institutions' do
-    it 'works' do
-      expect(institutions).to be_an Array
-      expect(institutions.first).to be_an String
-    end
-  end
-
   describe '#search_by_name_params' do
-    let(:search_by_name_params) { wos_queries.send(:search_by_name_params, name) }
+    let(:search_by_name_params) { wos_queries.send(:search_by_name_params, name, institutions) }
     let(:query_params) { search_by_name_params[:queryParameters] }
     let(:user_query) { query_params[:userQuery] }
 


### PR DESCRIPTION
Fix #271 
- this allows the consumer of the WosQueries object to provide any array of institutions
- the responsibility for setting the correct institutions lies with the consumer (Harvester, rake task etc.)
- this allows an author query without any institutions (previously impossible)
