### PR TITLE
Agent module

### DIFF
--- a/app/models/author_identity.rb
+++ b/app/models/author_identity.rb
@@ -11,13 +11,13 @@ class AuthorIdentity < ActiveRecord::Base
   # Converts an AuthorIdentity object to an AuthorAttributes object for use by other classes
   def to_author_attributes
     ScienceWire::AuthorAttributes.new(
-      ScienceWire::AuthorName.new(last_name, first_name, middle_name),
+      Agent::AuthorName.new(last_name, first_name, middle_name),
       email,
       # there is no seed list for AuthorIdentity because it is not needed for dumb search
       # but there is a seed list that can come from Author#approved_sciencewire_ids
       # if needed in the future
       [],
-      ScienceWire::AuthorInstitution.new(institution),
+      Agent::AuthorInstitution.new(institution),
       start_date,
       end_date
     )

--- a/lib/agent/author_address.rb
+++ b/lib/agent/author_address.rb
@@ -1,4 +1,4 @@
-module ScienceWire
+module Agent
   ##
   # Author/Institution address details used for creating search queries
   class AuthorAddress

--- a/lib/agent/author_institution.rb
+++ b/lib/agent/author_institution.rb
@@ -1,4 +1,4 @@
-module ScienceWire
+module Agent
   ##
   # Attributes used for creating author search queries
   class AuthorInstitution
@@ -36,9 +36,9 @@ module ScienceWire
     private
 
       def init_address(address)
-        return address if address.is_a?(AuthorAddress)
+        return address if address.is_a?(Agent::AuthorAddress)
         # set the address line 1, or an empty (default)
-        AuthorAddress.new(address.is_a?(String) ? { line1: address } : {})
+        Agent::AuthorAddress.new(address.is_a?(String) ? { line1: address } : {})
       end
   end
 end

--- a/lib/agent/author_name.rb
+++ b/lib/agent/author_name.rb
@@ -1,4 +1,4 @@
-module ScienceWire
+module Agent
   ##
   # Attributes used for creating author search queries
   class AuthorName

--- a/lib/science_wire/author_attributes.rb
+++ b/lib/science_wire/author_attributes.rb
@@ -4,10 +4,10 @@ module ScienceWire
   class AuthorAttributes
     attr_reader :name, :email, :institution, :seed_list, :start_date, :end_date
 
-    # @param name [AuthorName]
+    # @param name [Agent::AuthorName]
     # @param email [String, #to_s]
     # @param seed_list [Array<Integer>]
-    # @param institution [String, AuthorInstitution]
+    # @param institution [String, Agent::AuthorInstitution]
     # @param start_date [Date]
     # @param end_date [Date]
     def initialize(name, email, seed_list = [], institution = nil, start_date = nil, end_date = nil)
@@ -22,13 +22,13 @@ module ScienceWire
     private
 
       def init_name(name)
-        name.is_a?(AuthorName) ? name : AuthorName.new
+        name.is_a?(Agent::AuthorName) ? name : Agent::AuthorName.new
       end
 
       def init_institution(institution)
-        return institution if institution.is_a?(AuthorInstitution)
+        return institution if institution.is_a?(Agent::AuthorInstitution)
         # else set institution name, or nil (default)
-        AuthorInstitution.new(institution.is_a?(String) ? institution : nil)
+        Agent::AuthorInstitution.new(institution.is_a?(String) ? institution : nil)
       end
   end
 end

--- a/lib/science_wire/harvest_broker.rb
+++ b/lib/science_wire/harvest_broker.rb
@@ -39,7 +39,7 @@ module ScienceWire
     private
 
       def author_name(person)
-        ScienceWire::AuthorName.new(
+        Agent::AuthorName.new(
           person.last_name,
           person.first_name,
           use_middle_name ? person.middle_name : ''

--- a/lib/science_wire_harvester.rb
+++ b/lib/science_wire_harvester.rb
@@ -326,9 +326,9 @@ class ScienceWireHarvester
       @records_queued_for_pubmed_retrieval = {}
       @use_middle_name = Settings.HARVESTER.USE_MIDDLE_NAME
       @use_author_identities = Settings.HARVESTER.USE_AUTHOR_IDENTITIES
-      @default_institution = ScienceWire::AuthorInstitution.new(
+      @default_institution = Agent::AuthorInstitution.new(
         Settings.HARVESTER.INSTITUTION.name,
-        ScienceWire::AuthorAddress.new(Settings.HARVESTER.INSTITUTION.address.to_hash)
+        Agent::AuthorAddress.new(Settings.HARVESTER.INSTITUTION.address.to_hash)
       )
       @logger = nil # explicitly set to nill to enable lazy eval of `logger` method
     end

--- a/lib/tasks/sw.rake
+++ b/lib/tasks/sw.rake
@@ -62,7 +62,7 @@ namespace :sw do
   task :wos_publications_for_name, [:last, :first, :middle] => :environment do |_t, args|
     fail "last name argument is required" unless args[:last].present?
     fail "first name argument is required" unless args[:first].present?
-    author_name = ScienceWire::AuthorName.new(args[:last], args[:first], args[:middle])
+    author_name = Agent::AuthorName.new(args[:last], args[:first], args[:middle])
     attribs = ScienceWire::AuthorAttributes.new(author_name, '', [], ScienceWireHarvester.new.default_institution)
     puts "Querying ScienceWire for #{author_name.inspect}"
     ids = ScienceWire::HarvestBroker.new(nil, ScienceWireHarvester.new).ids_from_dumb_query(attribs)

--- a/spec/integration/smart_query_spec.rb
+++ b/spec/integration/smart_query_spec.rb
@@ -44,7 +44,7 @@ describe 'Smart query', 'data-integration': true do
       expect do
         client.id_suggestions(
           ScienceWire::AuthorAttributes.new(
-            ScienceWire::AuthorName.new(ln, fn, mn), '', seeds
+            Agent::AuthorName.new(ln, fn, mn), '', seeds
           )
         )
       end.to raise_error(Faraday::ClientError)
@@ -52,7 +52,7 @@ describe 'Smart query', 'data-integration': true do
     it '(name with email)' do
       suggestions = client.id_suggestions(
         ScienceWire::AuthorAttributes.new(
-          ScienceWire::AuthorName.new(ln, fn, mn), email, seeds
+          Agent::AuthorName.new(ln, fn, mn), email, seeds
         )
       )
       check_suggestions(suggestions)
@@ -116,7 +116,7 @@ describe 'Smart query', 'data-integration': true do
         known_confirmed_publications = [ 64_367_696 ]
         suggestions = client.id_suggestions(
           ScienceWire::AuthorAttributes.new(
-            ScienceWire::AuthorName.new(
+            Agent::AuthorName.new(
               'Hardy', 'Darren', ''
             ), 'darren.hardy@stanford.edu', ''
           )
@@ -128,7 +128,7 @@ describe 'Smart query', 'data-integration': true do
         known_confirmed_publications = [ 64_367_696 ]
         suggestions = client.id_suggestions(
           ScienceWire::AuthorAttributes.new(
-            ScienceWire::AuthorName.new(
+            Agent::AuthorName.new(
               'Hardy', 'Darren', ''
             ), 'drh@stanford.edu', ''
           )
@@ -140,7 +140,7 @@ describe 'Smart query', 'data-integration': true do
         known_confirmed_publications = [ 61_063_453, 64_367_696, 67_380_595 ]
         suggestions = client.id_suggestions(
           ScienceWire::AuthorAttributes.new(
-            ScienceWire::AuthorName.new(
+            Agent::AuthorName.new(
               'Hardy', 'Darren', ''
             ), 'dhardy@bren.ucsb.edu', ''
           )
@@ -154,7 +154,7 @@ describe 'Smart query', 'data-integration': true do
         known_confirmed_publications = [ 60_931_052 ]
         suggestions = client.id_suggestions(
           ScienceWire::AuthorAttributes.new(
-            ScienceWire::AuthorName.new(
+            Agent::AuthorName.new(
               'Reed', 'P', ''
             ), 'preed2@gsu.edu', ''
           )
@@ -166,7 +166,7 @@ describe 'Smart query', 'data-integration': true do
         known_confirmed_publications = [ 69_178_421 ]
         suggestions = client.id_suggestions(
           ScienceWire::AuthorAttributes.new(
-            ScienceWire::AuthorName.new(
+            Agent::AuthorName.new(
               'Reed', 'J', ''
             ), 'preed2@gsu.edu', ''
           )

--- a/spec/lib/agent/author_address_spec.rb
+++ b/spec/lib/agent/author_address_spec.rb
@@ -1,5 +1,5 @@
 
-describe ScienceWire::AuthorAddress do
+describe Agent::AuthorAddress do
   let(:line1) { 'Stanford University' }
   let(:line2) { '' }
   let(:city) { 'Stanford' }

--- a/spec/lib/agent/author_institution_spec.rb
+++ b/spec/lib/agent/author_institution_spec.rb
@@ -1,5 +1,5 @@
 
-describe ScienceWire::AuthorInstitution do
+describe Agent::AuthorInstitution do
   describe '#initialize' do
     subject { described_class.new(nil, nil) }
     it 'casts name to String' do
@@ -13,9 +13,9 @@ describe ScienceWire::AuthorInstitution do
     it 'address is optional' do
       expect { described_class.new('name') }.not_to raise_error
     end
-    it 'address defaults to an empty AuthorAddress' do
+    it 'address defaults to an empty Agent::AuthorAddress' do
       address = described_class.new('name').address
-      expect(address).to be_an ScienceWire::AuthorAddress
+      expect(address).to be_an Agent::AuthorAddress
       expect(address).to be_blank
       expect(address).to be_empty
     end

--- a/spec/lib/agent/author_name_spec.rb
+++ b/spec/lib/agent/author_name_spec.rb
@@ -1,5 +1,5 @@
 
-describe ScienceWire::AuthorName do
+describe Agent::AuthorName do
   let(:fn) { 'Amasa' }
   let(:mn) { 'Leland' }
   let(:ln) { 'Stanford' }

--- a/spec/lib/science_wire/author_attributes_spec.rb
+++ b/spec/lib/science_wire/author_attributes_spec.rb
@@ -3,14 +3,14 @@ describe ScienceWire::AuthorAttributes do
   describe '#initialize' do
     #initialize(name, email, seed_list = [], institution = nil, start_date = nil, end_date = nil)
     subject { described_class.new(nil, nil, [], 0, [], nil) }
-    it 'casts name to an AuthorName' do
-      expect(subject.name).to be_an ScienceWire::AuthorName
+    it 'casts name to an Agent::AuthorName' do
+      expect(subject.name).to be_an Agent::AuthorName
     end
     it 'casts email to a string' do
       expect(subject.email).to be_an String
     end
-    it 'casts institution to AuthorInstitution' do
-      expect(subject.institution).to be_an ScienceWire::AuthorInstitution
+    it 'casts institution to Agent::AuthorInstitution' do
+      expect(subject.institution).to be_an Agent::AuthorInstitution
     end
   end
 end

--- a/spec/lib/science_wire/harvest_broker_spec.rb
+++ b/spec/lib/science_wire/harvest_broker_spec.rb
@@ -1,13 +1,13 @@
 describe ScienceWire::HarvestBroker do
   let(:author) { create(:author) }
   let(:author_name) do
-    ScienceWire::AuthorName.new(
+    Agent::AuthorName.new(
       author.last_name,
       author.first_name,
       author.middle_name
     )
   end
-  let(:feynman_name) { ScienceWire::AuthorName.new('Feynman', 'Richard', 'P') }
+  let(:feynman_name) { Agent::AuthorName.new('Feynman', 'Richard', 'P') }
   let(:alt_author) { create(:author_with_alternate_identities, alt_count: 3) }
   let(:alt_author_varying_institution) do
     auth = alt_author
@@ -150,9 +150,9 @@ describe ScienceWire::HarvestBroker do
   end
 
   describe 'author_name' do
-    it 'returns a ScienceWire::AuthorName' do
+    it 'returns a Agent::AuthorName' do
       name = subject.send(:author_name, author)
-      expect(name).to be_an ScienceWire::AuthorName
+      expect(name).to be_an Agent::AuthorName
     end
   end
 end

--- a/spec/lib/science_wire/query/conference_proceeding_document_suggestion_spec.rb
+++ b/spec/lib/science_wire/query/conference_proceeding_document_suggestion_spec.rb
@@ -2,7 +2,7 @@
 describe ScienceWire::Query::ConferenceProceedingDocumentSuggestion do
   include SuggestionQueries
   subject { described_class.new(author_attributes) }
-  let(:author_name) { ScienceWire::AuthorName.new('Brown', 'Charlie', '') }
+  let(:author_name) { Agent::AuthorName.new('Brown', 'Charlie', '') }
   let(:author_attributes) do
     ScienceWire::AuthorAttributes.new(author_name, '', '', default_institution)
   end

--- a/spec/lib/science_wire/query/journal_document_suggestion_spec.rb
+++ b/spec/lib/science_wire/query/journal_document_suggestion_spec.rb
@@ -2,7 +2,7 @@
 describe ScienceWire::Query::JournalDocumentSuggestion do
   include SuggestionQueries
   subject { described_class.new(author_attributes) }
-  let(:author_name) { ScienceWire::AuthorName.new('Doe', 'John', 'S') }
+  let(:author_name) { Agent::AuthorName.new('Doe', 'John', 'S') }
   let(:author_attributes) do
     ScienceWire::AuthorAttributes.new(
       author_name, 'johnsdoe@example.com', [532_237], default_institution

--- a/spec/lib/science_wire/query/publication_query_by_author_name_spec.rb
+++ b/spec/lib/science_wire/query/publication_query_by_author_name_spec.rb
@@ -5,7 +5,7 @@ describe ScienceWire::Query::PublicationQueryByAuthorName do
   include AuthorNameQueries
   include InstitutionEmailQueries
   include PublicationQueryXsd
-  let(:charlie_brown_name) { ScienceWire::AuthorName.new('brown', 'charlie', '') }
+  let(:charlie_brown_name) { Agent::AuthorName.new('brown', 'charlie', '') }
   let(:max_rows) { 200 }
   let(:seeds) { [1, 2, 3] }
   let(:institution) { 'Example University' }
@@ -24,7 +24,7 @@ describe ScienceWire::Query::PublicationQueryByAuthorName do
   describe '#generate' do
     subject { described_class.new(author_attributes, max_rows) }
     context 'common first and last name' do
-      let(:author_name) { ScienceWire::AuthorName.new('smith', 'james', '') }
+      let(:author_name) { Agent::AuthorName.new('smith', 'james', '') }
       let(:author_attributes) { ScienceWire::AuthorAttributes.new(author_name, '', '', institution) }
       it 'generates a query' do
         expect(xml).to be_equivalent_to(without_cdata(common_first_last_name))
@@ -32,7 +32,7 @@ describe ScienceWire::Query::PublicationQueryByAuthorName do
       it_behaves_like 'XSD validates'
     end
     context 'middle name only' do
-      let(:author_name) { ScienceWire::AuthorName.new('', '', 'mary') }
+      let(:author_name) { Agent::AuthorName.new('', '', 'mary') }
       let(:author_attributes) { ScienceWire::AuthorAttributes.new(author_name, '', '', default_institution) }
       it 'generates a query' do
         expect(xml).to be_equivalent_to(without_cdata(middle_name_only))
@@ -40,7 +40,7 @@ describe ScienceWire::Query::PublicationQueryByAuthorName do
       it_behaves_like 'XSD validates'
     end
     context 'all attributes' do
-      let(:author_name) { ScienceWire::AuthorName.new('Smith', 'James', 'R') }
+      let(:author_name) { Agent::AuthorName.new('Smith', 'James', 'R') }
       let(:author_attributes) do
         ScienceWire::AuthorAttributes.new(author_name, 'james.smith@example.com', seeds, institution)
       end
@@ -77,7 +77,7 @@ describe ScienceWire::Query::PublicationQueryByAuthorName do
       it_behaves_like 'XSD validates'
     end
     context 'author with dates' do
-      let(:author_name) { ScienceWire::AuthorName.new('Bloggs', 'Fred', '') }
+      let(:author_name) { Agent::AuthorName.new('Bloggs', 'Fred', '') }
       let(:author_attributes) do
         # name, email, seed_list, institution, start_date, end_date
         ScienceWire::AuthorAttributes.new(

--- a/spec/lib/science_wire/query/suggestion_spec.rb
+++ b/spec/lib/science_wire/query/suggestion_spec.rb
@@ -19,7 +19,7 @@ describe ScienceWire::Query::Suggestion do
 
     context 'with default_institution' do
       context 'with email and seed' do
-        let(:author_name) { ScienceWire::AuthorName.new('Doe', 'John', 'S') }
+        let(:author_name) { Agent::AuthorName.new('Doe', 'John', 'S') }
         let(:author_attributes) do
           ScienceWire::AuthorAttributes.new(
             author_name, 'johnsdoe@example.com', [532_237], default_institution
@@ -33,7 +33,7 @@ describe ScienceWire::Query::Suggestion do
       end
 
       context 'with email and no seed' do
-        let(:author_name) { ScienceWire::AuthorName.new('Smith', 'Jane', '') }
+        let(:author_name) { Agent::AuthorName.new('Smith', 'Jane', '') }
         let(:author_attributes) do
           ScienceWire::AuthorAttributes.new(
             author_name, 'jane_smith@example.com', '', default_institution
@@ -47,7 +47,7 @@ describe ScienceWire::Query::Suggestion do
       end
 
       context 'with no email and no seed' do
-        let(:author_name) { ScienceWire::AuthorName.new('Brown', 'Charlie', '') }
+        let(:author_name) { Agent::AuthorName.new('Brown', 'Charlie', '') }
         let(:author_attributes) do
           ScienceWire::AuthorAttributes.new(
             author_name, '', '', default_institution

--- a/spec/lib/science_wire_client_spec.rb
+++ b/spec/lib/science_wire_client_spec.rb
@@ -4,7 +4,7 @@ describe ScienceWireClient, :vcr do
   describe '#query_sciencewire_by_author_name' do
     context 'with common last name, first name' do
       it 'returns a list of sciencewire ids' do
-        name = ScienceWire::AuthorName.new('smith', 'james', '')
+        name = Agent::AuthorName.new('smith', 'james', '')
         author_attributes = ScienceWire::AuthorAttributes.new(name, '', '', '', '')
         sw_ids = sw_client.query_sciencewire_by_author_name(author_attributes)
         expect(sw_ids).to be_an(Array)
@@ -17,7 +17,7 @@ describe ScienceWireClient, :vcr do
     end
     context 'with uncommon last name, first name, and max rows 4' do
       it 'returns an empty array' do
-        name = ScienceWire::AuthorName.new('ottawa', '', 'yukon')
+        name = Agent::AuthorName.new('ottawa', '', 'yukon')
         author_attributes = ScienceWire::AuthorAttributes.new(name, '', '', '', '')
         sw_ids = sw_client.query_sciencewire_by_author_name(author_attributes, 4)
         expect(sw_ids).to be_an(Array)
@@ -28,7 +28,7 @@ describe ScienceWireClient, :vcr do
 
   describe '#get_sciencewire_id_suggestions' do
     it 'returns suggestions for email address and name' do
-      name = ScienceWire::AuthorName.new('edler', 'alice', '')
+      name = Agent::AuthorName.new('edler', 'alice', '')
       seeds = [5_199_247, 7_877_232, 844_542, 1_178_390, 29_434_219, 30_072_480, 30_502_634, 46_558_063, 31_222_988]
       author_attributes = ScienceWire::AuthorAttributes.new(
         name, 'alice.edler@stanford.edu', seeds
@@ -41,7 +41,7 @@ describe ScienceWireClient, :vcr do
     end
 
     it 'gets suggestions from journals' do
-      name = ScienceWire::AuthorName.new('benson', 'sally', '')
+      name = Agent::AuthorName.new('benson', 'sally', '')
       seeds = [532_237, 29_681_830, 29_693_742, 30_153_017, 30_563_572, 30_711_058, 30_991_998, 31_488_302, 31_623_382, 32_897_909,
                33_038_883, 33_139_791, 33_878_760, 47_444_872, 53_640_378, 54_368_177, 59_612_803, 59_641_485, 60_094_854, 60_223_059, 60_478_790,
                62_816_475, 62_823_609, 62_903_742, 63_182_944, 62_767_480, 59_904_158, 37_634_308, 63_378_178, 63_775_722, 63_911_215, 4_167_402, 63_891_331,

--- a/spec/lib/science_wire_harvester_spec.rb
+++ b/spec/lib/science_wire_harvester_spec.rb
@@ -31,8 +31,8 @@ describe ScienceWireHarvester, :vcr do
   end
 
   describe '#default_institution' do
-    it 'is a ScienceWire::AuthorInstitution' do
-      expect(subject.default_institution).to be_an ScienceWire::AuthorInstitution
+    it 'is a Agent::AuthorInstitution' do
+      expect(subject.default_institution).to be_an Agent::AuthorInstitution
     end
     context 'name' do
       it 'is a String' do
@@ -44,9 +44,9 @@ describe ScienceWireHarvester, :vcr do
       end
     end
     context 'has an institution address' do
-      it 'is a ScienceWire::AuthorAddress' do
+      it 'is a Agent::AuthorAddress' do
         expect(subject.default_institution).to respond_to(:address)
-        expect(subject.default_institution.address).to be_an ScienceWire::AuthorAddress
+        expect(subject.default_institution.address).to be_an Agent::AuthorAddress
       end
       it 'is set by Settings' do
         address_hash = Settings.HARVESTER.INSTITUTION.address.to_hash

--- a/spec/models/author_identity_spec.rb
+++ b/spec/models/author_identity_spec.rb
@@ -127,8 +127,8 @@ RSpec.describe AuthorIdentity, type: :model do
     it 'returns an AuthorAttributes object' do
       expect(subject.to_author_attributes).to be_an ScienceWire::AuthorAttributes
     end
-    it 'sets the AuthorAttributes name to an AuthorName from itself' do
-      expect(subject.to_author_attributes.name).to eq ScienceWire::AuthorName.new(subject.last_name, subject.first_name, subject.middle_name)
+    it 'sets the AuthorAttributes name to an Agent::AuthorName from itself' do
+      expect(subject.to_author_attributes.name).to eq Agent::AuthorName.new(subject.last_name, subject.first_name, subject.middle_name)
     end
     it 'sets the AuthorAttributes seed_list from itself' do
       expect(subject.to_author_attributes.seed_list).to eq []
@@ -136,8 +136,8 @@ RSpec.describe AuthorIdentity, type: :model do
     it 'sets the AuthorAttributes email from itself' do
       expect(subject.to_author_attributes.email).to eq subject.email
     end
-    it 'sets the AuthorAttributes institution to an AuthorInstitution from itself' do
-      expect(subject.to_author_attributes.institution).to eq ScienceWire::AuthorInstitution.new(subject.institution)
+    it 'sets the AuthorAttributes institution to an Agent::AuthorInstitution from itself' do
+      expect(subject.to_author_attributes.institution).to eq Agent::AuthorInstitution.new(subject.institution)
     end
     it 'sets the AuthorAttributes start_date from itself' do
       expect(subject.to_author_attributes.start_date).to eq subject.start_date

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -126,8 +126,8 @@ def a_get(path)
 end
 
 def default_institution
-  ScienceWire::AuthorInstitution.new(
+  Agent::AuthorInstitution.new(
     Settings.HARVESTER.INSTITUTION.name,
-    ScienceWire::AuthorAddress.new(Settings.HARVESTER.INSTITUTION.address.to_hash)
+    Agent::AuthorAddress.new(Settings.HARVESTER.INSTITUTION.address.to_hash)
   )
 end


### PR DESCRIPTION
Extract author name/address/institution stuff out of the SW module, it doesn't belong there.  Preparation for further work on #272 and also for later removing the SW module entirely.  This PR will be solely a refactor, to make sure this is done right first.

- the module cannot be named `Author`, as in `Author::Name` because there is already an `Author` model in the rails app and ruby/rails is not smart enough to differentiate between the rails model/class and a separate module.

- to check that all the things are changed, I used:
```sh
$ git grep 'ScienceWire::Author'
# lots of stuff here, but it's all AuthorAttributes stuff that should remain so; hence
# the follow returns nothing, which means all the things are changed.
$ git grep 'ScienceWire::Author' | grep -v 'AuthorAttributes'
```

- unless some `git rebase` stuff is required, I think this is done and I need it (want it) to continue work on #272 