### PR TITLE
Every publication_identifier should be attached to a publication

### DIFF
--- a/app/models/publication_identifier.rb
+++ b/app/models/publication_identifier.rb
@@ -1,3 +1,3 @@
 class PublicationIdentifier < ActiveRecord::Base
-  belongs_to :publication
+  belongs_to :publication, required: true, inverse_of: :publication_identifiers
 end


### PR DESCRIPTION
Otherwise it is not identifying anything!

`inverse_of` is a recommended practice for associations.  Rails tries to auto-detect heuristically, but it is more reliable and efficient to declare the inverse.  See `Bi-directional associations` here:
   https://apidock.com/rails/ActiveRecord/Associations/ClassMethods

Verified there are no records currently (on prod or cap-qa) that would run afoul of this constraint:
```ruby
PublicationIdentifier.where(publication_id:nil).count
=> 0
```
But let's keep it that way.