### PR TITLE
WebOfScience::Harvester

### DIFF
--- a/lib/notification_manager.rb
+++ b/lib/notification_manager.rb
@@ -17,7 +17,7 @@ class NotificationManager
         log_exception(pubmed_logger, log_message, e)
       when CapAuthorsPoller, CapHttpClient
         log_exception(cap_logger, log_message, e)
-      when WebOfScience::Client, WebOfScience::Harvester
+      when WebOfScience::Client, WebOfScience::Harvester, WebOfScience::ProcessRecords
         log_exception(wos_logger, log_message, e)
       else
         log_exception(Rails.logger, log_message, e)

--- a/lib/notification_manager.rb
+++ b/lib/notification_manager.rb
@@ -17,7 +17,7 @@ class NotificationManager
         log_exception(pubmed_logger, log_message, e)
       when CapAuthorsPoller, CapHttpClient
         log_exception(cap_logger, log_message, e)
-      when WebOfScience::Client
+      when WebOfScience::Client, WebOfScience::Harvester
         log_exception(wos_logger, log_message, e)
       else
         log_exception(Rails.logger, log_message, e)

--- a/lib/web_of_science/harvester.rb
+++ b/lib/web_of_science/harvester.rb
@@ -1,0 +1,145 @@
+module WebOfScience
+
+  # Application logic to harvest publications from Web of Science;
+  # This is the bridge between the WebOfScience API and the SUL-PUB application.
+  # This class is responsible for processing WebOfScience API response data
+  # to integrate it into the application data models.
+  class Harvester
+
+    # Harvest all publications for an author
+    # @param author [Author]
+    # @return [Array<String>] WosUIDs that create Publications
+    def process_author(author)
+      raise(ArgumentError, 'author must be an Author') unless author.is_a? Author
+      process_records author, records_for_author(author)
+    end
+
+    # Harvest DOI publications for an author
+    # @param author [Author]
+    # @param dois [Array<String>] DOI values (not URIs)
+    # @return [Array<String>] WosUIDs that create Publications
+    def process_dois(author, dois)
+      raise(ArgumentError, 'author must be an Author') unless author.is_a? Author
+      raise(ArgumentError, 'dois must be Enumerable') unless dois.is_a? Enumerable
+      # TODO: normalize the dois using altmetrics identifier gem, as in PR #246
+      dois.reject! { |doi| publication_identifier?('doi', doi) }
+      return [] if dois.empty?
+      records = wos_queries.search_by_doi(dois.shift)
+      dois.each { |doi| records.merge_records wos_queries.search_by_doi(doi) }
+      process_records author, records
+    end
+
+    # Harvest PMID publications for an author
+    # @param author [Author]
+    # @param pmids [Array<String>] PMID values (not URIs)
+    # @return [Array<String>] WosUIDs that create Publications
+    def process_pmids(author, pmids)
+      raise(ArgumentError, 'author must be an Author') unless author.is_a? Author
+      raise(ArgumentError, 'pmids must be Enumerable') unless pmids.is_a? Enumerable
+      # TODO: normalize the pmids using altmetrics identifier gem, as in PR #246
+      pmids.reject! { |pmid| publication_identifier?('pmid', pmid) }
+      return [] if pmids.empty?
+      # TODO: define the flow for retrieving this data
+      # PMID ->  links-API to get UID -> WOS API to get record (likely MEDLINE record)
+      #      -> (if that fails) PubMed API for PubMed record
+      # TODO: process_records author, wos_queries.retrieve_by_id(pmids) # Does this work?
+      author.id # this is only here to avoid a rubocop error
+      raise(NotImplementedError, 'There is no processor defined for PMID publications')
+    end
+
+    # Harvest WOS-UID publications for an author
+    # @param author [Author]
+    # @param uids [Array<String>] WOS-UID or WOS-ItemId values (not URIs)
+    # @return [Array<String>] WosUIDs that create Publications
+    def process_uids(author, uids)
+      raise(ArgumentError, 'author must be an Author') unless author.is_a? Author
+      raise(ArgumentError, 'uids must be Enumerable') unless uids.is_a? Enumerable
+      uids.reject! { |uid| publication_identifier?('WosItemId', wos_item(uid)) }
+      return [] if uids.empty?
+      process_records author, wos_queries.retrieve_by_id(uids)
+    end
+
+    private
+
+      # Process records retrieved by any means
+      # @param author [Author]
+      # @param records [WebOfScience::Records]
+      # @return [Array<String>] WosUIDs that create Publications
+      def process_records(author, records)
+        processor = WebOfScience::ProcessRecords.new(author, records)
+        processor.execute
+      end
+
+      # ----
+      # Retrieve WOS Records for Author
+
+      # @param author [Author]
+      # @return records [WebOfScience::Records]
+      def records_for_author(author)
+        # TODO: iterate on author identities also, or leave that to the consumer of this class?
+        names = author_name(author).text_search_query
+        institution = author_institution(author).normalize_name
+        user_query = "AU=(#{names}) AND AD=(#{institution})"
+        wos_queries.search(user_query)
+      end
+
+      # @param author [Author]
+      # @return [Agent::AuthorName]
+      def author_name(author)
+        Agent::AuthorName.new(
+          author.last_name,
+          author.first_name,
+          Settings.HARVESTER.USE_MIDDLE_NAME ? author.middle_name : ''
+        )
+      end
+
+      # @param author [Author]
+      # @return [Agent::AuthorInstitution]
+      def author_institution(author)
+        return default_institution if author.institution.blank?
+        Agent::AuthorInstitution.new(author.institution)
+      end
+
+      # @return [Agent::AuthorInstitution]
+      def default_institution
+        @default_institution ||= begin
+          Agent::AuthorInstitution.new(
+            Settings.HARVESTER.INSTITUTION.name,
+            Agent::AuthorAddress.new(Settings.HARVESTER.INSTITUTION.address.to_hash)
+          )
+        end
+      end
+
+      # ----
+      # Utility methods
+
+      # Is there a PublicationIdentifier matching the type and value?
+      # @param type [String]
+      # @param value [String]
+      def publication_identifier?(type, value)
+        return false if value.nil?
+        PublicationIdentifier.where(identifier_type: type, identifier_value: value).count > 0
+      end
+
+      # Extract a WOS-ItemId from a WOS-UID or a WosItemId
+      # - a WOS-UID has the form {DB_PREFIX}:{WOS_ITEM_ID}
+      # - a WOS-ItemId has no {DB_PREFIX}:
+      # @param id [String]
+      # @return [String] the {WOS_ITEM_ID}
+      def wos_item(id)
+        id.split(':').last
+      end
+
+      # @return [WebOfScience::Queries]
+      def wos_queries
+        @wos_queries ||= begin
+          wos_client = WebOfScience::Client.new(Settings.WOS.AUTH_CODE)
+          WebOfScience::Queries.new(wos_client)
+        end
+      end
+
+      def logger
+        @logger ||= NotificationManager.wos_logger
+      end
+  end
+end

--- a/lib/web_of_science/process_records.rb
+++ b/lib/web_of_science/process_records.rb
@@ -1,0 +1,134 @@
+module WebOfScience
+
+  # This class complements the WebOfScience::Harvester
+  # Process records retrieved by any means; this is a progressive filtering of the harvested records to identify
+  # those records that should create a new Publication-PubHash, PublicationIdentifier(s) and Contribution(s).
+  class ProcessRecords
+
+    # @param author [Author]
+    # @param records [WebOfScience::Records]
+    def initialize(author, records)
+      raise(ArgumentError, 'author must be an Author') unless author.is_a? Author
+      raise(ArgumentError, 'records must be an WebOfScience::Records') unless records.is_a? WebOfScience::Records
+      @author = author
+      @records = records
+    end
+
+    # @return [Array<String>] WosUIDs that create a new Publication
+    def execute
+      return [] if records.count.zero?
+      create_publications
+      # TODO: batch harvest PubMed data for WOS records with a PMID?
+    rescue StandardError => err
+      logger.error(err.inspect)
+      []
+    end
+
+    private
+
+      attr_reader :author
+      attr_reader :records
+
+      # ----
+      # Record filters and data flow steps
+
+      # @return [Array<String>] WosUIDs that create a new Publication
+      def create_publications
+        new_wos_records = match_wos_records # cf. WebOfScienceSourceRecord
+        saved_wos_records = save_wos_records(new_wos_records) # save WebOfScienceSourceRecord
+        records = filter_by_identifiers(saved_wos_records) # cf. PublicationIdentifier
+        records.map { |rec| create_publication(rec) }.compact
+      end
+
+      ## 1
+      # Filter and select new WebOfScienceSourceRecords
+      # @return [Array<WebOfScience::Record>]
+      def match_wos_records
+        return [] if records.count.zero?
+        records.select { |rec| WebOfScienceSourceRecord.where(uid: rec.uid).count.zero? }
+      end
+
+      ## 2
+      # Save and select new WebOfScienceSourceRecords
+      # @param [Array<WebOfScience::Record>]
+      # @return [Array<WebOfScience::Record>]
+      def save_wos_records(records)
+        # IMPORTANT: add nothing to PublicationIdentifiers here, or new_records will reject them
+        return [] if records.empty?
+        # We only want the 'pmid' for "WOS" records ("MEDLINE" records have one already)
+        process_links(records.select { |rec| rec.database == 'WOS' })
+        records.select do |rec|
+          saved = WebOfScienceSourceRecord.new(source_data: rec.to_xml).save!
+          # TODO: add all identifiers to src-record, including links-API identifiers
+          saved
+        end
+      end
+
+      ## 3
+      # Select records that have no matching PublicationIdentifiers
+      # @param [Array<WebOfScience::Record>]
+      # @return [Array<WebOfScience::Record>]
+      def filter_by_identifiers(records)
+        return [] if records.empty?
+        records.reject do |rec|
+          publication_identifier?('WosItemID', rec.wos_item_id) ||
+            rec.identifiers.any? { |type, value| publication_identifier?(type, value) }
+        end
+      end
+
+      ## 4
+      # @param [WebOfScience::Record]
+      # @return [String|nil] WosUID for a new Publication
+      def create_publication(rec)
+        return nil if WebOfScienceSourceRecord.find_by(uid: rec.uid).nil?
+        # All of this is TBD, it might live here or in another class
+        # TODO: For WOS-record that has a PMID, fetch data from PubMed
+        # TODO: create a new Publication, including Publication.pub_hash data
+        # TODO: create new PublicationIdentifiers from rec.identifiers
+        # TODO: associate Publication with Author and create Contribution
+        rec.uid
+      rescue
+        logger.error("#{rec.uid} failed to create Publication")
+        nil
+      end
+
+      # ----
+      # WOS Links API methods
+
+      # Retrieve a batch of publication identifiers from the Links-API
+      #
+      # IMPORTANT: add nothing to PublicationIdentifiers here, or new_records will reject them
+      # Note: the WebOfScienceSourceRecord is already saved, it could be updated with
+      #       additional identifiers if there are fields defined for it.  Otherwise, these
+      #       identifiers will get added to PublicationIdentifier after a Publication is created.
+      #
+      # @param records [Array<WebOfScience::Record>]
+      def process_links(records)
+        return if records.empty?
+        links = links_client.links records.map(&:uid)
+        records.each { |rec| rec.identifiers.update links[rec.uid] }
+      rescue StandardError => err
+        logger.error(err.inspect)
+      end
+
+      # @return [WebOfScience::LinksClient]
+      def links_client
+        @links_client ||= Clarivate::LinksClient.new
+      end
+
+      # ----
+      # Utility methods
+
+      # Is there a PublicationIdentifier matching the type and value?
+      # @param type [String]
+      # @param value [String]
+      def publication_identifier?(type, value)
+        return false if value.nil?
+        PublicationIdentifier.where(identifier_type: type, identifier_value: value).count > 0
+      end
+
+      def logger
+        @logger ||= NotificationManager.wos_logger
+      end
+  end
+end

--- a/spec/lib/web_of_science/harvester_spec.rb
+++ b/spec/lib/web_of_science/harvester_spec.rb
@@ -1,0 +1,118 @@
+# http://savonrb.com/version2/testing.html
+# require the helper module
+require 'savon/mock/spec_helper'
+
+describe WebOfScience::Harvester do
+  include Savon::SpecHelper
+
+  # set Savon in and out of mock mode
+  before(:all) { savon.mock!   }
+  after(:all)  { savon.unmock! }
+
+  subject(:harvester) { described_class.new }
+
+  let(:wos_auth_response) { File.read('spec/fixtures/wos_client/authenticate.xml') }
+  let(:wos_queries) do
+    wos_client = WebOfScience::Client.new('secret')
+    WebOfScience::Queries.new(wos_client)
+  end
+
+  let(:wos_uids) { %w(WOS:A1976BW18000001 WOS:A1972N549400003) }
+  let(:wos_retrieve_by_id_response) { File.read('spec/fixtures/wos_client/wos_retrieve_by_id_response.xml') }
+  let(:wos_search_by_doi_response) { File.read('spec/fixtures/wos_client/wos_search_by_doi_response.xml') }
+  let(:wos_search_by_name_response) { File.read('spec/fixtures/wos_client/wos_search_by_name_response.xml') }
+
+  let(:medline_xml) { File.read('spec/fixtures/wos_client/medline_encoded_records.html') }
+  let(:any_records_will_do) { WebOfScience::Records.new(encoded_records: medline_xml) }
+
+  let(:author) do
+    # public data from
+    # - https://stanfordwho.stanford.edu
+    # - https://med.stanford.edu/profiles/russ-altman
+    author = FactoryGirl.create(:author,
+                                 preferred_first_name: 'Russ',
+                                 preferred_last_name: 'Altman',
+                                 preferred_middle_name: 'Biagio',
+                                 email: 'Russ.Altman@stanford.edu',
+                                 cap_import_enabled: true)
+    # create some `author.alternative_identities`
+    FactoryGirl.create(:author_identity,
+                       author: author,
+                       first_name: 'R',
+                       middle_name: 'B',
+                       last_name: 'Altman',
+                       email: nil,
+                       institution: 'Stanford University')
+    FactoryGirl.create(:author_identity,
+                       author: author,
+                       first_name: 'Russ',
+                       middle_name: nil,
+                       last_name: 'Altman',
+                       email: nil,
+                       institution: nil)
+    author
+  end
+
+  before do
+    allow(described_class).to receive(:wos_queries).and_return(wos_queries)
+  end
+
+  shared_examples 'it_can_process_records' do
+    let(:processor) { WebOfScience::ProcessRecords.new(author, any_records_will_do) }
+
+    before do
+      allow(WebOfScience::ProcessRecords).to receive(:new).and_return(processor)
+    end
+
+    it 'works' do
+      expect(processor).to receive(:execute).and_return(['WOS-UID'])
+      harvest_process
+    end
+  end
+
+  describe '#process_author' do
+    before do
+      savon.expects(:authenticate).returns(wos_auth_response)
+      savon.expects(:search).with(message: :any).returns(wos_search_by_name_response)
+    end
+
+    let(:harvest_process) { harvester.process_author(author) }
+
+    it_behaves_like 'it_can_process_records'
+  end
+
+  describe '#process_dois' do
+    before do
+      savon.expects(:authenticate).returns(wos_auth_response)
+      savon.expects(:search).with(message: :any).returns(wos_search_by_doi_response)
+    end
+
+    let(:doi) { '10.1007/s12630-011-9462-1' } # don't care if this actually belongs to the author or not
+    let(:harvest_process) { harvester.process_dois(author, [doi]) }
+
+    it_behaves_like 'it_can_process_records'
+  end
+
+  describe '#process_pmids' do
+    before do
+      savon.expects(:authenticate).returns(wos_auth_response)
+      #TODO: savon.expects(:search).with(message: :any).returns(wos_search_by_pmid_response)
+    end
+
+    let(:pmid) { 'A PMID' } # don't care if this actually belongs to the author or not
+    let(:harvest_process) { harvester.process_pmids(author, [pmid]) }
+
+    # TODO: it_behaves_like 'it_can_process_records'
+  end
+
+  describe '#process_uids' do
+    before do
+      savon.expects(:authenticate).returns(wos_auth_response)
+      savon.expects(:retrieve_by_id).with(message: :any).returns(wos_retrieve_by_id_response)
+    end
+
+    let(:harvest_process) { harvester.process_uids(author, wos_uids) }
+
+    it_behaves_like 'it_can_process_records'
+  end
+end

--- a/spec/lib/web_of_science/process_records_spec.rb
+++ b/spec/lib/web_of_science/process_records_spec.rb
@@ -1,0 +1,127 @@
+describe WebOfScience::ProcessRecords do
+  let(:author) do
+    # public data from
+    # - https://stanfordwho.stanford.edu
+    # - https://med.stanford.edu/profiles/russ-altman
+    author = FactoryGirl.create(:author,
+                                 preferred_first_name: 'Russ',
+                                 preferred_last_name: 'Altman',
+                                 preferred_middle_name: 'Biagio',
+                                 email: 'Russ.Altman@stanford.edu',
+                                 cap_import_enabled: true)
+    # create some `author.alternative_identities`
+    FactoryGirl.create(:author_identity,
+                       author: author,
+                       first_name: 'R',
+                       middle_name: 'B',
+                       last_name: 'Altman',
+                       email: nil,
+                       institution: 'Stanford University')
+    FactoryGirl.create(:author_identity,
+                       author: author,
+                       first_name: 'Russ',
+                       middle_name: nil,
+                       last_name: 'Altman',
+                       email: nil,
+                       institution: nil)
+    author
+  end
+
+  let(:medline_xml) { File.read('spec/fixtures/wos_client/medline_encoded_records.html') }
+  let(:medline_records) { WebOfScience::Records.new(encoded_records: medline_xml) }
+
+  let(:wos_record_uid) { 'WOS:000288663100014' }
+  let(:wos_record_xml) { File.read('spec/fixtures/wos_client/wos_record_000288663100014.xml') }
+  let(:wos_records_xml) { "<records>#{wos_record_xml}</records>" }
+  let(:wos_records) { WebOfScience::Records.new(records: wos_records_xml) }
+  let(:wos_records_links) do
+    { 'WOS:000288663100014' => { 'pmid' => '21253920', 'doi' => '10.1007/s12630-011-9462-1' } }
+  end
+
+  let(:links_client) { Clarivate::LinksClient.new }
+  let(:null_logger) { Logger.new('/dev/null') }
+
+  before do
+    allow(processor).to receive(:logger).and_return(null_logger)
+    allow(processor).to receive(:links_client).and_return(links_client)
+  end
+
+  shared_examples '#execute' do
+    # ---
+    # Happy paths
+
+    it 'works' do
+      result = processor.execute
+      expect(result).not_to be_nil
+    end
+    it 'returns an Array' do
+      result = processor.execute
+      expect(result).to be_an Array
+    end
+    it 'returns Array<String> with WosUIDs on success' do
+      result = processor.execute
+      uid_success = result & records.uids
+      expect(uid_success).not_to be_empty
+    end
+    it 'creates new WebOfScienceSourceRecords' do
+      expect { processor.execute }.to change { WebOfScienceSourceRecord.count }
+    end
+    it 'creates new Publications'
+    it 'creates new PublicationIdentifiers'
+    it 'creates new Contributions'
+
+    # ---
+    # Unhappy paths
+
+    it 'raises ArgumentError for author' do
+      expect { described_class.new('author', records) }.to raise_error(ArgumentError)
+    end
+    it 'raises ArgumentError for records' do
+      expect { described_class.new(author, []) }.to raise_error(ArgumentError)
+    end
+
+    context 'save_wos_records fails' do
+      before do
+        allow(processor).to receive(:save_wos_records).and_raise(RuntimeError)
+      end
+
+      it 'does not create new WebOfScienceSourceRecords' do
+        expect { processor.execute }.not_to change { WebOfScienceSourceRecord.count }
+      end
+      it 'logs errors' do
+        expect(null_logger).to receive(:error)
+        processor.execute
+      end
+      it 'returns an Array' do
+        result = processor.execute
+        expect(result).to be_an Array
+      end
+      it 'returns empty Array' do
+        result = processor.execute
+        expect(result).to be_empty
+      end
+    end
+  end
+
+  context 'with MEDLINE records' do
+    subject(:processor) { described_class.new(author, records) }
+
+    let(:records) { medline_records }
+
+    # Note: medline records are not submitted to the links-API
+
+    it_behaves_like '#execute'
+  end
+
+  context 'with WOS records' do
+    subject(:processor) { described_class.new(author, records) }
+
+    let(:records) { wos_records }
+
+    before do
+      allow(links_client).to receive(:links).with([wos_record_uid]).and_return(wos_records_links)
+    end
+
+    it_behaves_like '#execute'
+  end
+end


### PR DESCRIPTION
Fix #272 to use an `Agent::AuthorName` and `Agent::AuthorInstitution` for WOS searches
Fix #254 to code the business logic for the WOS harvester
Fix #326 to log possible exceptions in the LinksClient calls
Fix #301 to code logic for de-duping new WOS-records to create new Pubs
Fix #392 integrate with LinksAmr
Connected to #317 - design discussions on the WOS harvester

This PR focuses on
- using the AuthorName and AuthorInstitution to issue an author query
- saving WebOfScienceSourceRecords
- integrating links-API data into `WebOfScience::Record#identifiers`
  - [x] depends on #328 - rebase on master when it's merged
  - [x] depends on #370 - rebase on master when it's merged

This PR _does not_ attempt to:
- create new `Publication` records
- create new `PublicationIdentifier` records
- these two goals depend on mapping the PubHash data

TODO:
- [x] WIP to refactor after pairing discussion today (Nov 6th)
- [x] add or enhance specs
- [x] split out some commits into separate PRs
- [x] cleanup commit history
- [x] refactor - extract class for `ProcessRecords`
- [x] identify ways to split up the work
  - create pending tests and ticket work to get that stuff done
  - create Publication records (e.g. mapping data to pub_hash)
  - create PublicationIdentifier records
