### PR TITLE
Stronger validation for Contribution model

### DIFF
--- a/app/api/sul_bib/publications_api.rb
+++ b/app/api/sul_bib/publications_api.rb
@@ -80,7 +80,7 @@ module SulBib
           error!('You have not supplied a valid authorship record.', 406)
         end
         pub = Publication.build_new_manual_publication(pub_hash, original_source)
-        pub.save
+        pub.save!
         pub.reload
         logger.debug("Created new publication #{pub.inspect}")
         header 'Location', env['REQUEST_URI'].to_s + '/' + pub.id.to_s
@@ -111,7 +111,7 @@ module SulBib
       logger.info(original_source)
 
       old_pub.update_manual_pub_from_pub_hash(new_pub, original_source)
-      old_pub.save
+      old_pub.save!
       old_pub.reload
       logger.debug("resulting pub hash: #{old_pub.pub_hash}")
       old_pub.pub_hash

--- a/app/api/sul_bib/publications_api.rb
+++ b/app/api/sul_bib/publications_api.rb
@@ -66,7 +66,7 @@ module SulBib
     post do
       logger.info('adding new manual publication from BibJSON')
       logger.info(original_source)
-      pub_hash = params[:pub_hash]
+      pub_hash = params[:pub_hash].to_hash.deep_symbolize_keys # Avoid Hashie::Mash!
       fingerprint = Digest::SHA2.hexdigest(original_source)
       existing_record = UserSubmittedSourceRecord.where(source_fingerprint: fingerprint).first
       if existing_record
@@ -98,7 +98,7 @@ module SulBib
     put ':id' do
       # the last known etag must be sent in the 'if-match' header, returning `412 Precondition Failed` if etags don't match,
       # and a `428 Precondition Required` if the if-match header isn't supplied
-      new_pub = params[:pub_hash]
+      new_pub = params[:pub_hash].to_hash.deep_symbolize_keys # Avoid Hashie::Mash!
       old_pub = publication_find(params[:id])
       case
       when !old_pub.sciencewire_id.blank? || !old_pub.pmid.blank?

--- a/app/models/contribution.rb
+++ b/app/models/contribution.rb
@@ -15,6 +15,15 @@ class Contribution < ActiveRecord::Base
   validates :visibility, inclusion: { in: VISIBILITY_VALUES }, allow_nil: true # TODO: disallow nil
   validates :status, inclusion: { in: STATUS_VALUES }, allow_nil: true         # TODO: disallow nil
 
+  after_initialize :init
+
+  # apply some default values and coercions (lowercasing)
+  def init
+    self.featured   = false if featured.nil? # can't use ||= with boolean
+    self.status     = status.downcase if status
+    self.visibility = visibility.downcase if visibility
+  end
+
   def cap_profile_id
     (author.cap_profile_id if author) || self[:cap_profile_id]
   end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -89,11 +89,13 @@ class Publication < ActiveRecord::Base
   end
 
   def self.find_by_doi(doi)
-    PublicationIdentifier.includes(:publication).where(identifier_type: 'doi', identifier_value: doi).map(&:publication)
+    Publication.includes(:publication_identifiers)
+               .find_by("publication_identifiers.identifier_type": 'doi', "publication_identifiers.identifier_value": doi)
   end
 
-  def self.find_by_pmid_in_pub_id_table(pmid)
-    PublicationIdentifier.includes(:publication).where(identifier_type: 'pmid', identifier_value: pmid).map(&:publication)
+  def self.find_by_pmid_pub_id(pmid)
+    Publication.includes(:publication_identifiers)
+               .find_by("publication_identifiers.identifier_type": 'pmid', "publication_identifiers.identifier_value": pmid)
   end
 
   # @return [Publication] new object

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -133,20 +133,20 @@ class Publication < ActiveRecord::Base
   def update_from_pubmed
     return false if pmid.blank?
     pm_source_record = PubmedSourceRecord.find_by_pmid(pmid)
+    return false unless pm_source_record
     pm_source_record.pubmed_update
     rebuild_pub_hash
-    save
   end
 
   def update_from_sciencewire
     return false if sciencewire_id.blank?
     sw_source = SciencewireSourceRecord.find_by_sciencewire_id(sciencewire_id)
+    return false unless sw_source
     sw_source.sciencewire_update
     rebuild_pub_hash
-    save
   end
 
-  # @return [self]
+  # @return [Boolean] true if .save is successful
   def rebuild_pub_hash
     if sciencewire_id
       sw_source_record = SciencewireSourceRecord.find_by_sciencewire_id(sciencewire_id)
@@ -156,7 +156,7 @@ class Publication < ActiveRecord::Base
       self.pub_hash = pubmed_source_record.source_as_hash
     end
     sync_publication_hash_and_db
-    self
+    save
   end
 
   def delete!

--- a/lib/doi_search.rb
+++ b/lib/doi_search.rb
@@ -1,19 +1,14 @@
 class DoiSearch
   def self.search(doi)
-    results = Publication.find_by_doi doi
+    results = [Publication.find_by_doi(doi)].compact
     results += ScienceWireClient.new.get_pub_by_doi(doi) if results.none?(&:authoritative_doi_source?)
     results.reject! { |pub| non_sw_pub pub } if results.size > 1
     results
   end
 
-  # @return [Boolean] true if the pub is not from sciencwire
+  # @return [Boolean] true if the pub is not from sciencewire
   def self.non_sw_pub(pub)
     return false if pub.is_a? Hash # Hashes are returned from the SW only query
-
-    if pub.authoritative_doi_source?
-      false
-    else
-      true
-    end
+    !pub.authoritative_doi_source?
   end
 end

--- a/lib/pubmed_harvester.rb
+++ b/lib/pubmed_harvester.rb
@@ -1,4 +1,3 @@
-
 class PubmedHarvester
   # Searches locally, then ScienceWire, then Pubmed for a publication by PubmedId
   # @param [String] pmid PubmedId
@@ -6,7 +5,7 @@ class PubmedHarvester
   #   If no publication found, returns an empty Array
   def self.search_all_sources_by_pmid(pmid)
     result = Publication.where(pmid: pmid).to_a # TODO: index manual and batch with pmid?
-    result = Publication.find_by_pmid_in_pub_id_table(pmid) if result.empty?
+    result = [Publication.find_by_pmid_pub_id(pmid)].compact if result.empty?
 
     if result.none?(&:authoritative_pmid_source?)
       sw_records_doc = ScienceWireClient.new.pull_records_from_sciencewire_for_pmids(pmid)

--- a/lib/tasks/sul.rake
+++ b/lib/tasks/sul.rake
@@ -30,7 +30,7 @@ namespace :sul do
       end
       begin
         pub.send(method)
-        pub.save
+        pub.save if pub.changed?
         success_count += 1
       rescue  => e
         message = "*****ERROR on publication ID #{pub.id}: #{e.message}"

--- a/script/fix_sw_procs_marked_as_article.rb
+++ b/script/fix_sw_procs_marked_as_article.rb
@@ -10,7 +10,6 @@ class Finder
       @found += 1
       @logger.info "Fixing #{pub.id}"
       pub.rebuild_pub_hash
-      pub.save
     end
 
   rescue => e

--- a/script/missing_wos_ids.rb
+++ b/script/missing_wos_ids.rb
@@ -60,7 +60,7 @@ class MissingWosId
           if src.publication.wos_item_id.present?
             logger.warn "Publication #{pub[:id]} has a new WoSItemID in SciencewireSourceRecord"
           end
-          pub.rebuild_pub_hash
+          pub.rebuild_pub_hash || raise("Error(s) saving Publication: #{pub.errors}")
           logger.warn "Updated Publication #{pub[:id]} with an updated SciencewireSourceRecord"
         end
       end

--- a/script/missing_wos_ids.rb
+++ b/script/missing_wos_ids.rb
@@ -61,7 +61,6 @@ class MissingWosId
             logger.warn "Publication #{pub[:id]} has a new WoSItemID in SciencewireSourceRecord"
           end
           pub.rebuild_pub_hash
-          pub.save!
           logger.warn "Updated Publication #{pub[:id]} with an updated SciencewireSourceRecord"
         end
       end

--- a/script/rebuild_conference_papers.rb
+++ b/script/rebuild_conference_papers.rb
@@ -11,7 +11,6 @@ class RebuildConferencePapers
           found += 1
           logger.debug "Rebuilding pub_hash for Publication.find(#{pub.id})"
           pub.rebuild_pub_hash # from SciencewireSourceRecord
-          pub.save
         end
       rescue => e
         logger.error "Problem with Publication.find(#{pub.id}): #{e.inspect}"

--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -392,16 +392,15 @@ describe Publication do
   end
 
   describe '.find_by_doi' do
-    it 'returns an array of Publications that have this doi' do
+    it 'returns one Publication that has this doi' do
       publication.pub_hash = { identifier: [{ type: 'doi', id: '10.1016/j.mcn.2012.03.008', url: 'https://dx.doi.org/10.1016/j.mcn.2012.03.008' }] }
       publication.send(:sync_identifiers_in_pub_hash_to_db)
-      res = Publication.find_by_doi '10.1016/j.mcn.2012.03.008'
-      expect(res.size).to eq(1)
-      expect(res.first.id).to eq(publication.id)
+      res = Publication.find_by_doi('10.1016/j.mcn.2012.03.008')
+      expect(res.id).to eq(publication.id)
     end
 
-    it "returns an empty array if the doi isn't found" do
-      expect(Publication.find_by_doi('does not exist')).to be_empty
+    it "returns nil if the doi isn't found" do
+      expect(Publication.find_by_doi('does not exist')).to be_nil
     end
   end
 

--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -152,7 +152,6 @@ describe Publication do
     it 'should sync existing authors in the pub hash to contributions in the db' do
       publication.pub_hash = { authorship: [{ status: 'new', sul_author_id: author.id }] }
       publication.send(:update_any_new_contribution_info_in_pub_hash_to_db)
-      publication.save
       expect(publication.contributions.size).to eq(1)
       c = publication.contributions.last
       expect(c.author).to eq(author)
@@ -161,10 +160,9 @@ describe Publication do
 
     it 'should update attributions of existing contributions to the database' do
       expect(publication.contributions.size).to eq(0)
-      publication.contributions.build_or_update(author, status: 'unknown')
+      publication.contributions.create(author: author, cap_profile_id: author.cap_profile_id, status: 'unknown')
       publication.pub_hash = { authorship: [{ status: 'new', sul_author_id: author.id }] }
       publication.send(:update_any_new_contribution_info_in_pub_hash_to_db)
-      publication.save
       expect(publication.contributions.size).to eq(1)
       c = publication.contributions.reload.last
       expect(c.author).to eq(author)
@@ -174,7 +172,6 @@ describe Publication do
     it 'should look up authors by their cap profile id' do
       author.cap_profile_id = 'abc'
       author.save
-
       publication.pub_hash = { authorship: [{ status: 'new', cap_profile_id: author.cap_profile_id }] }
       publication.send(:update_any_new_contribution_info_in_pub_hash_to_db)
 
@@ -329,21 +326,6 @@ describe Publication do
       expect(publication.pub_hash[:apa_citation]).to eq(apa)
       expect(publication.pub_hash[:mla_citation]).to eq(mla)
       expect(publication.pub_hash[:chicago_citation]).to eq(chicago)
-    end
-  end
-
-  describe 'contributions.build_or_update' do
-    it 'should add a contribution' do
-      c = publication.contributions.build_or_update(author, status: 'unknown')
-      expect(c.author).to eq(author)
-      expect(c.status).to eq('unknown')
-    end
-
-    it 'should update a contribution record if the association exists' do
-      publication.contributions.build_or_update author
-      c = publication.contributions.build_or_update(author, status: 'new')
-      expect(c.author).to eq(author)
-      expect(c.status).to eq('new')
     end
   end
 


### PR DESCRIPTION
Existing validations were ad hoc and required the caller to interrogate potential values before instantiating the model. Afterwards model state was not validatable.

ActiveRecord validations offer a more comprehensive and reliable approach. This PR guarantees `publication` and `author` associations (already true for prod data). It also validates values for `visibility` and `status` in the conventional way, demonstrated in tests. See:
  http://guides.rubyonrails.org/active_record_validations.html

Note: this does NOT make `visibility` and `status` values required, because production data has already allowed `nil` values, even for `featured` (a boolean field):

```ruby
pry(main)> Contribution.group(:status).count
=> {nil=>4, "approved"=>318802, "denied"=>134889, "new"=>302397,
"unknown"=>138209}
pry(main)> Contribution.group(:visibility).count
=> {nil=>9, "private"=>129817, "public"=>764475}
pry(main)> Contribution.group(:featured).count
=> {nil=>4, false=>864760, true=>29539}
```

We should discuss what we want to do about that (if anything).

I had to reposition the declaration of constants to be before declaration of validations, but otherwise this is pretty lightweight revision to the model. 

Tests were cleaned up to avoid unnecessary intermediate assignment of hashes.  Lastly, a method unused anywhere except tests was removed.