### PR TITLE
Avoid n+1 SQL queries

### DIFF
--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -88,11 +88,11 @@ class Publication < ActiveRecord::Base
   end
 
   def self.find_by_doi(doi)
-    PublicationIdentifier.where(identifier_type: 'doi', identifier_value: doi).map(&:publication)
+    PublicationIdentifier.includes(:publication).where(identifier_type: 'doi', identifier_value: doi).map(&:publication)
   end
 
   def self.find_by_pmid_in_pub_id_table(pmid)
-    PublicationIdentifier.where(identifier_type: 'pmid', identifier_value: pmid).map(&:publication)
+    PublicationIdentifier.includes(:publication).where(identifier_type: 'pmid', identifier_value: pmid).map(&:publication)
   end
 
   # @return [Publication] new object


### PR DESCRIPTION
When you know you are going back to the DB to fetch the associated object for each record, just include that table in the first query and avoid **N+1** requests.