### PR TITLE
A simple Harvester base class

### DIFF
--- a/lib/harvester.rb
+++ b/lib/harvester.rb
@@ -1,0 +1,3 @@
+module Harvester
+  require 'harvester/base'
+end

--- a/lib/harvester/base.rb
+++ b/lib/harvester/base.rb
@@ -1,0 +1,24 @@
+module Harvester
+  # An iota of abstraction for things a harvester must do.
+  # The starting point is always one or more Authors.
+  class Base
+    # @return [void]
+    def harvest_all
+      Author.where(active_in_cap: true, cap_import_enabled: true)
+            .find_in_batches(batch_size: batch_size)
+            .each { |batch| harvest(batch) }
+    end
+
+    # @param [Enumerable<Author>] authors
+    # @return [void]
+    def harvest(_authors)
+      raise "harvest must be implemented in subclass"
+    end
+
+    private
+
+      def batch_size
+        100
+      end
+  end
+end

--- a/spec/lib/harvester/base_spec.rb
+++ b/spec/lib/harvester/base_spec.rb
@@ -1,0 +1,20 @@
+describe Harvester::Base do
+  let(:authors) { FactoryGirl.create_list(:author, 5, cap_import_enabled: true) }
+  let(:subclass) { Class.new(described_class) }
+  let(:instance) { subclass.new }
+
+  describe '#harvest_all' do
+    it 'chunks calls to harvest based on batch_size' do
+      expect { authors }.to change { Author.count }.by(5)
+      expect(instance).to receive(:batch_size).and_return(2)
+      expect(instance).to receive(:harvest).exactly(3).times
+      instance.harvest_all
+    end
+  end
+
+  describe '#harvest' do
+    it 'throws exception from base class' do
+      expect { instance.harvest([]) }.to raise_error(RuntimeError)
+    end
+  end
+end

--- a/spec/lib/science_wire_harvester_spec.rb
+++ b/spec/lib/science_wire_harvester_spec.rb
@@ -1,4 +1,3 @@
-
 describe ScienceWireHarvester, :vcr do
   let(:author_without_seed_data) { create :author, emails_for_harvest: '' }
   let(:author_with_seed_email) { create :author }


### PR DESCRIPTION
Connected to #254

This is mostly a demonstration.  The main takeaway is starting from an Enumerable of Authors and not having to deal with a bunch of externalizable logic about author selection or batching. Note that `harvest` still operates on an Enumerable of `Author`s, so one given subclass might do:
```ruby
def harvest(authors)
  authors.each { |author| harvest_one(author) }
end
```
while another that hypothetically supports querying, say, 10 authors at once might (re-)batch.  
```ruby
def harvest(authors)
  authors.each_slice(10) { |slice| harvest_ten(slice) }
end
```
Neither has to worry about *any* author selection logic unless it wants to.  Any prevailing pattern that would need to be implemented can be done externally (e.g. single author is trivial), or in the base class thereby covering all subclasses.

If we want to carry this forward, I can add basic tests.  Otherwise just take it for what it is worth as a clean approach.