### PR TITLE
Rails deprecation: Use .reload instead of association(true)

### DIFF
--- a/spec/api/sul_bib/authorship_api_spec.rb
+++ b/spec/api/sul_bib/authorship_api_spec.rb
@@ -149,7 +149,7 @@ describe SulBib::API, :vcr do
       it 'creates a new authorship record without overwriting existing authorship records' do
         http_request
         count = contribution_count + 1
-        expect(publication_with_contributions.contributions(true).size).to eq(count)
+        expect(publication_with_contributions.contributions.reload.size).to eq(count)
       end
       it 'increases number of contribution records for specified publication by one' do
         expect do

--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -108,7 +108,7 @@ describe Publication do
       publication.sync_identifiers_in_pub_hash_to_db
       i = PublicationIdentifier.last
       expect(i.identifier_type).to eq('x')
-      expect(publication.publication_identifiers(true)).to include(i)
+      expect(publication.publication_identifiers.reload).to include(i)
     end
 
     it 'should not persist SULPubIds' do
@@ -166,7 +166,7 @@ describe Publication do
       publication.update_any_new_contribution_info_in_pub_hash_to_db
       publication.save
       expect(publication.contributions.size).to eq(1)
-      c = publication.contributions(true).last
+      c = publication.contributions.reload.last
       expect(c.author).to eq(author)
       expect(c.status).to eq('z')
     end


### PR DESCRIPTION
See:
https://stackoverflow.com/questions/25188266/what-does-activerecord-do-with-arguments-passed-in-to-association-attribute-meth

This would help us in a potential Rails 5 upgrade.