### PR TITLE
Clarivate::LinksClient - fix bug when vals is empty

### DIFF
--- a/lib/clarivate/links_client.rb
+++ b/lib/clarivate/links_client.rb
@@ -85,7 +85,7 @@ module Clarivate
       # @param [Nokogiri::XML::Nodeset] vals
       # @return [Hash<String => String>] namespace to value
       def response_vals_to_hash(vals)
-        return {} if vals.first.text == 'No Result Found'
+        return {} if vals.empty? || vals.first.text == 'No Result Found'
         vals.map { |val| [val.attr('name'), val.text] }.to_h
       end
 

--- a/spec/fixtures/clarivate/links_empty_results.xml
+++ b/spec/fixtures/clarivate/links_empty_results.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<response xmlns="http://www.isinet.com/xrpc41" src="app.id=API Demo">
+<fn name="LinksAMR.retrieve" rc="OK">
+  <map>
+    <map name="cite_A1972N549400003">
+      <map name="WOS">
+      </map>
+    </map>
+    <map name="cite_A1976BW18000001">
+      <map name="WOS">
+      </map>
+    </map>
+  </map>
+</fn>
+</response>

--- a/spec/lib/clarivate/links_client_spec.rb
+++ b/spec/lib/clarivate/links_client_spec.rb
@@ -64,6 +64,25 @@ describe Clarivate::LinksClient do
         expect(links.values.first).to be_empty
       end
     end
+
+    context 'empty results' do
+      let(:response_xml) { File.read('spec/fixtures/clarivate/links_empty_results.xml') }
+      let(:ids) { %w(A1972N549400003 A1976BW18000001) }
+      let(:links) { links_client.links(ids) }
+
+      before do
+        allow(links_client.send(:connection)).to receive(:post).with(any_args).and_return(double(body: response_xml))
+      end
+      it 'returns a Hash with id-keys' do
+        expect(links.keys).to eq ids
+      end
+      it 'returns a Hash with Hash values' do
+        expect(links.values.first).to be_an Hash
+      end
+      it 'Hash values are empty' do
+        expect(links.values.first).to be_empty
+      end
+    end
   end
 
   describe '#request_body' do


### PR DESCRIPTION
Discovered a bug while working on the WOS harvester.  Extracted this from #333 