### PR TITLE
Publication model has methods that should be private

### DIFF
--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -199,69 +199,6 @@ class Publication < ActiveRecord::Base
     self
   end
 
-  def sync_identifiers_in_pub_hash_to_db
-    incoming_types = Array(pub_hash[:identifier]).map { |id| id[:type] }
-    publication_identifiers.each do |id|
-      next if id.identifier_type =~ /^legacy_cap_pub_id$/i # Do not delete legacy_cap_pub_id
-      id.delete unless incoming_types.include? id.identifier_type
-    end
-
-    Array(pub_hash[:identifier]).each do |identifier|
-      next if identifier[:type] =~ /^SULPubId$/i
-
-      i = publication_identifiers.find { |x| x.identifier_type == identifier[:type] } || PublicationIdentifier.new
-
-      i.assign_attributes certainty: 'confirmed',
-                          identifier_type: identifier[:type],
-                          identifier_value: identifier[:id],
-                          identifier_uri: identifier[:url]
-
-      if i.persisted?
-        i.save
-      else
-        publication_identifiers << i unless publication_identifiers.include? i
-      end
-    end
-  end
-
-  def update_any_new_contribution_info_in_pub_hash_to_db
-    Array(pub_hash[:authorship]).each do |contrib|
-      hash_for_update = {
-        status: contrib[:status],
-        visibility: contrib[:visibility],
-        featured: contrib[:featured]
-      }
-
-      # Find or create an Author of the contribution
-      author_id = contrib[:sul_author_id]
-      cap_profile_id = contrib[:cap_profile_id]
-      author = Author.find_by_id(author_id)
-      if cap_profile_id.present?
-        author ||= Author.find_by_cap_profile_id(cap_profile_id)
-        author ||= begin
-          Author.fetch_from_cap_and_create(cap_profile_id)
-        rescue => e
-          msg = "error retrieving CAP profile #{cap_profile_id} for contribution: #{contrib}"
-          NotificationManager.log_exception(NotificationManager.cap_logger, msg, e)
-          nil
-        end
-      end
-      next if author.nil?
-
-      hash_for_update[:author_id] = author.id
-      hash_for_update[:cap_profile_id] = author.cap_profile_id if author.cap_profile_id.present?
-      contrib = contributions.where(author_id: author.id).first_or_initialize
-      contrib.assign_attributes(hash_for_update)
-
-      if contrib.persisted?
-        contrib.save
-      else
-        contributions << contrib unless contributions.include? contrib
-      end
-    end
-    true
-  end
-
   def delete!
     self.deleted = true
     save
@@ -309,18 +246,6 @@ class Publication < ActiveRecord::Base
     pub_hash[:sulpubid] = sul_pub_id
     pub_hash[:identifier] ||= []
     pub_hash[:identifier] << { type: 'SULPubId', id: sul_pub_id, url: "#{Settings.SULPUB_ID.PUB_URI}/#{sul_pub_id}" }
-  end
-
-  def add_all_identifiers_in_db_to_pub_hash
-    publication_identifiers.reload if persisted?
-    db_ids = publication_identifiers.collect do |id|
-      ident_hash = {}
-      ident_hash[:type] = id.identifier_type if id.identifier_type.present?
-      ident_hash[:id] = id.identifier_value if id.identifier_value.present?
-      ident_hash[:url] = id.identifier_uri if id.identifier_uri.present?
-      ident_hash
-    end
-    pub_hash[:identifier] = db_ids
   end
 
   def add_all_db_contributions_to_my_pub_hash
@@ -373,4 +298,76 @@ class Publication < ActiveRecord::Base
   end
 
   alias authoritative_doi_source? sciencewire_pub?
+
+  private
+
+    def add_all_identifiers_in_db_to_pub_hash
+      publication_identifiers.reload if persisted?
+      db_ids = publication_identifiers.collect do |id|
+        ident_hash = {}
+        ident_hash[:type] = id.identifier_type if id.identifier_type.present?
+        ident_hash[:id] = id.identifier_value if id.identifier_value.present?
+        ident_hash[:url] = id.identifier_uri if id.identifier_uri.present?
+        ident_hash
+      end
+      pub_hash[:identifier] = db_ids
+    end
+
+    def sync_identifiers_in_pub_hash_to_db
+      incoming_types = Array(pub_hash[:identifier]).map { |id| id[:type] }
+      publication_identifiers.each do |id|
+        next if id.identifier_type =~ /^legacy_cap_pub_id$/i # Do not delete legacy_cap_pub_id
+        id.delete unless incoming_types.include? id.identifier_type
+      end
+
+      Array(pub_hash[:identifier]).each do |identifier|
+        next if identifier[:type] =~ /^SULPubId$/i
+        i = publication_identifiers.find { |x| x.identifier_type == identifier[:type] } || PublicationIdentifier.new
+        i.assign_attributes certainty: 'confirmed',
+                            identifier_type: identifier[:type],
+                            identifier_value: identifier[:id],
+                            identifier_uri: identifier[:url]
+        if i.persisted?
+          i.save
+        else
+          publication_identifiers << i unless publication_identifiers.include? i
+        end
+      end
+    end
+
+    def update_any_new_contribution_info_in_pub_hash_to_db
+      Array(pub_hash[:authorship]).each do |contrib|
+        hash_for_update = {
+          status: contrib[:status],
+          visibility: contrib[:visibility],
+          featured: contrib[:featured]
+        }
+        # Find or create an Author of the contribution
+        author_id = contrib[:sul_author_id]
+        cap_profile_id = contrib[:cap_profile_id]
+        author = Author.find_by_id(author_id)
+        if cap_profile_id.present?
+          author ||= Author.find_by_cap_profile_id(cap_profile_id)
+          author ||= begin
+            Author.fetch_from_cap_and_create(cap_profile_id)
+          rescue => e
+            msg = "error retrieving CAP profile #{cap_profile_id} for contribution: #{contrib}"
+            NotificationManager.log_exception(NotificationManager.cap_logger, msg, e)
+            nil
+          end
+        end
+        next if author.nil?
+
+        hash_for_update[:author_id] = author.id
+        hash_for_update[:cap_profile_id] = author.cap_profile_id if author.cap_profile_id.present?
+        contrib = contributions.where(author_id: author.id).first_or_initialize
+        contrib.assign_attributes(hash_for_update)
+        if contrib.persisted?
+          contrib.save
+        else
+          contributions << contrib unless contributions.include? contrib
+        end
+      end
+      true
+    end
 end

--- a/lib/tasks/cap_cutover.rake
+++ b/lib/tasks/cap_cutover.rake
@@ -247,7 +247,7 @@ namespace :cap_cutover do
               title: pub_hash[:title],
               year: pub_hash[:year]
             )
-            pub.update_any_new_contribution_info_in_pub_hash_to_db
+            pub.send(:update_any_new_contribution_info_in_pub_hash_to_db)
             pub.sync_publication_hash_and_db
             pub.save
           else

--- a/spec/api/sul_bib/sourcelookup_spec.rb
+++ b/spec/api/sul_bib/sourcelookup_spec.rb
@@ -66,7 +66,7 @@ describe SulBib::API, :vcr do
             }
           ]
         }
-        publication.sync_identifiers_in_pub_hash_to_db
+        publication.send(:sync_identifiers_in_pub_hash_to_db)
         result = sourcelookup_by_doi
         expect(result['metadata']).to include('records')
         expect(result['metadata']['records']).to eq('1')

--- a/spec/lib/doi_search_spec.rb
+++ b/spec/lib/doi_search_spec.rb
@@ -23,7 +23,7 @@ describe DoiSearch do
           provenance: 'cap',
           identifier: [{ type: 'doi', id: '10.1111/j.1444-0938.2010.00524.x', url: 'https://dx.doi.org/10.1111/j.1444-0938.2010.00524.x' }]
         }
-        publication.sync_identifiers_in_pub_hash_to_db
+        publication.send(:sync_identifiers_in_pub_hash_to_db)
         publication.save
 
         result = DoiSearch.search '10.1111/j.1444-0938.2010.00524.x'

--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -49,7 +49,7 @@ describe Publication do
       subject do
         expect(Author).to receive(:find_by_id).and_return(author)
         publication.pub_hash = pub_hash.dup
-        publication.update_any_new_contribution_info_in_pub_hash_to_db
+        publication.send(:update_any_new_contribution_info_in_pub_hash_to_db)
         publication.save
         publication.reload
       end
@@ -77,7 +77,7 @@ describe Publication do
         expect(Author).to receive(:find_by_cap_profile_id).and_return(nil)
         expect(Author).to receive(:fetch_from_cap_and_create).and_return(author)
         publication.pub_hash = pub_hash_cap_authorship.dup
-        publication.update_any_new_contribution_info_in_pub_hash_to_db
+        publication.send(:update_any_new_contribution_info_in_pub_hash_to_db)
         publication.save
         publication.reload
       end
@@ -96,7 +96,7 @@ describe Publication do
         expect(NotificationManager).to receive(:cap_logger).once.and_return(logger)
         expect(logger).to receive(:error).exactly(3)
         publication.pub_hash = pub_hash_cap_authorship.dup
-        publication.update_any_new_contribution_info_in_pub_hash_to_db
+        publication.send(:update_any_new_contribution_info_in_pub_hash_to_db)
       end
     end
   end
@@ -151,7 +151,7 @@ describe Publication do
   describe 'update_any_new_contribution_info_in_pub_hash_to_db' do
     it 'should sync existing authors in the pub hash to contributions in the db' do
       publication.pub_hash = { authorship: [{ status: 'new', sul_author_id: author.id }] }
-      publication.update_any_new_contribution_info_in_pub_hash_to_db
+      publication.send(:update_any_new_contribution_info_in_pub_hash_to_db)
       publication.save
       expect(publication.contributions.size).to eq(1)
       c = publication.contributions.last
@@ -161,9 +161,9 @@ describe Publication do
 
     it 'should update attributions of existing contributions to the database' do
       expect(publication.contributions.size).to eq(0)
-      publication.contributions.build_or_update(author, status: 'new')
+      publication.contributions.build_or_update(author, status: 'unknown')
       publication.pub_hash = { authorship: [{ status: 'new', sul_author_id: author.id }] }
-      publication.update_any_new_contribution_info_in_pub_hash_to_db
+      publication.send(:update_any_new_contribution_info_in_pub_hash_to_db)
       publication.save
       expect(publication.contributions.size).to eq(1)
       c = publication.contributions.reload.last
@@ -176,7 +176,7 @@ describe Publication do
       author.save
 
       publication.pub_hash = { authorship: [{ status: 'new', cap_profile_id: author.cap_profile_id }] }
-      publication.update_any_new_contribution_info_in_pub_hash_to_db
+      publication.send(:update_any_new_contribution_info_in_pub_hash_to_db)
 
       publication.save
       expect(publication.contributions.size).to eq(1)
@@ -187,7 +187,7 @@ describe Publication do
 
     it 'should ignore unknown authors' do
       publication.pub_hash = { authorship: [{ status: 'ignored', cap_profile_id: 'doesnt_exist' }] }
-      publication.update_any_new_contribution_info_in_pub_hash_to_db
+      publication.send(:update_any_new_contribution_info_in_pub_hash_to_db)
       publication.save
       expect(publication.contributions).to be_empty
     end


### PR DESCRIPTION
NOTE: for the purposes of this revision, I am treating `cap_cutover.rake` as a vestigial/deprecated piece of code. Where it is the sole (external) caller for one method, I am not treating that as
a continuing "current" use.  I edited it so the task will still work the same (by using `.send`, similar to the specs), but I am allowing `Publication` to take the otherwise private method private.

In a separate PR, most of `cap_cutover.rake` is being removed.
