### PR TITLE
WebOfScience rake tasks - the saga begins

### DIFF
--- a/lib/clarivate/links_client.rb
+++ b/lib/clarivate/links_client.rb
@@ -6,6 +6,8 @@ module Clarivate
     LINKS_HOST = 'https://ws.isiknowledge.com'.freeze
     LINKS_PATH = '/cps/xrpc'.freeze
 
+    ALL_FIELDS = %w(ut doi pmid title isbn issn issue vol year tpages sourceURL timesCited citingArticlesURL relatedRecordsURL).freeze
+
     attr_reader :username, :password, :host
 
     # @param [String] username

--- a/lib/tasks/wos.rake
+++ b/lib/tasks/wos.rake
@@ -1,0 +1,17 @@
+namespace :wos do
+  desc 'Retrieve and print links for a publication by WOS-UID or WosItemId'
+  task :links, [:wos_id] => :environment do |_t, args|
+    raise 'wos_id argument is required.' if args[:wos_id].blank?
+    wos_ids = [args[:wos_id]]
+    links = WOS.links_client.links(wos_ids, fields: Clarivate::LinksClient::ALL_FIELDS)
+    puts JSON.pretty_generate(links)
+  end
+
+  desc 'Retrieve and print a single publication by WOS-UID or WosItemId'
+  task :publication, [:wos_id] => :environment do |_t, args|
+    raise 'wos_id argument is required.' if args[:wos_id].blank?
+    wos_ids = [args[:wos_id]]
+    records = WOS.queries.retrieve_by_id(wos_ids)
+    records.each(&:print) # XML documents
+  end
+end

--- a/lib/web_of_science/record.rb
+++ b/lib/web_of_science/record.rb
@@ -74,6 +74,7 @@ module WebOfScience
       formatter = REXML::Formatters::Pretty.new
       formatter.compact = true
       formatter.write(rexml_doc, $stdout)
+      $stdout.write("\n")
       nil
     end
 

--- a/lib/wos.rb
+++ b/lib/wos.rb
@@ -1,0 +1,27 @@
+# Web of Science/Knowlege (WOS) utilities
+module WOS
+  # rubocop:disable Style/ClassVars
+
+  # WIP - commented out to avoid code-coverage failure
+  # # @return [WebOfScience::Harvester]
+  # def self.harvester
+  #   @@harvester ||= WebOfScience::Harvester.new
+  # end
+
+  # @return [Clarivate::LinksClient]
+  def self.links_client
+    @@links_client ||= Clarivate::LinksClient.new
+  end
+
+  # @return [WebOfScience::Client]
+  def self.client
+    @@client ||= WebOfScience::Client.new(Settings.WOS.AUTH_CODE)
+  end
+
+  # @return [WebOfScience::Queries]
+  def self.queries
+    @@queries ||= WebOfScience::Queries.new(client)
+  end
+
+  # rubocop:enable Style/ClassVars
+end

--- a/spec/lib/wos_spec.rb
+++ b/spec/lib/wos_spec.rb
@@ -1,0 +1,29 @@
+describe WOS do
+  describe '#harvester' do
+    xit 'works' do
+      result = described_class.harvester
+      expect(result).to be_an WebOfScience::Harvester
+    end
+  end
+
+  describe '#links_client' do
+    it 'works' do
+      result = described_class.links_client
+      expect(result).to be_an Clarivate::LinksClient
+    end
+  end
+
+  describe '#client' do
+    it 'works' do
+      result = described_class.client
+      expect(result).to be_an WebOfScience::Client
+    end
+  end
+
+  describe '#queries' do
+    it 'works' do
+      result = described_class.queries
+      expect(result).to be_an WebOfScience::Queries
+    end
+  end
+end


### PR DESCRIPTION
Connected to #253 

The beginning of `wos:{x}` rake tasks.

### Motivation
- This adds WOS API utils module/singleton, available in rails console
- Added `wos:publication` task, based on `sw:publication` task
- Added `wos:links` task to get all the link fields for a publication
