### PR TITLE
WebOfScience::Identifiers

### DIFF
--- a/lib/web_of_science/identifiers.rb
+++ b/lib/web_of_science/identifiers.rb
@@ -1,0 +1,104 @@
+require 'forwardable'
+
+module WebOfScience
+
+  # Immutable Web of Knowledge (WOK) identifiers
+  class Identifiers
+    extend Forwardable
+    include Enumerable
+
+    # Delegate enumerable methods to the mutable Hash.
+    # This is just a convenience.
+    delegate %i(each keys values has_key? has_value? include? reject select to_json) => :to_h
+
+    # @return [String]
+    attr_reader :uid
+
+    # @param rec [WebOfScience::Record]
+    def initialize(rec)
+      raise(ArgumentError, 'ids must be a WebOfScience::Record') unless rec.is_a? WebOfScience::Record
+      extract_ids(rec)
+      parse_medline
+      parse_wos
+      @ids.freeze
+    end
+
+    # Extract the {DB_PREFIX} from a WOS-UID in the form {DB_PREFIX}:{ITEM_ID}
+    # @return [String|nil]
+    def database
+      @database ||= begin
+        uid_split = uid.split(':')
+        uid_split.length > 1 ? uid_split[0] : nil
+      end
+    end
+
+    # @return [String|nil]
+    def doi
+      ids['doi']
+    end
+
+    # @return [String|nil]
+    def issn
+      ids['issn']
+    end
+
+    # Update identifiers to preserve the values already in the identifiers;
+    # the update only allows select identifiers to be merged (doi, issn, pmid)
+    # an only if those identifiers are not already defined.
+    # @param links [Hash<String => String>] other identifiers (from Links API)
+    # @return [WebOfScience::Identifiers]
+    def update(links)
+      return self if links.blank?
+      links = filter_ids(links)
+      @ids = ids.reverse_merge(links).freeze
+      self
+    end
+
+    # @return [String|nil]
+    def pmid
+      ids['pmid']
+    end
+
+    # A mutable Hash of the identifiers
+    # @return [Hash]
+    def to_h
+      ids.dup
+    end
+
+    # @return [String|nil]
+    def wos_item_id
+      ids['WosItemID']
+    end
+
+    private
+
+      attr_reader :ids
+
+      ALLOWED_TYPES = %w(doi issn pmid).freeze
+
+      # @param ids [Hash]
+      def filter_ids(ids)
+        ids.select { |type, _v| ALLOWED_TYPES.include? type }
+      end
+
+      # @param rec [WebOfScience::Record]
+      def extract_ids(rec)
+        ids = rec.doc.xpath('/REC/dynamic_data/cluster_related/identifiers/identifier')
+        ids = ids.map { |id| [id['type'], id['value']] }.to_h
+        @ids = filter_ids(ids)
+        @uid = rec.doc.xpath('/REC/UID').text.freeze
+        @ids.update('WosUID' => uid)
+      end
+
+      def parse_medline
+        return unless database == 'MEDLINE'
+        ids['pmid'].sub!('MEDLINE:', '') if ids['pmid'].present?
+        ids['pmid'] ||= uid.sub('MEDLINE:', '')
+      end
+
+      def parse_wos
+        return unless database == 'WOS'
+        @ids.update('WosItemID' => uid.split(':').last)
+      end
+  end
+end

--- a/spec/fixtures/wos_client/medline_record_24452614.xml
+++ b/spec/fixtures/wos_client/medline_record_24452614.xml
@@ -1,0 +1,139 @@
+<?xml version='1.0'?>
+<REC r_id_disclaimer='ResearcherID data provided by Clarivate Analytics'>
+  <UID>MEDLINE:24452614</UID>
+  <static_data>
+    <summary>
+      <EWUID>
+        <WUID coll_id='MEDLINE'/>
+        <edition value='MEDLINE.MEDLINE'/>
+      </EWUID>
+      <pub_info coverdate='2014-Jan-22' edate='2014-01-22' has_abstract='Y' medium='Print' model='Electronic' pubday='22' pubmonth='Jan' pubtype='Journal' pubyear='2014' sortdate='2014-01-22' vol='3'>
+        <page begin='e93'>e93</page>
+      </pub_info>
+      <titles count='4'>
+        <title type='item'>
+          Identifying druggable targets by protein microenvironments matching:
+          application to transcription factors.
+        </title>
+        <title type='source'>CPT: pharmacometrics &amp; systems pharmacology</title>
+        <title type='abbrev_iso'>CPT Pharmacometrics Syst Pharmacol</title>
+        <title type='source_abbrev'>CPT Pharmacometrics Syst Pharmacol</title>
+      </titles>
+      <names count='2'>
+        <name display='Y' role='author' seq_no='1'>
+          <display_name>Liu, T</display_name>
+          <full_name>Liu, T</full_name>
+          <initials>T</initials>
+        </name>
+        <name display='Y' role='author' seq_no='2'>
+          <display_name>Altman, R B</display_name>
+          <full_name>Altman, R B</full_name>
+          <initials>RB</initials>
+        </name>
+      </names>
+      <doctypes count='1'>
+        <doctype>Journal Article</doctype>
+      </doctypes>
+    </summary>
+    <fullrecord_metadata>
+      <languages count='1'>
+        <language type='primary'>English</language>
+      </languages>
+      <normalized_languages count='1'>
+        <language type='primary'>English</language>
+      </normalized_languages>
+      <normalized_doctypes count='1'>
+        <doctype>Article</doctype>
+      </normalized_doctypes>
+      <addresses count='1'>
+        <address_name>
+          <address_spec addr_no='1'>
+            <full_address>Department of Genetics, Stanford University, Stanford, California, USA.</full_address>
+          </address_spec>
+        </address_name>
+      </addresses>
+      <fund_ack>
+        <grants complete='Y' count='3'>
+          <grant>
+            <grant_agency>NIGMS NIH HHS</grant_agency>
+            <grant_ids count='1'>
+              <grant_id>R01 GM102365</grant_id>
+            </grant_ids>
+            <country>United States</country>
+            <acronym>GM</acronym>
+          </grant>
+          <grant>
+            <grant_agency>NLM NIH HHS</grant_agency>
+            <grant_ids count='1'>
+              <grant_id>R01 LM005652</grant_id>
+            </grant_ids>
+            <country>United States</country>
+            <acronym>LM</acronym>
+          </grant>
+          <grant>
+            <grant_agency>NIGMS NIH HHS</grant_agency>
+            <grant_ids count='1'>
+              <grant_id>U54 GM072970</grant_id>
+            </grant_ids>
+            <country>United States</country>
+            <acronym>GM</acronym>
+          </grant>
+        </grants>
+      </fund_ack>
+      <abstracts count='1'>
+        <abstract>
+          <abstract_text>
+            <p>
+              Druggability of a protein is its potential to be modulated by
+              drug-like molecules. It is important in the target selection
+              phase. We hypothesize that: (i) known drug-binding sites contain
+              advantageous physicochemical properties for drug binding, or
+              "druggable microenvironments" and (ii) given a target, the
+              presence of multiple druggable microenvironments similar to those
+              seen previously is associated with a high likelihood of
+              druggability. We developed DrugFEATURE to quantify druggability by
+              assessing the microenvironments in potential small-molecule
+              binding sites. We benchmarked DrugFEATURE using two data sets. One
+              data set measures druggability using NMR-based screening.
+              DrugFEATURE correlates well with this metric. The second data set
+              is based on historical drug discovery outcomes. Using the
+              DrugFEATURE cutoffs derived from the first, we accurately
+              discriminated druggable and difficult targets in the second. We
+              further identified novel druggable transcription factors with
+              implications for cancer therapy. DrugFEATURE provides useful
+              insight for drug discovery, by evaluating druggability and
+              suggesting specific regions for interacting with drug-like
+              molecules.CPT: Pharmacometrics Systems Pharmacology (2014) 3, e93;
+              doi:10.1038/psp.2013.66; published online 22 January 2014. 
+            </p>
+          </abstract_text>
+        </abstract>
+      </abstracts>
+    </fullrecord_metadata>
+    <item xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' Owner='NLM' Status='PubMed-not-MEDLINE' coll_id='MEDLINE' xsi:type='itemType_medline'>
+      <MedlineJournalInfo>
+        <Country>United States</Country>
+        <NlmUniqueID>101580011</NlmUniqueID>
+        <ISSNLinking>2163-8306</ISSNLinking>
+      </MedlineJournalInfo>
+      <DateCreated>2014-01-23</DateCreated>
+      <DateCompleted>2014-01-23</DateCompleted>
+      <DateRevised>2016-10-19</DateRevised>
+      <Affiliation>Department of Genetics, Stanford University, Stanford, California, USA.</Affiliation>
+      <OtherID Source='NLM'>PMC3910014</OtherID>
+    </item>
+  </static_data>
+  <dynamic_data>
+    <citation_related>
+      <tc_list>
+        <silo_tc coll_id='MEDLINE' local_count='0'/>
+      </tc_list>
+    </citation_related>
+    <cluster_related>
+      <identifiers>
+        <identifier type='doi' value='10.1038/psp.2013.66'/>
+        <identifier type='pmid' value='MEDLINE:24452614'/>
+      </identifiers>
+    </cluster_related>
+  </dynamic_data>
+</REC>

--- a/spec/fixtures/wos_client/wos_record_000288663100014.xml
+++ b/spec/fixtures/wos_client/wos_record_000288663100014.xml
@@ -1,0 +1,194 @@
+<REC r_id_disclaimer='ResearcherID data provided by Clarivate Analytics'>
+  <UID>WOS:000288663100014</UID>
+  <static_data>
+    <summary>
+      <EWUID>
+        <WUID coll_id='WOS'/>
+        <edition value='WOS.SCI'/>
+      </EWUID>
+      <pub_info coverdate='APR 2011' has_abstract='N' issue='4' pubmonth='APR' pubtype='Journal' pubyear='2011' sortdate='2011-04-01' vol='58'>
+        <page begin='413' end='414' page_count='2'>413-414</page>
+      </pub_info>
+      <titles count='6'>
+        <title type='source'>CANADIAN JOURNAL OF ANESTHESIA-JOURNAL CANADIEN D ANESTHESIE</title>
+        <title type='source_abbrev'>CAN J ANESTH</title>
+        <title type='abbrev_iso'>Can. J. Anesth.</title>
+        <title type='abbrev_11'>CAN J ANEST</title>
+        <title type='abbrev_29'>CAN J ANESTH</title>
+        <title type='item'>Kinked PerifixA (R) FX Springwound epidural catheters</title>
+      </titles>
+      <names count='4'>
+        <name daisng_id='14891281' seq_no='1' addr_no='1' reprint='Y' role='author'>
+          <display_name>Hilton, Gillian</display_name>
+          <full_name>Hilton, Gillian</full_name>
+          <wos_standard>Hilton, G</wos_standard>
+          <first_name>Gillian</first_name>
+          <last_name>Hilton</last_name>
+          <email_addr>ghilton@stanford.edu</email_addr>
+        </name>
+        <name daisng_id='39140400' seq_no='2' addr_no='1' role='author'>
+          <display_name>Jette, Christine G.</display_name>
+          <full_name>Jette, Christine G.</full_name>
+          <wos_standard>Jette, CG</wos_standard>
+          <first_name>Christine G.</first_name>
+          <last_name>Jette</last_name>
+        </name>
+        <name daisng_id='13971962' seq_no='3' addr_no='1' role='author'>
+          <display_name>Ouyang, Yi-Bing</display_name>
+          <full_name>Ouyang, Yi-Bing</full_name>
+          <wos_standard>Ouyang, YB</wos_standard>
+          <first_name>Yi-Bing</first_name>
+          <last_name>Ouyang</last_name>
+        </name>
+        <name daisng_id='30381906' seq_no='4' addr_no='1' role='author'>
+          <display_name>Riley, Edward T.</display_name>
+          <full_name>Riley, Edward T.</full_name>
+          <wos_standard>Riley, ET</wos_standard>
+          <first_name>Edward T.</first_name>
+          <last_name>Riley</last_name>
+        </name>
+      </names>
+      <doctypes count='1'>
+        <doctype>Letter</doctype>
+      </doctypes>
+      <publishers>
+        <publisher>
+          <address_spec addr_no='1'>
+            <full_address>233 SPRING ST, NEW YORK, NY 10013 USA</full_address>
+            <city>NEW YORK</city>
+          </address_spec>
+          <names count='1'>
+            <name addr_no='1' role='publisher' seq_no='1'>
+              <display_name>SPRINGER</display_name>
+              <full_name>SPRINGER</full_name>
+            </name>
+          </names>
+        </publisher>
+      </publishers>
+    </summary>
+    <fullrecord_metadata>
+      <languages count='1'>
+        <language type='primary'>English</language>
+      </languages>
+      <normalized_languages count='1'>
+        <language type='primary'>English</language>
+      </normalized_languages>
+      <normalized_doctypes count='1'>
+        <doctype>Letter</doctype>
+      </normalized_doctypes>
+      <refs count='4'/>
+      <addresses count='1'>
+        <address_name>
+          <address_spec addr_no='1'>
+            <full_address>Stanford Univ, Sch Med, Stanford, CA 94305 USA</full_address>
+            <organizations count='2'>
+              <organization>Stanford Univ</organization>
+              <organization pref='Y'>Stanford University</organization>
+            </organizations>
+            <suborganizations count='1'>
+              <suborganization>Sch Med</suborganization>
+            </suborganizations>
+            <city>Stanford</city>
+            <state>CA</state>
+            <country>USA</country>
+            <zip location='AP'>94305</zip>
+          </address_spec>
+          <names count='4'>
+            <name daisng_id='14891281' seq_no='1' addr_no='1' reprint='Y' role='author'>
+              <display_name>Hilton, Gillian</display_name>
+              <full_name>Hilton, Gillian</full_name>
+              <wos_standard>Hilton, G</wos_standard>
+              <first_name>Gillian</first_name>
+              <last_name>Hilton</last_name>
+              <email_addr>ghilton@stanford.edu</email_addr>
+            </name>
+            <name daisng_id='39140400' seq_no='2' addr_no='1' role='author'>
+              <display_name>Jette, Christine G.</display_name>
+              <full_name>Jette, Christine G.</full_name>
+              <wos_standard>Jette, CG</wos_standard>
+              <first_name>Christine G.</first_name>
+              <last_name>Jette</last_name>
+            </name>
+            <name daisng_id='13971962' seq_no='3' addr_no='1' role='author'>
+              <display_name>Ouyang, Yi-Bing</display_name>
+              <full_name>Ouyang, Yi-Bing</full_name>
+              <wos_standard>Ouyang, YB</wos_standard>
+              <first_name>Yi-Bing</first_name>
+              <last_name>Ouyang</last_name>
+            </name>
+            <name daisng_id='30381906' seq_no='4' addr_no='1' role='author'>
+              <display_name>Riley, Edward T.</display_name>
+              <full_name>Riley, Edward T.</full_name>
+              <wos_standard>Riley, ET</wos_standard>
+              <first_name>Edward T.</first_name>
+              <last_name>Riley</last_name>
+            </name>
+          </names>
+        </address_name>
+      </addresses>
+      <reprint_addresses count='1'>
+        <address_name>
+          <address_spec addr_no='1'>
+            <full_address>Stanford Univ, Sch Med, Stanford, CA 94305 USA</full_address>
+            <organizations count='2'>
+              <organization>Stanford Univ</organization>
+              <organization pref='Y'>Stanford University</organization>
+            </organizations>
+            <suborganizations count='1'>
+              <suborganization>Sch Med</suborganization>
+            </suborganizations>
+            <city>Stanford</city>
+            <state>CA</state>
+            <country>USA</country>
+            <zip location='AP'>94305</zip>
+          </address_spec>
+          <names count='1'>
+            <name addr_no='1' reprint='Y' role='author' seq_no='1'>
+              <display_name>Hilton, Gillian</display_name>
+              <full_name>Hilton, Gillian</full_name>
+              <wos_standard>Hilton, G</wos_standard>
+              <first_name>Gillian</first_name>
+              <last_name>Hilton</last_name>
+              <email_addr>ghilton@stanford.edu</email_addr>
+            </name>
+          </names>
+        </address_name>
+      </reprint_addresses>
+      <category_info>
+        <headings count='1'>
+          <heading>Science &amp; Technology</heading>
+        </headings>
+        <subheadings count='1'>
+          <subheading>Life Sciences &amp; Biomedicine</subheading>
+        </subheadings>
+        <subjects count='3'>
+          <subject ascatype='traditional' code='BA'>Anesthesiology</subject>
+          <subject ascatype='extended'>Anesthesiology</subject>
+          <subject ascatype='traditional' code='BA'>ANESTHESIOLOGY</subject>
+        </subjects>
+      </category_info>
+    </fullrecord_metadata>
+    <item xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' coll_id='WOS' xsi:type='itemType_wos'>
+      <ids avail='N'>738SS</ids>
+      <bib_id>58 (4): 413-414 APR 2011</bib_id>
+      <bib_pagecount type='Journal'>72</bib_pagecount>
+      <keywords_plus count='1'>
+        <keyword>LABOR ANALGESIA</keyword>
+      </keywords_plus>
+    </item>
+  </static_data>
+  <dynamic_data>
+    <citation_related>
+      <tc_list>
+        <silo_tc coll_id='WOS' local_count='2'/>
+      </tc_list>
+    </citation_related>
+    <cluster_related>
+      <identifiers>
+        <identifier type='issn' value='0832-610X'/>
+        <identifier type='doi' value='10.1007/s12630-011-9462-1'/>
+        <identifier type='xref_doi' value='10.1007/s12630-011-9462-1'/>
+      </identifiers>
+    </cluster_related>
+  </dynamic_data>
+</REC>

--- a/spec/lib/web_of_science/identifiers_spec.rb
+++ b/spec/lib/web_of_science/identifiers_spec.rb
@@ -1,0 +1,195 @@
+describe WebOfScience::Identifiers do
+  subject(:identifiers) { described_class.new wos_record }
+
+  let(:wos_record_xml) { File.read('spec/fixtures/wos_client/wos_record_000288663100014.xml') }
+  let(:wos_record) { WebOfScience::Record.new(record: wos_record_xml) }
+  let(:wos_uid) { 'WOS:000288663100014' }
+
+  let(:ids) do
+    { 'issn'      => '0832-610X',
+      'doi'       => '10.1007/s12630-011-9462-1',
+      'xref_doi'  => '10.1007/s12630-011-9462-1',
+      'WosUID'    => 'WOS:000288663100014',
+      'WosItemID' => '000288663100014' }
+  end
+
+  context 'WOS record' do
+    it 'works' do
+      expect(identifiers).to be_an described_class
+    end
+    it 'raises ArgumentError with nil params' do
+      expect { described_class.new }.to raise_error(ArgumentError)
+    end
+    context 'allows useful identifiers, like' do
+      it 'doi' do
+        expect(identifiers.doi).to eq(ids['doi'])
+      end
+      it 'issn' do
+        expect(identifiers.issn).to eq(ids['issn'])
+      end
+      it 'pmid' do
+        expect(identifiers.pmid).to eq(ids['pmid'])
+      end
+      it 'uid' do
+        expect(identifiers.uid).to eq(ids['WosUID'])
+      end
+      it 'uid is frozen' do
+        expect { identifiers.uid[0] = 'a' }.to raise_error(RuntimeError)
+      end
+      it 'wos_item_id' do
+        expect(identifiers.wos_item_id).to eq(ids['WosItemID'])
+      end
+    end
+    context 'the dark side' do
+      it 'filters out identifiers that are not allowed' do
+        # Is this WOS cruft?  Do we want an xref_doi?  If so, how is it different from DOI?
+        expect(identifiers.to_h).not_to include('xref_doi' => '10.1007/s12630-011-9462-1')
+      end
+    end
+  end
+
+  context 'MEDLINE record' do
+    subject(:identifiers) { described_class.new medline_record }
+
+    let(:medline_record_xml) { File.read('spec/fixtures/wos_client/medline_record_24452614.xml') }
+    let(:medline_record) { WebOfScience::Record.new(record: medline_record_xml) }
+    let(:medline_uid) { 'MEDLINE:24452614' }
+    let(:medline_pmid) { '24452614' }
+
+    let(:ids) do
+      { 'doi' => '10.1038/psp.2013.66',
+        'pmid' => '24452614',
+        'WosUID' => 'MEDLINE:24452614' }
+    end
+
+    it 'uid' do
+      expect(identifiers.uid).to eq(ids['WosUID'])
+    end
+    it 'doi' do
+      expect(identifiers.doi).to eq(ids['doi'])
+    end
+    it 'issn' do
+      expect(identifiers.issn).to be_nil
+    end
+    it 'pmid is stripped of the MEDLINE prefix' do
+      expect(identifiers.pmid).to eq medline_pmid
+    end
+    it 'Wos-UID contains the pmid' do
+      expect(identifiers.uid).to match medline_pmid
+    end
+    it 'WosItemID is nil' do
+      expect(identifiers.wos_item_id).to be_nil
+    end
+  end
+
+  describe '#to_h' do
+    let(:hash) { identifiers.to_h }
+
+    it 'works' do
+      expect(hash).to be_an Hash
+    end
+    it 'contains identifiers' do
+      expect(hash).to eq ids.reject { |type, _v| type == 'xref_doi' }
+    end
+    it 'is mutable and accepts anything' do
+      hash.update(a: 1)
+      expect(hash).to include(a: 1)
+    end
+  end
+
+  describe 'Enumerable/Hash behavior' do
+    # These convenience methods work by calling select methods on the Hash from to_h
+    it 'works' do
+      expect(identifiers).to be_an Enumerable
+    end
+    it 'has keys' do
+      expect(identifiers.keys).to be_an Array
+    end
+    it 'has values' do
+      expect(identifiers.values).to be_an Array
+    end
+    it 'can be an Array' do
+      expect(identifiers.to_a).to be_an Array
+    end
+    it 'can be a JSON Hash' do
+      expect(identifiers.to_json).to be_an String
+      expect(JSON.parse(identifiers.to_json)).to be_an Hash
+    end
+    it 'can be filtered with reject' do
+      result = identifiers.reject { |k, _v| k == 'doi' }
+      expect(result).to be_an Hash
+      expect(result.keys).not_to include('doi') # it does exist in identifiers
+    end
+    it 'can be filtered with select' do
+      result = identifiers.select { |k, _v| k == 'doi' }
+      expect(result).to be_an Hash
+      expect(result.keys).to eq ['doi']
+    end
+    it 'does not respond to in-place modifier: reject!' do
+      expect { identifiers.reject! { |k, _v| k == 'doi' } }.to raise_error(NoMethodError)
+    end
+    it 'does not respond to in-place modifier: select!' do
+      expect { identifiers.select! { |k, _v| k == 'doi' } }.to raise_error(NoMethodError)
+    end
+  end
+
+  context 'can merge with links identifiers' do
+    subject(:identifiers) { described_class.new wos_record4links }
+
+    let(:wos_id) { '000346594100007' }
+    let(:record4links) { File.read('spec/fixtures/wos_client/wos_record4links.html') }
+    let(:wos_record4links) { WebOfScience::Record.new(encoded_record: record4links) }
+
+    # links_client = Clarivate::LinksClient.new
+    # links = links_client.links([wos_id], fields: ['doi', 'pmid'])
+    let(:links) { { '000346594100007' => { 'doi' => '10.1002/2013GB004790' } } }
+
+    it 'has compatible keys in the Hash value' do
+      # These sets of identifiers should both contain the 'doi' identifier
+      expect(links[wos_id].keys & identifiers.keys).to eq ['doi']
+    end
+  end
+
+  describe '#update' do
+    let(:links) do
+      # The links-API can return these for WosItemID '000288663100014'
+      { 'doi' => '10.1007/s12630-011-9462-2', # artificially changed this to end with '2'
+        'pmid' => '21253920' }
+    end
+
+    let(:dark_links) do
+      links.merge(DarthVader: 'the dark side')
+    end
+
+    it 'returns a WebOfScience::Identifiers' do
+      expect(identifiers.update(links)).to be_an described_class
+    end
+    it 'preserves existing identifiers' do
+      # If it doesn't preserve them, the doi will end in `2` here
+      expect(identifiers.update(links).to_h).to include('doi' => '10.1007/s12630-011-9462-1')
+    end
+    it 'duplicate identifiers are discarded' do
+      # The inverse of the spec above, for completeness
+      expect(identifiers.update(links).to_h).not_to include('doi' => '10.1007/s12630-011-9462-2')
+    end
+    it 'merges additional identifiers' do
+      expect(identifiers.update(links).to_h).to include('pmid' => '21253920')
+    end
+    it 'excludes unknown identifiers' do
+      expect(identifiers.update(dark_links).to_h).not_to include(DarthVader: 'the dark side')
+    end
+    it 'cannot be updated with any unknown key:value pairs' do
+      identifiers.update(a: 1)
+      expect(identifiers.to_h).not_to include(a: 1)
+    end
+    it 'does nothing and returns self when links.blank?' do
+      expect(identifiers.update(nil)).to eq(identifiers)
+    end
+    # TODO: it should validate the data for known identifiers
+    # TODO: this can use altmetrics identifier gem to validate identifier values
+    xit 'cannot be updated with any invalid identifier values' do
+      identifiers.update('pmid' => 1)
+      expect(identifiers.to_h).not_to include('pmid' => 1)
+    end
+  end
+end

--- a/spec/lib/web_of_science/record_spec.rb
+++ b/spec/lib/web_of_science/record_spec.rb
@@ -82,12 +82,6 @@ describe WebOfScience::Record do
     it_behaves_like 'it is an array of names'
   end
 
-  describe '#database' do
-    it 'works' do
-      expect(wos_record_encoded.database).to eq wos_uid.split(':').first
-    end
-  end
-
   describe '#names' do
     let(:agents) { wos_record_encoded.names }
 
@@ -97,64 +91,23 @@ describe WebOfScience::Record do
   describe '#identifiers' do
     it 'works' do
       result = wos_record_encoded.identifiers
-      expect(result).to include('issn' => '0010-0870')
-    end
-    it 'adds a WosUID' do
-      result = wos_record_encoded.identifiers
-      expect(result).to include('WosUID' => wos_record_encoded.uid)
-    end
-    it 'adds a WosItemID extracted from the UID' do
-      result = wos_record_encoded.identifiers
-      expect(result).to include('WosItemID' => wos_record_encoded.wos_item_id)
+      expect(result).to be_an WebOfScience::Identifiers
     end
 
-    context 'MEDLINE record' do
-      # => {"doi"=>"10.1038/psp.2013.66", "pmid"=>"24452614", "WosUID"=>"MEDLINE:24452614", "WosItemID"=>"24452614"}
-      let(:ids) { medline_record_encoded.identifiers }
-
-      it 'WosUID has a MEDLINE prefix' do
-        expect(ids).to include('WosUID' => 'MEDLINE:24452614')
-      end
-      it 'pmid is stripped of the MEDLINE prefix' do
-        expect(ids).to include('pmid' => '24452614')
+    describe '#database' do
+      # check that it is delegated successfully to identifiers
+      it 'works' do
+        expect(wos_record_encoded.database).to eq wos_uid.split(':').first
       end
     end
 
-    context 'merge with links identifiers' do
-      let(:wos_id) { '000346594100007' }
-      let(:record4links) { File.read('spec/fixtures/wos_client/wos_record4links.html') }
-      let(:wos_record4links) { described_class.new(encoded_record: record4links) }
-
-      # links_client = Clarivate::LinksClient.new
-      # links = links_client.links([wos_id])
-      let(:links) { { '000346594100007' => { 'doi' => '10.1002/2013GB004790' } } }
-
-      it 'has compatible keys in the Hash value' do
-        # These sets of identifiers should both contain the 'doi' identifier
-        identifiers = wos_record4links.identifiers
-        expect(links[wos_id].keys & identifiers.keys).to include 'doi'
+    describe '#uid' do
+      # check that it is delegated successfully to identifiers
+      it 'WOS records have a WOS-UID' do
+        expect(wos_record_encoded.uid).to eq wos_uid
       end
-    end
-
-    describe '#doi' do
-      it 'is nil when not available in identifiers' do
-        # The mock record does not have one
-        expect(wos_record_encoded.doi).to be_nil
-      end
-      it 'is extracted from identifiers' do
-        allow(wos_record_encoded).to receive(:identifiers).and_return('doi' => 'DOI')
-        expect(wos_record_encoded.doi).to eq 'DOI'
-      end
-    end
-
-    describe '#pmid' do
-      it 'is nil when not available in identifiers' do
-        # The mock record does not have one
-        expect(wos_record_encoded.pmid).to be_nil
-      end
-      it 'is extracted from identifiers' do
-        allow(wos_record_encoded).to receive(:identifiers).and_return('pmid' => 'PMID')
-        expect(wos_record_encoded.pmid).to eq 'PMID'
+      it 'MEDLINE records have a MEDLINE-UID (PMID)' do
+        expect(medline_record_encoded.uid).to eq medline_uid
       end
     end
   end
@@ -296,21 +249,6 @@ describe WebOfScience::Record do
     end
     it 'contains summary fields' do
       expect(struct.summary).to be_an OpenStruct
-    end
-  end
-
-  describe '#uid' do
-    it 'WOS records have a WOS-UID' do
-      expect(wos_record_encoded.uid).to eq wos_uid
-    end
-    it 'MEDLINE records have a MEDLINE-UID (PMID)' do
-      expect(medline_record_encoded.uid).to eq medline_uid
-    end
-  end
-
-  describe '#wos_item_id' do
-    it 'works' do
-      expect(wos_record_encoded.wos_item_id).to eq wos_uid.split(':').last
     end
   end
 


### PR DESCRIPTION
Required for #333 

Connected to #254 to code the business logic for the WOS harvester
Connected to #301 to code logic for de-duping new WOS-records to create new Pubs

This replaces #365 (although #365 was OK, it left the identifiers open to exploitation/corruption, alternative truths and all that is evil, Darth).

This class is entirely responsible for WOS identifiers and managing any inconsistencies there might be between how WOS names their identifiers and how sul_pub names them.  It's purpose is to be the sole gatekeeper between WOS and sul_pub.  In that role, it is tasked with protecting the identifiers as immutable data, but allowing very specific merges from the links-API data.  It's also responsible for parsing identifiers based on the type of WOS-DB providing the record and transforming some identifiers into useful forms that match sul_pub identifiers.