### PR TITLE
[Obsolete -> 379, 380] WebOfScience::Record#to_pub_hash

### DIFF
--- a/lib/web_of_science/record.rb
+++ b/lib/web_of_science/record.rb
@@ -67,7 +67,7 @@ module WebOfScience
       ids            = []
 
       ids   << { type: 'PMID', id: @pmid, url: "#{Settings.PUBMED.ARTICLE_BASE_URI}#{@pmid}" } unless @pmid.blank?
-      ids   << { type: 'WoSItemID', id: @wos_item_id, url: "#{Settings.SCIENCEWIRE.ARTICLE_BASE_URI}#{@wos_item_id}" } unless @wos_item_id.blank?
+      ids   << { type: 'WoSItemID', id: @wos_item_id, url: "#{Settings.SCIENCEWIRE.ARTICLE_BASE_URI}#{@wos_item_id}"} unless @wos_item_id.blank?
       ids   << { type: 'doi', id: @doi, url: "#{Settings.DOI.BASE_URI}#{@doi}" } unless @doi.blank?
       ids   << { type: 'issn', id: @issn, url: Settings.SULPUB_ID.SEARCHWORKS_URI + @issn } unless @issn == nil
 
@@ -78,7 +78,7 @@ module WebOfScience
 
       record_as_hash[:title]                = @titles['item']
       record_as_hash[:abstract_restricted]  = @abstracts #yes there might be multiple abstracts
-      record_as_hash[:author]               = @authors.map {|e| { name: e['display_name']} }
+      record_as_hash[:author]               = @authors.map {|e| { name: e['display_name']}}
 
       record_as_hash[:year] = @pub_info['pubyear']
       record_as_hash[:date] = @pub_info['sortdate']
@@ -91,8 +91,8 @@ module WebOfScience
       #sul_document_type = lookup_cap_doc_type_by_sw_doc_category(record_as_hash[:documentcategory_sw])
       #record_as_hash[:type] = sul_document_type
 
-      record_as_hash[:publisher] = publishers.map{|e| e['display_name']}
-      record_as_hash[:city]      = publishers.map{|e| e['address']['city']} ## Something is not right with the addresses field, need to be double checked
+      record_as_hash[:publisher] = publishers.map {|e| e['display_name']}
+      record_as_hash[:city]      = publishers.map {|e| e['address']['city']} ## Something is not right with the addresses field, need to be double checked
       #record_as_hash[:stateprovince] = publication.xpath('CopyrightStateProvince').text unless publication.xpath('CopyrightStateProvince').blank?
       #record_as_hash[:country] = publication.xpath('CopyrightCountry').text unless publication.xpath('CopyrightCountry').blank?
       record_as_hash[:pages]     = @pub_info['page']['begin'] + '-' + @pub_info['page']['end']

--- a/lib/web_of_science/record.rb
+++ b/lib/web_of_science/record.rb
@@ -97,8 +97,6 @@ module WebOfScience
       #record_as_hash[:country] = publication.xpath('CopyrightCountry').text unless publication.xpath('CopyrightCountry').blank?
       record_as_hash[:pages]     = @pub_info['page']['begin'] + '-' + @pub_info['page']['end']
 
-      record_as_hash
-
       PubHash.new(record_as_hash)
     end
 

--- a/lib/web_of_science/record.rb
+++ b/lib/web_of_science/record.rb
@@ -62,7 +62,7 @@ module WebOfScience
     end
 
 
-    def toPubHash
+    def to_pub_hash
       record_as_hash = {}
       ids            = []
 

--- a/lib/web_of_science/record.rb
+++ b/lib/web_of_science/record.rb
@@ -67,18 +67,18 @@ module WebOfScience
       ids            = []
 
       ids   << { type: 'PMID', id: @pmid, url: "#{Settings.PUBMED.ARTICLE_BASE_URI}#{@pmid}" } unless @pmid.blank?
-      ids   << { type: 'WoSItemID', id: @wos_item_id, url: "#{Settings.SCIENCEWIRE.ARTICLE_BASE_URI}#{@wos_item_id}"} unless @wos_item_id.blank?
+      ids   << { type: 'WoSItemID', id: @wos_item_id, url: "#{Settings.SCIENCEWIRE.ARTICLE_BASE_URI}#{ @wos_item_id} "} unless @wos_item_id.blank?
       ids   << { type: 'doi', id: @doi, url: "#{Settings.DOI.BASE_URI}#{@doi}" } unless @doi.blank?
-      ids   << { type: 'issn', id: @issn, url: Settings.SULPUB_ID.SEARCHWORKS_URI + @issn } unless @issn == nil
+      ids   << { type: 'issn', id: @issn, url: Settings.SULPUB_ID.SEARCHWORKS_URI + @issn } unless @issn.nil?
 
       record_as_hash[:provenance] = Settings.sciencewire_source
       record_as_hash[:pmid]       = @pmid unless @pmid.blank?
-      record_as_hash[:issn]       = @identifiers['issn']  unless @identifiers['issn'] == nil
+      record_as_hash[:issn]       = @identifiers['issn']  unless @identifiers['issn'].nil?
       record_as_hash[:identifier] = ids
 
       record_as_hash[:title]                = @titles['item']
       record_as_hash[:abstract_restricted]  = @abstracts #yes there might be multiple abstracts
-      record_as_hash[:author]               = @authors.map {|e| { name: e['display_name']}}
+      record_as_hash[:author]               = @authors.map { |e| { name: e['display_name']} }
 
       record_as_hash[:year] = @pub_info['pubyear']
       record_as_hash[:date] = @pub_info['sortdate']
@@ -91,8 +91,8 @@ module WebOfScience
       #sul_document_type = lookup_cap_doc_type_by_sw_doc_category(record_as_hash[:documentcategory_sw])
       #record_as_hash[:type] = sul_document_type
 
-      record_as_hash[:publisher] = publishers.map {|e| e['display_name']}
-      record_as_hash[:city]      = publishers.map {|e| e['address']['city']} ## Something is not right with the addresses field, need to be double checked
+      record_as_hash[:publisher] = publishers.map { |e| e['display_name'] }
+      record_as_hash[:city]      = publishers.map { |e| e['address']['city'] } ## Something is not right with the addresses field, need to be double checked
       #record_as_hash[:stateprovince] = publication.xpath('CopyrightStateProvince').text unless publication.xpath('CopyrightStateProvince').blank?
       #record_as_hash[:country] = publication.xpath('CopyrightCountry').text unless publication.xpath('CopyrightCountry').blank?
       record_as_hash[:pages]     = @pub_info['page']['begin'] + '-' + @pub_info['page']['end']

--- a/lib/web_of_science/record.rb
+++ b/lib/web_of_science/record.rb
@@ -7,64 +7,42 @@ module WebOfScience
 
     # @return doc [Nokogiri::XML::Document] WOS record document
     attr_reader :doc
+    attr_reader :database
+    attr_reader :uid
+    attr_reader :names
+    attr_reader :authors
+    attr_reader :doctypes
+    attr_reader :identifiers
+    attr_reader :doi
+    attr_reader :pmid
+    attr_reader :issn
+    attr_reader :pub_info
+    attr_reader :publishers
+    attr_reader :wos_item_id
+    attr_reader :titles
 
     # @param record [String] record in XML
     # @param encoded_record [String] record in HTML encoding
-    def initialize(record: nil, encoded_record: nil)
-      record = decode_record(record, encoded_record)
-      @doc = Nokogiri::XML(record) { |config| config.strict.noblanks }
+    def initialize(record: nil, encoded_record: nil, wosExtractor: WebOfScience::WosExtractor.new)
+      record       = decode_record(record, encoded_record)
+      @doc         = Nokogiri::XML(record) { |config| config.strict.noblanks }
+      @uid         = wosExtractor.extract_uid(@doc)
+      @database    = wosExtractor.extract_database(@uid)
+      @names       = wosExtractor.extract_names(@doc)
+      @authors     = wosExtractor.extract_authors(@names)
+      @doctypes    = wosExtractor.extract_doctypes(@doc)
+      @identifiers = wosExtractor.extract_identifiers(@doc)
+      @doi         = wosExtractor.extract_doi(@identifiers)
+      @pmid        = wosExtractor.extract_pmid(@identifiers)
+      @issn        = wosExtractor.extract_issn(@identifiers)
+      @pub_info    = wosExtractor.extract_pub_info(@doc)
+      @publishers  = wosExtractor.extract_publishers(@doc)
+      @wos_item_id = wosExtractor.extract_wos_item_id(@uid)
+      @titles      = wosExtractor.extract_titles(@doc)
+      @abstracts   = wosExtractor.extract_abstracts(@doc) #yes there might be multiple abstracts
     end
 
-    # @return authors [Array<Hash<String => String>>]
-    def authors
-      @authors ||= names.select { |name| name['role'] == 'author' }
-    end
 
-    # Extract the {DB_PREFIX} from a WOS-UID in the form {DB_PREFIX}:{WOS_ITEM_ID}
-    # @return [String|nil]
-    def database
-      @database ||= begin
-        uid_split = uid.split(':')
-        uid_split.length > 1 ? uid_split[0] : nil
-      end
-    end
-
-    # @return doctypes [Array<String>]
-    def doctypes
-      @doctypes ||= doc.search('static_data/summary/doctypes/doctype').map(&:text)
-    end
-
-    # @return [String|nil]
-    def doi
-      identifiers['doi']
-    end
-
-    # @return identifiers [Hash<String => String>]
-    def identifiers
-      @identifiers ||= begin
-        ids = doc.search('dynamic_data/cluster_related/identifiers/identifier')
-        ids = ids.map { |id| [id['type'], id['value']] }.to_h
-        ids['WosUID'] = uid
-        ids['WosItemID'] = wos_item_id
-        ids['pmid'].sub!('MEDLINE:', '') if database == 'MEDLINE'
-        ids
-      end
-    end
-
-    # @return names [Array<Hash<String => String>>]
-    def names
-      @names ||= begin
-        names = doc.search('static_data/summary/names/name').map do |name|
-          attributes_with_children_hash(name)
-        end
-        names.sort { |name| name['seq_no'].to_i }
-      end
-    end
-
-    # @return [String|nil]
-    def pmid
-      identifiers['pmid']
-    end
 
     # Pretty print the record in XML
     # @return nil
@@ -77,115 +55,60 @@ module WebOfScience
       nil
     end
 
-    # @return pub_info [Hash<String => String>]
-    def pub_info
-      @pub_info ||= begin
-        info = doc.at('static_data/summary/pub_info')
-        fields = attributes_map(info)
-        fields += info.children.map do |child|
-          [child.name, attributes_map(child).to_h ]
-        end
-        fields.to_h
-      end
-    end
-
-    # @return publishers [Array<Hash>]
-    def publishers
-      @publishers ||= begin
-        publishers = doc.search('static_data/summary/publishers/publisher').map do |publisher|
-          # parse the publisher address(es)
-          addresses = publisher.search('address_spec').map do |address|
-            attributes_with_children_hash(address)
-          end
-          addresses.sort! { |a| a['addr_no'].to_i }
-          # parse the publisher name(s)
-          names = publisher.search('names/name').map do |name|
-            attributes_with_children_hash(name)
-          end
-          # associate each publisher name with it's address by 'addr_no'
-          names.each do |name|
-            address = addresses.find { |addr| addr['addr_no'] == name['addr_no'] }
-            name['address'] = address
-          end
-          names.sort { |name| name['seq_no'].to_i }
-        end
-        publishers.flatten
-      end
-    end
-
-    # Extract the REC summary fields
-    # @return summary [Hash]
-    def summary
-      @summary ||= {
-        'doctypes' => doctypes,
-        'names' => names,
-        'pub_info' => pub_info,
-        'publishers' => publishers,
-        'titles' => titles,
-      }
-    end
-
-    # An OpenStruct for the summary fields
-    # @return summary [OpenStruct]
-    def summary_struct
-      to_o(summary)
-    end
-
-    # @return titles [Hash<String => String>]
-    def titles
-      @titles ||= begin
-        titles = doc.search('static_data/summary/titles/title')
-        titles.map { |title| [title['type'], title.text] }.to_h
-      end
-    end
-
-    # Extract the REC fields
-    # @return [Hash]
-    def to_h
-      {
-        'summary' => summary,
-      }
-    end
-
-    # An OpenStruct for the REC fields
-    # @return [OpenStruct]
-    def to_struct
-      to_o(to_h)
-    end
 
     # @return xml [String] XML
     def to_xml
       doc.to_xml(save_with: XML_OPTIONS).strip
     end
 
-    # @return uid [String] the UID
-    def uid
-      @uid ||= doc.search('UID').text
-    end
 
-    # Extract the {WOS_ITEM_ID} from a WOS-UID in the form {DB_PREFIX}:{WOS_ITEM_ID}
-    # @return [String]
-    def wos_item_id
-      @wos_item_id ||= uid.split(':').last
+    def toPubHash
+      record_as_hash = {}
+      ids            = []
+
+      ids   << { type: 'PMID', id: @pmid, url: "#{Settings.PUBMED.ARTICLE_BASE_URI}#{@pmid}" } unless @pmid.blank?
+      ids   << { type: 'WoSItemID', id: @wos_item_id, url: "#{Settings.SCIENCEWIRE.ARTICLE_BASE_URI}#{@wos_item_id}" } unless @wos_item_id.blank?
+      ids   << { type: 'doi', id: @doi, url: "#{Settings.DOI.BASE_URI}#{@doi}" } unless @doi.blank?
+      ids   << { type: 'issn', id: @issn, url: Settings.SULPUB_ID.SEARCHWORKS_URI + @issn } unless (@issn == nil)
+
+
+      record_as_hash[:provenance] = Settings.sciencewire_source
+      record_as_hash[:pmid]       = @pmid unless @pmid.blank?
+      record_as_hash[:issn]       = @identifiers['issn']  unless (@identifiers['issn'] == nil)
+      record_as_hash[:identifier] = ids
+
+
+      record_as_hash[:title]                = @titles['item']
+      record_as_hash[:abstract_restricted]  = @abstracts #yes there might be multiple abstracts
+      record_as_hash[:author]               = @authors.map{|e|  { name: e['display_name']}}
+
+
+      record_as_hash[:year] = @pub_info['pubyear']
+      record_as_hash[:date] = @pub_info['sortdate']
+
+      record_as_hash[:authorcount] = @authors.count
+
+      record_as_hash[:documenttypes_sw] = @doctypes
+
+      #record_as_hash[:documentcategory_sw] = publication.xpath('DocumentCategory').text unless publication.xpath('DocumentCategory').blank?
+      #sul_document_type = lookup_cap_doc_type_by_sw_doc_category(record_as_hash[:documentcategory_sw])
+      #record_as_hash[:type] = sul_document_type
+
+      record_as_hash[:publisher] = publishers.map{|e| e['display_name']}
+      record_as_hash[:city] = publishers.map{|e| e['address']['city']} ## Something is not right with the addresses field, need to be double checked
+      #record_as_hash[:stateprovince] = publication.xpath('CopyrightStateProvince').text unless publication.xpath('CopyrightStateProvince').blank?
+      #record_as_hash[:country] = publication.xpath('CopyrightCountry').text unless publication.xpath('CopyrightCountry').blank?
+      record_as_hash[:pages] = @pub_info['page']['begin'] + '-' + @pub_info['page']['end']
+
+      record_as_hash
+
+      PubHash.new(record_as_hash)
     end
 
     private
 
       XML_OPTIONS = Nokogiri::XML::Node::SaveOptions::AS_XML | Nokogiri::XML::Node::SaveOptions::NO_DECLARATION
 
-      # @param element [Nokogiri::XML::Element]
-      # @return attributes [Array<Array[String, String]>]
-      def attributes_map(element)
-        element.attributes.map { |name, att| [name, att.value] }
-      end
-
-      # @param element [Nokogiri::XML::Element]
-      # @return fields [Hash]
-      def attributes_with_children_hash(element)
-        fields = attributes_map(element)
-        fields += element.children.map { |c| [c.name, c.text] }
-        fields.to_h
-      end
 
       # Return a decoded record, whether it is passed in already or needs to be decoded
       # @param record [String] record in XML
@@ -199,10 +122,5 @@ module WebOfScience
         coder.decode(encoded_record)
       end
 
-      # Convert Hash to OpenStruct with recursive application to nested hashes
-      def to_o(hash)
-        JSON.parse(hash.to_json, object_class: OpenStruct)
-      end
-
-  end
+    end
 end

--- a/lib/web_of_science/record.rb
+++ b/lib/web_of_science/record.rb
@@ -69,24 +69,21 @@ module WebOfScience
       ids   << { type: 'PMID', id: @pmid, url: "#{Settings.PUBMED.ARTICLE_BASE_URI}#{@pmid}" } unless @pmid.blank?
       ids   << { type: 'WoSItemID', id: @wos_item_id, url: "#{Settings.SCIENCEWIRE.ARTICLE_BASE_URI}#{@wos_item_id}" } unless @wos_item_id.blank?
       ids   << { type: 'doi', id: @doi, url: "#{Settings.DOI.BASE_URI}#{@doi}" } unless @doi.blank?
-      ids   << { type: 'issn', id: @issn, url: Settings.SULPUB_ID.SEARCHWORKS_URI + @issn } unless (@issn == nil)
-
+      ids   << { type: 'issn', id: @issn, url: Settings.SULPUB_ID.SEARCHWORKS_URI + @issn } unless @issn == nil
 
       record_as_hash[:provenance] = Settings.sciencewire_source
       record_as_hash[:pmid]       = @pmid unless @pmid.blank?
-      record_as_hash[:issn]       = @identifiers['issn']  unless (@identifiers['issn'] == nil)
+      record_as_hash[:issn]       = @identifiers['issn']  unless @identifiers['issn'] == nil
       record_as_hash[:identifier] = ids
-
 
       record_as_hash[:title]                = @titles['item']
       record_as_hash[:abstract_restricted]  = @abstracts #yes there might be multiple abstracts
-      record_as_hash[:author]               = @authors.map{|e|  { name: e['display_name']}}
-
+      record_as_hash[:author]               = @authors.map {|e| { name: e['display_name']} }
 
       record_as_hash[:year] = @pub_info['pubyear']
       record_as_hash[:date] = @pub_info['sortdate']
 
-      record_as_hash[:authorcount] = @authors.count
+      record_as_hash[:authorcount]      = @authors.count
 
       record_as_hash[:documenttypes_sw] = @doctypes
 
@@ -95,10 +92,10 @@ module WebOfScience
       #record_as_hash[:type] = sul_document_type
 
       record_as_hash[:publisher] = publishers.map{|e| e['display_name']}
-      record_as_hash[:city] = publishers.map{|e| e['address']['city']} ## Something is not right with the addresses field, need to be double checked
+      record_as_hash[:city]      = publishers.map{|e| e['address']['city']} ## Something is not right with the addresses field, need to be double checked
       #record_as_hash[:stateprovince] = publication.xpath('CopyrightStateProvince').text unless publication.xpath('CopyrightStateProvince').blank?
       #record_as_hash[:country] = publication.xpath('CopyrightCountry').text unless publication.xpath('CopyrightCountry').blank?
-      record_as_hash[:pages] = @pub_info['page']['begin'] + '-' + @pub_info['page']['end']
+      record_as_hash[:pages]     = @pub_info['page']['begin'] + '-' + @pub_info['page']['end']
 
       record_as_hash
 

--- a/lib/web_of_science/wos_extractor.rb
+++ b/lib/web_of_science/wos_extractor.rb
@@ -1,0 +1,137 @@
+module WebOfScience
+
+
+  class WosExtractor
+
+
+    # @return identifiers [Hash<String => String>]
+
+    def extract_identifiers(doc)
+      ids = doc.search('dynamic_data/cluster_related/identifiers/identifier')
+      ids = ids.map { |id| [id['type'], id['value']] }.to_h
+      ids['WosUID'] = extract_uid(doc)
+      ids['WosItemID'] = extract_wos_item_id(ids['WosUID'])
+      ids['pmid'].sub!('MEDLINE:', '') if extract_database(ids['WosUID']) == 'MEDLINE'
+      ids
+    end
+
+    # @return [String|nil]
+    def extract_doi(identifiers)
+      identifiers['doi']
+    end
+
+    # @return [String|nil]
+    def extract_pmid(identifiers)
+      identifiers['pmid']
+    end
+
+    # @return [String|nil]
+    def extract_issn(identifiers)
+      identifiers['issn']
+    end
+
+    # @return uid [String] the UID
+    def extract_uid(doc)
+      doc.search('UID').text
+    end
+
+    # Extract the {WOS_ITEM_ID} from a WOS-UID in the form {DB_PREFIX}:{WOS_ITEM_ID}
+    # @return [String]
+    def extract_wos_item_id(uid)
+      uid.split(':').last
+    end
+
+    # Extract the {DB_PREFIX} from a WOS-UID in the form {DB_PREFIX}:{WOS_ITEM_ID}
+    # @return [String|nil]
+    def extract_database(uid)
+      uid_split = uid.split(':')
+      uid_split.length > 1 ? uid_split[0] : nil
+    end
+
+
+    # @return names [Array<Hash<String => String>>]
+    def extract_names(doc)
+      names = doc.search('static_data/summary/names/name').map do |name|
+        attributes_with_children_hash(name)
+      end
+      names.sort { |name| name['seq_no'].to_i }
+    end
+
+    # @return authors [Array<Hash<String => String>>]
+    def extract_authors(names)
+      names.select { |name| name['role'] == 'author' }
+    end
+
+    # @return abstracts [Array<Hash<String => String>>]
+    def extract_abstracts(doc)
+      doc.search('static_data/fullrecord_metadata/abstracts/abstract/abstract_text').map{|e| e.text}
+    end
+
+    # @return doctypes [Array<String>]
+    def extract_doctypes(doc)
+      doc.search('static_data/summary/doctypes/doctype').map(&:text)
+    end
+
+    # @return pub_info [Hash<String => String>]
+    def extract_pub_info(doc)
+      info = doc.at('static_data/summary/pub_info')
+      fields = attributes_map(info)
+      fields += info.children.map do |child|
+        [child.name, attributes_map(child).to_h ]
+      end
+      fields.to_h
+    end
+
+    # @return publishers [Array<Hash>]
+    def extract_publishers(doc)
+      publishers = doc.search('static_data/summary/publishers/publisher').map do |publisher|
+        # parse the publisher address(es)
+        addresses = publisher.search('address_spec').map do |address|
+          attributes_with_children_hash(address)
+        end
+        addresses.sort! { |a| a['addr_no'].to_i }
+        # parse the publisher name(s)
+        names = publisher.search('names/name').map do |name|
+          attributes_with_children_hash(name)
+        end
+        # associate each publisher name with it's address by 'addr_no'
+        names.each do |name|
+          address = addresses.find { |addr| addr['addr_no'] == name['addr_no'] }
+          name['address'] = address
+        end
+        names.sort { |name| name['seq_no'].to_i }
+      end
+      publishers.flatten
+    end
+
+    # @return titles [Hash<String => String>]
+    def extract_titles(doc)
+      titles = doc.search('static_data/summary/titles/title')
+      titles.map { |title| [title['type'], title.text] }.to_h
+    end
+
+
+    private
+
+
+      XML_OPTIONS = Nokogiri::XML::Node::SaveOptions::AS_XML | Nokogiri::XML::Node::SaveOptions::NO_DECLARATION
+
+      # @param element [Nokogiri::XML::Element]
+      # @return attributes [Array<Array[String, String]>]
+      def attributes_map(element)
+        element.attributes.map { |name, att| [name, att.value] }
+      end
+
+      # @param element [Nokogiri::XML::Element]
+      # @return fields [Hash]
+      def attributes_with_children_hash(element)
+        fields = attributes_map(element)
+        fields += element.children.map { |c| [c.name, c.text] }
+        fields.to_h
+      end
+
+
+  end
+
+end
+

--- a/spec/lib/web_of_science/record_spec.rb
+++ b/spec/lib/web_of_science/record_spec.rb
@@ -224,56 +224,6 @@ describe WebOfScience::Record do
     end
   end
 
-=begin
-  describe '#summary' do
-    let(:summary) { wos_record_encoded.summary }
-
-    it 'works' do
-      expect(summary).to be_an Hash
-    end
-    it 'contains doctypes Array' do
-      expect(summary['doctypes']).to be_an Array
-    end
-    it 'contains names Array' do
-      expect(summary['names']).to be_an Array
-    end
-    it 'contains pub_info Hash' do
-      expect(summary['pub_info']).to be_an Hash
-    end
-    it 'contains publishers Array' do
-      expect(summary['publishers']).to be_an Array
-    end
-    it 'contains titles Hash' do
-      expect(summary['titles']).to be_an Hash
-    end
-  end
-=end
-=begin
-
-  describe '#summary_struct' do
-    let(:summary) { wos_record_encoded.summary_struct }
-
-    it 'works' do
-      expect(summary).to be_an OpenStruct
-    end
-    it 'contains doctypes Array' do
-      expect(summary.doctypes).to be_an Array
-    end
-    it 'contains names Array' do
-      expect(summary.names).to be_an Array
-    end
-    it 'contains pub_info OpenStruct' do
-      expect(summary.pub_info).to be_an OpenStruct
-    end
-    it 'contains publishers Array' do
-      expect(summary.publishers).to be_an Array
-    end
-    it 'contains titles OpenStruct' do
-      expect(summary.titles).to be_an OpenStruct
-    end
-  end
-=end
-
   describe '#titles' do
     it 'works' do
       result = wos_record_encoded.titles
@@ -281,31 +231,6 @@ describe WebOfScience::Record do
     end
   end
 
-=begin
-  describe '#to_h' do
-    let(:hash) { wos_record_encoded.to_h }
-
-    it 'works' do
-      expect(hash).to be_an Hash
-    end
-    it 'contains summary fields' do
-      expect(hash['summary']).to eq wos_record_encoded.summary
-    end
-  end
-=end
-
-=begin
-  describe '#to_struct' do
-    let(:struct) { wos_record_encoded.to_struct }
-
-    it 'works' do
-      expect(struct).to be_an OpenStruct
-    end
-    it 'contains summary fields' do
-      expect(struct.summary).to be_an OpenStruct
-    end
-  end
-=end
 
   describe '#uid' do
     it 'WOS records have a WOS-UID' do

--- a/spec/lib/web_of_science/record_spec.rb
+++ b/spec/lib/web_of_science/record_spec.rb
@@ -224,6 +224,7 @@ describe WebOfScience::Record do
     end
   end
 
+=begin
   describe '#summary' do
     let(:summary) { wos_record_encoded.summary }
 
@@ -246,6 +247,8 @@ describe WebOfScience::Record do
       expect(summary['titles']).to be_an Hash
     end
   end
+=end
+=begin
 
   describe '#summary_struct' do
     let(:summary) { wos_record_encoded.summary_struct }
@@ -269,6 +272,7 @@ describe WebOfScience::Record do
       expect(summary.titles).to be_an OpenStruct
     end
   end
+=end
 
   describe '#titles' do
     it 'works' do
@@ -277,6 +281,7 @@ describe WebOfScience::Record do
     end
   end
 
+=begin
   describe '#to_h' do
     let(:hash) { wos_record_encoded.to_h }
 
@@ -287,7 +292,9 @@ describe WebOfScience::Record do
       expect(hash['summary']).to eq wos_record_encoded.summary
     end
   end
+=end
 
+=begin
   describe '#to_struct' do
     let(:struct) { wos_record_encoded.to_struct }
 
@@ -298,6 +305,7 @@ describe WebOfScience::Record do
       expect(struct.summary).to be_an OpenStruct
     end
   end
+=end
 
   describe '#uid' do
     it 'WOS records have a WOS-UID' do


### PR DESCRIPTION
#368
-Refactored Record toward the SRP pattern by moving out all the logic of WOS XML Document information extraction, in its own class named Wos_Extractor.

-Record now simply act as a the pure data type that it is, that is a Record. It provide methods to access the Record relevant information and the toPubHash Method to get a PubHash from it. Ideally that function should be moved in the consumer of the Record. The record can't know all its consumer in advance and provide a method for each. But a consumer as the PubHash class knows what it can be initialized from. Hence a class method in PubHash such that PubHash.fromRecord(record) that would instantiate the PubHash would be preferable. 

-As of now we extract 90% of what is required. In comment are the contentious element that are missing. The other fiels missing are the 2 PubMed fields that can be extracted when the Record is a Medline Record. This can be determine by the Database field.

Mapping can be found here https://github.com/sul-dlss/sul_pub/wiki/WOS-to-Pub_hash-Mapping