### PR TITLE
Avoid reloading twice

### DIFF
--- a/script/publication_identifier_normalization.rb
+++ b/script/publication_identifier_normalization.rb
@@ -25,7 +25,6 @@ class PublicationIdentifierNormalization
 
   # @param pub [Publication] the Publication associated with a PublicationIdentifier
   def pub_hash_update(pub)
-    pub.publication_identifiers.reload # force a reload
     pub.add_all_identifiers_in_db_to_pub_hash
     pub.save!
   rescue => e


### PR DESCRIPTION
The first thing `add_all_identifiers_in_db_to_pub_hash` does is:
```
publication_identifiers.reload if persisted?
```

Since this script only runs on persisted objects, that means it will do the same reload every time anyway.