### PR TITLE
WebOfScience::Record#pub_hash

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ gem 'pry-rails'
 gem 'pubmed_search'
 gem 'savon', '~> 2.11'
 gem 'simple_form'
+gem 'StreetAddress', '~> 1.0', '>= 1.0.6'
 gem 'turnout'
 gem 'whenever', require: false
 gem 'yaml_db'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    StreetAddress (1.0.6)
     actionmailer (4.2.10)
       actionpack (= 4.2.10)
       actionview (= 4.2.10)
@@ -459,6 +460,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  StreetAddress (~> 1.0, >= 1.0.6)
   activerecord-import
   bibtex-ruby
   bio

--- a/lib/web_of_science/map_abstract.rb
+++ b/lib/web_of_science/map_abstract.rb
@@ -1,0 +1,44 @@
+module WebOfScience
+
+  # Map WOS record abstract data into the SUL PubHash data
+  class MapAbstract < Mapper
+
+    # @return [Array<String>]
+    def abstracts
+      # Note: rec.doc.xpath(nil).map(&:text) => []
+      @abstracts ||= rec.doc.xpath(path).map(&:text)
+    end
+
+    private
+
+      # publication abstract details
+      # @return [Hash]
+      def mapper
+        return {} if abstracts.empty?
+        @abstract ||= begin
+          # Often there is only one abstract; if there is more than one,
+          # assume the first abstract is the most useful abstract.
+          abstract = abstracts.first
+          case rec.database
+          when 'MEDLINE'
+            { abstract: abstract }
+          else
+            { abstract_restricted: abstract }
+          end
+        end
+      end
+
+      # The XPath for abstracts data from any WOK database record
+      # @return [String, nil]
+      def path
+        case rec.database
+        when 'MEDLINE', 'WOS'
+          '/REC/static_data/fullrecord_metadata/abstracts/abstract/abstract_text'
+        else
+          rec.logger.error("Unknown WOK database: #{rec.database}")
+          nil
+        end
+      end
+
+  end
+end

--- a/lib/web_of_science/map_citation.rb
+++ b/lib/web_of_science/map_citation.rb
@@ -1,0 +1,54 @@
+module WebOfScience
+
+  # Map WOS record citation data into the SUL PubHash data
+  class MapCitation < Mapper
+
+    private
+
+      # publication citation details
+      # @return [Hash]
+      def mapper
+        @citation ||= begin
+          c = {}
+          c[:year] = rec.pub_info['pubyear']
+          c[:date] = rec.pub_info['sortdate']
+          c[:pages] = pages if pages.present?
+          c[:title] = rec.titles['item']
+          c[:journal] = journal
+          c
+        end
+      end
+
+      # Journal information
+      # @return [Hash]
+      def journal
+        j = {}
+        j[:name] = rec.titles['source'] if rec.titles['source'].present?
+        j[:volume] = rec.pub_info['vol'] if rec.pub_info['vol'].present?
+        j[:issue] = rec.pub_info['issue'] if rec.pub_info['issue'].present?
+        j[:pages] = pages if pages.present?
+        issn = journal_identifier
+        j[:identifier] = issn if issn.present?
+        j
+      end
+
+      # Journal EISSN or ISSN
+      # @return [Hash]
+      def journal_identifier
+        issn  = rec.identifiers.pub_hash.find { |id| id[:type] == 'issn' }
+        eissn = rec.identifiers.pub_hash.find { |id| id[:type] == 'eissn' }
+        issn || eissn
+      end
+
+      # @return [String]
+      def pages
+        @pages ||= begin
+          page = rec.pub_info['page']
+          return if page.blank?
+          fst = page['begin'].to_s.strip
+          lst = page['end'].to_s.strip
+          fst == lst ? fst : [fst, lst].select(&:present?).join('-')
+        end
+      end
+  end
+end

--- a/lib/web_of_science/map_names.rb
+++ b/lib/web_of_science/map_names.rb
@@ -1,0 +1,41 @@
+module WebOfScience
+
+  # Map WOS record data into the SUL PubHash data
+  class MapNames < Mapper
+
+    private
+
+      # publication authors
+      # @return [Hash]
+      def mapper
+        # - use names, with role, to include 'author' and other roles, possibly 'editor' also
+        # - the PubHash class has methods to separate them when creating citations
+        @names ||= {
+          author: names,
+          authorcount: rec.authors.count
+        }
+      end
+
+      # Parse the WOS names and return a Hash compatible with Csl::AuthorName
+      # @return [Hash]
+      def names
+        rec.names.map do |name|
+          name = name.slice('first_name', 'middle_name', 'last_name', 'full_name', 'role').symbolize_keys
+          match = name[:first_name].to_s.match(/\A([A-Z])([A-Z])/)
+          if match
+            # first_name is the initials, with first and middle initials combined
+            name[:first_name] = match[1]
+            name[:middle_name] ||= match[2]
+          end
+          name
+        end
+        # MEDLINE data might have a different form, e.g.
+        # <name display='Y' role='author' seq_no='2'>
+        #   <display_name>Altman, Russ B</display_name>
+        #   <full_name>Altman, Russ B</full_name>
+        #   <initials>RB</initials>
+        # </name>
+      end
+
+  end
+end

--- a/lib/web_of_science/map_pub_hash.rb
+++ b/lib/web_of_science/map_pub_hash.rb
@@ -30,10 +30,7 @@ module WebOfScience
 
       # publication agents
       def pub_hash_agents
-        # - use names, with role, to include 'author' and other roles, possibly 'editor' also
-        # - the PubHash class has methods to separate them when creating citations
-        pub[:author] = pub_hash_names
-        pub[:authorcount] = rec.authors.count
+        pub.update WebOfScience::MapNames.new(rec).pub_hash
         pub.update rec.publisher.pub_hash
       end
 
@@ -65,27 +62,6 @@ module WebOfScience
         pub[:wos_uid] = rec.uid
         pub[:wos_item_id] = rec.wos_item_id if rec.wos_item_id.present?
         pub[:identifier] = rec.identifiers.pub_hash
-      end
-
-      # Parse the WOS names and return a Hash compatible with Csl::AuthorName
-      # @return [Hash]
-      def pub_hash_names
-        rec.names.map do |name|
-          name = name.slice('first_name', 'middle_name', 'last_name', 'full_name', 'role').symbolize_keys
-          match = name[:first_name].to_s.match(/\A([A-Z])([A-Z])/)
-          if match
-            # first_name is the initials, with first and middle initials combined
-            name[:first_name] = match[1]
-            name[:middle_name] ||= match[2]
-          end
-          name
-        end
-        # MEDLINE data might have a different form, e.g.
-        # <name display='Y' role='author' seq_no='2'>
-        #   <display_name>Altman, Russ B</display_name>
-        #   <full_name>Altman, Russ B</full_name>
-        #   <initials>RB</initials>
-        # </name>
       end
 
   end

--- a/lib/web_of_science/map_pub_hash.rb
+++ b/lib/web_of_science/map_pub_hash.rb
@@ -1,0 +1,217 @@
+require 'street_address'
+
+module WebOfScience
+
+  # Map WOS record data into the SUL PubHash data
+  class MapPubHash < Mapper
+
+    private
+
+      attr_reader :pub
+
+      # Map WOS record data into the SUL PubHash data
+      # @return [Hash]
+      def mapper
+        @pub || begin
+          @pub = {}
+          pub_hash_abstract
+          pub_hash_agents
+          pub_hash_citation
+          pub_hash_doctypes
+          pub_hash_identifiers
+          pub
+        end
+      end
+
+      # publication abstract
+      def pub_hash_abstract
+        # TODO
+        # binding.pry
+        # pub[:abstract_restricted] = abstracts #yes there might be multiple abstracts
+      end
+
+      # publication agents
+      def pub_hash_agents
+        # - use names, with role, to include 'author' and other roles, possibly 'editor' also
+        # - the PubHash class has methods to separate them when creating citations
+        pub[:author] = pub_hash_names
+        pub[:authorcount] = rec.authors.count
+        pub_hash_publisher
+      end
+
+      # publication citation details
+      def pub_hash_citation
+        pub[:year] = rec.pub_info['pubyear']
+        pub[:date] = rec.pub_info['sortdate']
+        pub[:pages] = pub_hash_pages if pub_hash_pages.present?
+        pub[:title] = rec.titles['item']
+        pub[:journal] = pub_hash_journal
+      end
+
+      # publication document types and categories
+      def pub_hash_doctypes
+        # binding.pry
+
+        # Notes for book reviews that are journal articles
+        #
+        # publication_id: 331355,
+        #   identifier_type: "WoSItemID",
+        #   identifier_value: "000244272600114",
+        #   identifier_uri: "https://ws.isiknowledge.com/cps/openurl/service?url_ver=Z39.88-2004&rft_id=info:ut/000244272600114",
+        # :sw_id=>"52846721",
+        # :issn=>"0002-8762",
+        #
+        # :documenttypes_sw=>["Book Review"],
+        # :type=>"article",
+
+        # Example MEDLINE record has "normalized_doctypes"
+        #   <fullrecord_metadata>
+        #     <normalized_doctypes count='2'>
+        #       <doctype>Other</doctype>
+        #       <doctype>Article</doctype>
+        #     </normalized_doctypes>
+
+        #[doctypes, [pub_info['pubtype']]].flatten
+        types = rec.doctypes
+        types << rec.pub_info['pubtype'] if rec.pub_info['pubtype'].present?
+        pub[:documenttypes_sw] = types
+        pub[:documentcategory_sw] = rec.pub_info['pubtype']
+        pub[:type] = case rec.pub_info['pubtype']
+                     when /conference/i
+                       Settings.sul_doc_types.inproceedings
+                     else
+                       Settings.sul_doc_types.article
+                     end
+      end
+
+      # publication identifiers
+      def pub_hash_identifiers
+        pub[:provenance] = Settings.wos_source
+        pub[:doi] = rec.doi if rec.doi.present?
+        pub[:eissn] = rec.eissn if rec.eissn.present?
+        pub[:issn] = rec.issn if rec.issn.present?
+        pub[:pmid] = rec.pmid if rec.pmid.present?
+        pub[:wos_uid] = rec.uid
+        pub[:wos_item_id] = rec.wos_item_id if rec.wos_item_id.present?
+        pub[:identifier] = rec.identifiers.pub_hash
+      end
+
+      # Journal information
+      # @return [Hash]
+      def pub_hash_journal
+        identifier = rec.identifiers.pub_hash.select { |id| id['type'] == 'issn' }
+        h = {}
+        h[:name] = rec.titles['source'] if rec.titles['source'].present?
+        h[:volume] = rec.pub_info['vol'] if rec.pub_info['vol'].present?
+        h[:issue] = rec.pub_info['issue'] if rec.pub_info['issue'].present?
+        h[:pages] = pub_hash_pages if pub_hash_pages.present?
+        h[:identifier] = identifier if identifier.present?
+        h
+      end
+
+      # Parse the WOS names and return a Hash compatible with Csl::AuthorName
+      # @return [Hash]
+      def pub_hash_names
+        rec.names.map do |name|
+          name = name.slice('first_name', 'middle_name', 'last_name', 'full_name', 'role').symbolize_keys
+          match = name[:first_name].to_s.match(/\A([A-Z])([A-Z])/)
+          if match
+            # first_name is the initials, with first and middle initials combined
+            name[:first_name] = match[1]
+            name[:middle_name] ||= match[2]
+          end
+          name
+        end
+        # MEDLINE data might have a different form, e.g.
+        # <name display='Y' role='author' seq_no='2'>
+        #   <display_name>Altman, Russ B</display_name>
+        #   <full_name>Altman, Russ B</full_name>
+        #   <initials>RB</initials>
+        # </name>
+      end
+
+      # @return [String]
+      def pub_hash_pages
+        @pub_hash_pages ||= begin
+          page = rec.pub_info['page']
+          return if page.blank?
+          fst = page['begin']
+          lst = page['end']
+          fst == lst ? fst : [fst, lst].join('-')
+        end
+      end
+
+      # Extract publisher information into these fields:
+      # :publisher=>"OXFORD UNIV PRESS"
+      # :city=>"OXFORD"
+      # :stateprovince=>""
+      # :country=>"UNITED KINGDOM"
+      def pub_hash_publisher
+        return if rec.publishers.blank?
+        # The WOS record allows for multiple publishers, for some reason, but journals usually have only one
+        # publisher and our other data sources only provide one publisher; so choose the first one here.
+        publisher = rec.publishers.first
+        pub[:publisher] = publisher['full_name']
+        publisher_address(publisher['address'])
+      end
+
+      # Useful snippet to see a bunch of addresses
+      # altman_records = WOS.queries.search_by_name('Altman, Russ, B', ['Stanford University']);
+      # addresses = altman_records.map {|rec| rec.publishers.blank? ? {} : rec.publishers.first['address'] }
+      # To see non-USA addresses
+      # addresses.reject {|add| add['full_address'] =~ /USA/ }
+
+      # @param address [Hash]
+      def publisher_address(address)
+        return if address.blank?
+        # The city is provided by WOS
+        pub[:city] = address['city']
+        # The rest is a parsing game
+        full_address = address['full_address']
+        publisher_state(full_address)
+        publisher_country(full_address)
+      end
+
+      def medline_country
+        return false unless rec.database == 'MEDLINE'
+        country = rec.doc.xpath('/REC/static_data/item/MedlineJournalInfo/Country')
+        pub[:country] = country.text if country.present?
+        country.present?
+      end
+
+      # Extract a state from "{state} {zip} [{country}]"
+      def publisher_country(full_address)
+        return if medline_country
+        return if usa_address(full_address)
+        # This could be a US address that did not parse or it is an international address.
+        # A best guess at the country comes from the last CSV element:
+        country = full_address.split(',').last.to_s.strip
+        if country.end_with?('USA')
+          pub[:country] = 'USA'
+        elsif country.present?
+          pub[:country] = country #unless country =~ /[0-9]*/
+        end
+      end
+
+      # Extract a state from "{state} {zip} [{country}]"
+      def publisher_state(full_address)
+        return if usa_address(full_address)
+        # Some US addresses escape the StreetAddress parser.
+        # Most often, the state acronym is in the last CSV element.
+        state = full_address.split(',').last.to_s.strip
+        matches = state.match(/([A-Z]{2})\s+([0-9-]*)/)
+        pub[:stateprovince] = matches[1] if matches.present?
+      end
+
+      # Extract the state and country from a US address
+      def usa_address(full_address)
+        @usa_address ||= StreetAddress::US.parse(full_address)
+        return false if @usa_address.blank?
+        # This is a US address
+        pub[:stateprovince] = @usa_address.state
+        pub[:country] = 'USA'
+        true
+      end
+
+  end
+end

--- a/lib/web_of_science/map_pub_hash.rb
+++ b/lib/web_of_science/map_pub_hash.rb
@@ -23,9 +23,7 @@ module WebOfScience
 
       # publication abstract
       def pub_hash_abstract
-        # TODO
-        # binding.pry
-        # pub[:abstract_restricted] = abstracts #yes there might be multiple abstracts
+        pub.update rec.abstract_mapper.pub_hash
       end
 
       # publication agents

--- a/lib/web_of_science/map_pub_hash.rb
+++ b/lib/web_of_science/map_pub_hash.rb
@@ -39,11 +39,7 @@ module WebOfScience
 
       # publication citation details
       def pub_hash_citation
-        pub[:year] = rec.pub_info['pubyear']
-        pub[:date] = rec.pub_info['sortdate']
-        pub[:pages] = pub_hash_pages if pub_hash_pages.present?
-        pub[:title] = rec.titles['item']
-        pub[:journal] = pub_hash_journal
+        pub.update WebOfScience::MapCitation.new(rec).pub_hash
       end
 
       # publication document types and categories
@@ -94,19 +90,6 @@ module WebOfScience
         pub[:identifier] = rec.identifiers.pub_hash
       end
 
-      # Journal information
-      # @return [Hash]
-      def pub_hash_journal
-        identifier = rec.identifiers.pub_hash.select { |id| id['type'] == 'issn' }
-        h = {}
-        h[:name] = rec.titles['source'] if rec.titles['source'].present?
-        h[:volume] = rec.pub_info['vol'] if rec.pub_info['vol'].present?
-        h[:issue] = rec.pub_info['issue'] if rec.pub_info['issue'].present?
-        h[:pages] = pub_hash_pages if pub_hash_pages.present?
-        h[:identifier] = identifier if identifier.present?
-        h
-      end
-
       # Parse the WOS names and return a Hash compatible with Csl::AuthorName
       # @return [Hash]
       def pub_hash_names
@@ -128,15 +111,5 @@ module WebOfScience
         # </name>
       end
 
-      # @return [String]
-      def pub_hash_pages
-        @pub_hash_pages ||= begin
-          page = rec.pub_info['page']
-          return if page.blank?
-          fst = page['begin']
-          lst = page['end']
-          fst == lst ? fst : [fst, lst].join('-')
-        end
-      end
   end
 end

--- a/lib/web_of_science/map_pub_hash.rb
+++ b/lib/web_of_science/map_pub_hash.rb
@@ -44,30 +44,7 @@ module WebOfScience
 
       # publication document types and categories
       def pub_hash_doctypes
-        # binding.pry
-
-        # Notes for book reviews that are journal articles
-        #
-        # publication_id: 331355,
-        #   identifier_type: "WoSItemID",
-        #   identifier_value: "000244272600114",
-        #   identifier_uri: "https://ws.isiknowledge.com/cps/openurl/service?url_ver=Z39.88-2004&rft_id=info:ut/000244272600114",
-        # :sw_id=>"52846721",
-        # :issn=>"0002-8762",
-        #
-        # :documenttypes_sw=>["Book Review"],
-        # :type=>"article",
-
-        # Example MEDLINE record has "normalized_doctypes"
-        #   <fullrecord_metadata>
-        #     <normalized_doctypes count='2'>
-        #       <doctype>Other</doctype>
-        #       <doctype>Article</doctype>
-        #     </normalized_doctypes>
-
-        #[doctypes, [pub_info['pubtype']]].flatten
-        types = rec.doctypes
-        types << rec.pub_info['pubtype'] if rec.pub_info['pubtype'].present?
+        types = [rec.doctypes, rec.pub_info['pubtype']].flatten.compact
         pub[:documenttypes_sw] = types
         pub[:documentcategory_sw] = rec.pub_info['pubtype']
         pub[:type] = case rec.pub_info['pubtype']

--- a/lib/web_of_science/map_publisher.rb
+++ b/lib/web_of_science/map_publisher.rb
@@ -1,0 +1,118 @@
+require 'street_address'
+
+module WebOfScience
+
+  # WOS publisher information
+  class MapPublisher < Mapper
+
+    # @return publishers [Array<Hash>]
+    def publishers
+      @publishers ||= begin
+        publishers = rec.doc.search('static_data/summary/publishers/publisher').map do |publisher|
+          # parse the publisher address(es)
+          addresses = publisher.search('address_spec').map do |address|
+            WebOfScience::XmlParser.attributes_with_children_hash(address)
+          end
+          addresses.sort! { |a| a['addr_no'].to_i }
+          # parse the publisher name(s)
+          names = publisher.search('names/name').map do |name|
+            WebOfScience::XmlParser.attributes_with_children_hash(name)
+          end
+          # associate each publisher name with it's address by 'addr_no'
+          names.each do |name|
+            address = addresses.find { |addr| addr['addr_no'] == name['addr_no'] }
+            name['address'] = address
+          end
+          names.sort { |name| name['seq_no'].to_i }
+        end
+        publishers.flatten
+      end
+    end
+
+    private
+
+      attr_reader :pub
+
+      # Map WOS publisher data into the SUL PubHash data
+      def mapper
+        @pub || begin
+          @pub = {}
+          pub_hash_publisher
+          pub
+        end
+      end
+
+      # Extract publisher information into these fields:
+      # :publisher=>"OXFORD UNIV PRESS"
+      # :city=>"OXFORD"
+      # :stateprovince=>""
+      # :country=>"UNITED KINGDOM"
+      def pub_hash_publisher
+        return if publishers.blank?
+        # The WOS record allows for multiple publishers, for some reason, but journals usually have only one
+        # publisher and our other data sources only provide one publisher; so choose the first one here.
+        publisher = publishers.first
+        pub[:publisher] = publisher['full_name']
+        publisher_address(publisher['address'])
+      end
+
+      # Useful snippet to see a bunch of addresses
+      # altman_records = WOS.queries.search_by_name('Altman, Russ, B', ['Stanford University']);
+      # addresses = altman_records.map {|rec| rec.publishers.blank? ? {} : rec.publishers.first['address'] }
+      # To see non-USA addresses
+      # addresses.reject {|add| add['full_address'] =~ /USA/ }
+
+      # @param address [Hash]
+      def publisher_address(address)
+        return if address.blank?
+        # The city is provided by WOS
+        pub[:city] = address['city']
+        # The rest is a parsing game
+        full_address = address['full_address']
+        publisher_state(full_address)
+        publisher_country(full_address)
+      end
+
+      def medline_country
+        return false unless rec.database == 'MEDLINE'
+        country = rec.doc.xpath('/REC/static_data/item/MedlineJournalInfo/Country')
+        pub[:country] = country.text if country.present?
+        country.present?
+      end
+
+      # Extract a state from "{state} {zip} [{country}]"
+      def publisher_country(full_address)
+        return if medline_country
+        return if usa_address(full_address)
+        # This could be a US address that did not parse or it is an international address.
+        # A best guess at the country comes from the last CSV element:
+        country = full_address.split(',').last.to_s.strip
+        if country.end_with?('USA')
+          pub[:country] = 'USA'
+        elsif country.present?
+          pub[:country] = country #unless country =~ /[0-9]*/
+        end
+      end
+
+      # Extract a state from "{state} {zip} [{country}]"
+      def publisher_state(full_address)
+        return if usa_address(full_address)
+        # Some US addresses escape the StreetAddress parser.
+        # Most often, the state acronym is in the last CSV element.
+        state = full_address.split(',').last.to_s.strip
+        matches = state.match(/([A-Z]{2})\s+([0-9-]*)/)
+        pub[:stateprovince] = matches[1] if matches.present?
+      end
+
+      # Extract the state and country from a US address
+      def usa_address(full_address)
+        @usa_address ||= StreetAddress::US.parse(full_address)
+        return false if @usa_address.blank?
+        # This is a US address
+        pub[:stateprovince] = @usa_address.state
+        pub[:country] = 'USA'
+        true
+      end
+
+  end
+end

--- a/lib/web_of_science/record.rb
+++ b/lib/web_of_science/record.rb
@@ -6,6 +6,8 @@ module WebOfScience
   class Record
     extend Forwardable
 
+    delegate %i(abstracts) => :abstract_mapper
+
     delegate %i(database doi eissn issn pmid uid wos_item_id) => :identifiers
 
     delegate %i(publishers) => :publisher
@@ -17,6 +19,11 @@ module WebOfScience
     # @param encoded_record [String] record in HTML encoding
     def initialize(record: nil, encoded_record: nil)
       @doc = WebOfScience::XmlParser.parse(record, encoded_record)
+    end
+
+    # @return abstract_mapper [WebOfScience::MapAbstract]
+    def abstract_mapper
+      @abstract_mapper ||= WebOfScience::MapAbstract.new(self)
     end
 
     # @return authors [Array<Hash<String => String>>]
@@ -77,6 +84,7 @@ module WebOfScience
     # @return summary [Hash]
     def summary
       @summary ||= {
+        'abstracts' => abstracts,
         'doctypes' => doctypes,
         'names' => names,
         'pub_info' => pub_info,

--- a/lib/web_of_science/record.rb
+++ b/lib/web_of_science/record.rb
@@ -124,6 +124,12 @@ module WebOfScience
       }
     end
 
+    # Map WOS record data into the SUL PubHash data
+    # @return [Hash]
+    def pub_hash
+      @pub_hash ||= WebOfScience::MapPubHash.new(self).pub_hash
+    end
+
     # An OpenStruct for the REC fields
     # @return [OpenStruct]
     def to_struct

--- a/spec/fixtures/wos_client/wos_record_000268565100019.xml
+++ b/spec/fixtures/wos_client/wos_record_000268565100019.xml
@@ -1,0 +1,311 @@
+<?xml version='1.0'?>
+<REC r_id_disclaimer='ResearcherID data provided by Clarivate Analytics'>
+  <UID>WOS:000268565100019</UID>
+  <static_data>
+    <summary>
+      <EWUID>
+        <WUID coll_id='WOS'/>
+        <edition value='WOS.SCI'/>
+      </EWUID>
+      <pub_info coverdate='AUG 2009' has_abstract='Y' issue='2' pubmonth='AUG' pubtype='Journal' pubyear='2009' sortdate='2009-08-01' vol='86'>
+        <page begin='183' end='189' page_count='7'>183-189</page>
+      </pub_info>
+      <titles count='6'>
+        <title type='source'>CLINICAL PHARMACOLOGY &amp; THERAPEUTICS</title>
+        <title type='source_abbrev'>CLIN PHARMACOL THER</title>
+        <title type='abbrev_iso'>Clin. Pharmacol. Ther.</title>
+        <title type='abbrev_11'>CLIN PHARM</title>
+        <title type='abbrev_29'>CLIN PHARMACOL THER</title>
+        <title type='item'>Generating Genome-Scale Candidate Gene Lists for Pharmacogenomics</title>
+      </titles>
+      <names count='3'>
+        <name daisng_id='13886131' seq_no='1' addr_no='1 3' role='author'>
+          <display_name>Hansen, N. T.</display_name>
+          <full_name>Hansen, N. T.</full_name>
+          <wos_standard>Hansen, NT</wos_standard>
+          <first_name>N. T.</first_name>
+          <last_name>Hansen</last_name>
+        </name>
+        <name daisng_id='1001211729' seq_no='2' addr_no='3' role='author'>
+          <display_name>Brunak, S.</display_name>
+          <full_name>Brunak, S.</full_name>
+          <wos_standard>Brunak, S</wos_standard>
+          <first_name>S.</first_name>
+          <last_name>Brunak</last_name>
+        </name>
+        <name daisng_id='745091' seq_no='3' addr_no='1 2' dais_id='10190039' reprint='Y' role='author'>
+          <display_name>Altman, R. B.</display_name>
+          <full_name>Altman, R. B.</full_name>
+          <wos_standard>Altman, RB</wos_standard>
+          <first_name>R. B.</first_name>
+          <last_name>Altman</last_name>
+          <email_addr>russ.altman@stanford.edu</email_addr>
+        </name>
+      </names>
+      <doctypes count='1'>
+        <doctype>Article</doctype>
+      </doctypes>
+      <publishers>
+        <publisher>
+          <address_spec addr_no='1'>
+            <full_address>75 VARICK ST, 9TH FLR, NEW YORK, NY 10013-1917 USA</full_address>
+            <city>NEW YORK</city>
+          </address_spec>
+          <names count='1'>
+            <name addr_no='1' role='publisher' seq_no='1'>
+              <display_name>NATURE PUBLISHING GROUP</display_name>
+              <full_name>NATURE PUBLISHING GROUP</full_name>
+            </name>
+          </names>
+        </publisher>
+      </publishers>
+    </summary>
+    <fullrecord_metadata>
+      <languages count='1'>
+        <language type='primary'>English</language>
+      </languages>
+      <normalized_languages count='1'>
+        <language type='primary'>English</language>
+      </normalized_languages>
+      <normalized_doctypes count='1'>
+        <doctype>Article</doctype>
+      </normalized_doctypes>
+      <refs count='31'/>
+      <addresses count='3'>
+        <address_name>
+          <address_spec addr_no='1'>
+            <full_address>Stanford Univ, Dept Bioengn, Stanford, CA 94305 USA</full_address>
+            <organizations count='2'>
+              <organization>Stanford Univ</organization>
+              <organization pref='Y'>Stanford University</organization>
+            </organizations>
+            <suborganizations count='1'>
+              <suborganization>Dept Bioengn</suborganization>
+            </suborganizations>
+            <city>Stanford</city>
+            <state>CA</state>
+            <country>USA</country>
+            <zip location='AP'>94305</zip>
+          </address_spec>
+          <names count='2'>
+            <name daisng_id='13886131' seq_no='1' addr_no='1' role='author'>
+              <display_name>Hansen, N. T.</display_name>
+              <full_name>Hansen, N. T.</full_name>
+              <wos_standard>Hansen, NT</wos_standard>
+              <first_name>N. T.</first_name>
+              <last_name>Hansen</last_name>
+            </name>
+            <name daisng_id='745091' seq_no='3' addr_no='1' dais_id='10190039' reprint='Y' role='author'>
+              <display_name>Altman, R. B.</display_name>
+              <full_name>Altman, R. B.</full_name>
+              <wos_standard>Altman, RB</wos_standard>
+              <first_name>R. B.</first_name>
+              <last_name>Altman</last_name>
+              <email_addr>russ.altman@stanford.edu</email_addr>
+            </name>
+          </names>
+        </address_name>
+        <address_name>
+          <address_spec addr_no='2'>
+            <full_address>Stanford Univ, Dept Genet, Stanford, CA 94305 USA</full_address>
+            <organizations count='2'>
+              <organization>Stanford Univ</organization>
+              <organization pref='Y'>Stanford University</organization>
+            </organizations>
+            <suborganizations count='1'>
+              <suborganization>Dept Genet</suborganization>
+            </suborganizations>
+            <city>Stanford</city>
+            <state>CA</state>
+            <country>USA</country>
+            <zip location='AP'>94305</zip>
+          </address_spec>
+          <names count='1'>
+            <name daisng_id='745091' seq_no='3' addr_no='2' dais_id='10190039' reprint='Y' role='author'>
+              <display_name>Altman, R. B.</display_name>
+              <full_name>Altman, R. B.</full_name>
+              <wos_standard>Altman, RB</wos_standard>
+              <first_name>R. B.</first_name>
+              <last_name>Altman</last_name>
+              <email_addr>russ.altman@stanford.edu</email_addr>
+            </name>
+          </names>
+        </address_name>
+        <address_name>
+          <address_spec addr_no='3'>
+            <full_address>Tech Univ Denmark, Ctr Biol Sequence Anal, DK-2800 Lyngby, Denmark</full_address>
+            <organizations count='2'>
+              <organization>Tech Univ Denmark</organization>
+              <organization pref='Y'>Technical University of Denmark</organization>
+            </organizations>
+            <suborganizations count='1'>
+              <suborganization>Ctr Biol Sequence Anal</suborganization>
+            </suborganizations>
+            <city>Lyngby</city>
+            <country>Denmark</country>
+            <zip location='BC'>DK-2800</zip>
+          </address_spec>
+          <names count='2'>
+            <name daisng_id='13886131' seq_no='1' addr_no='3' role='author'>
+              <display_name>Hansen, N. T.</display_name>
+              <full_name>Hansen, N. T.</full_name>
+              <wos_standard>Hansen, NT</wos_standard>
+              <first_name>N. T.</first_name>
+              <last_name>Hansen</last_name>
+            </name>
+            <name daisng_id='1001211729' seq_no='2' addr_no='3' role='author'>
+              <display_name>Brunak, S.</display_name>
+              <full_name>Brunak, S.</full_name>
+              <wos_standard>Brunak, S</wos_standard>
+              <first_name>S.</first_name>
+              <last_name>Brunak</last_name>
+            </name>
+          </names>
+        </address_name>
+      </addresses>
+      <reprint_addresses count='1'>
+        <address_name>
+          <address_spec addr_no='1'>
+            <full_address>Stanford Univ, Dept Bioengn, Stanford, CA 94305 USA</full_address>
+            <organizations count='2'>
+              <organization>Stanford Univ</organization>
+              <organization pref='Y'>Stanford University</organization>
+            </organizations>
+            <suborganizations count='1'>
+              <suborganization>Dept Bioengn</suborganization>
+            </suborganizations>
+            <city>Stanford</city>
+            <state>CA</state>
+            <country>USA</country>
+            <zip location='AP'>94305</zip>
+          </address_spec>
+          <names count='1'>
+            <name addr_no='1' reprint='Y' role='author' seq_no='1'>
+              <display_name>Altman, R. B.</display_name>
+              <full_name>Altman, R. B.</full_name>
+              <wos_standard>Altman, RB</wos_standard>
+              <first_name>R. B.</first_name>
+              <last_name>Altman</last_name>
+              <email_addr>russ.altman@stanford.edu</email_addr>
+            </name>
+          </names>
+        </address_name>
+      </reprint_addresses>
+      <category_info>
+        <headings count='1'>
+          <heading>Science &amp; Technology</heading>
+        </headings>
+        <subheadings count='1'>
+          <subheading>Life Sciences &amp; Biomedicine</subheading>
+        </subheadings>
+        <subjects count='3'>
+          <subject ascatype='traditional' code='TU'>Pharmacology &amp; Pharmacy</subject>
+          <subject ascatype='extended'>Pharmacology &amp; Pharmacy</subject>
+          <subject ascatype='traditional' code='TU'>PHARMACOLOGY &amp; PHARMACY</subject>
+        </subjects>
+      </category_info>
+      <fund_ack>
+        <fund_text>
+          <p>
+            We thank G. Cooper for providing us with genome-wide data for
+            warfarin, M. E. Dolan and A. Stark for data on carboplatin, K. Lage
+            for access to InWeb interactome, R. Whaley for PharmGKB data, and B.
+            Daigle and Y. Garten for their valuable input on the manuscript. We
+            also acknowledge support from the National Institutes of Health
+            (grant GM61374 and LM05652), the National Science Foundation (award
+            CNS-0619926), the Villum Kann Rasmussen Foundation, and the NABIIT
+            (Nanoscience and Technology, Biotechnology and IT) program.
+          </p>
+        </fund_text>
+        <grants count='4'>
+          <grant>
+            <grant_agency>National Institutes of Health</grant_agency>
+            <grant_ids count='2'>
+              <grant_id>GM61374</grant_id>
+              <grant_id>LM05652</grant_id>
+            </grant_ids>
+          </grant>
+          <grant>
+            <grant_agency>National Science Foundation</grant_agency>
+            <grant_ids count='1'>
+              <grant_id>CNS-0619926</grant_id>
+            </grant_ids>
+          </grant>
+          <grant>
+            <grant_agency>Villum Kann Rasmussen Foundation</grant_agency>
+          </grant>
+          <grant>
+            <grant_agency>NABIIT (Nanoscience and Technology, Biotechnology and IT) program</grant_agency>
+          </grant>
+        </grants>
+      </fund_ack>
+      <abstracts count='1'>
+        <abstract>
+          <abstract_text count='1'>
+            <p>
+              A critical task in pharmacogenomics is identifying genes that may
+              be important modulators of drug response. High-throughput
+              experimental methods are often plagued by false positives and do
+              not take advantage of existing knowledge. Candidate gene lists can
+              usefully summarize existing knowledge, but they are expensive to
+              generate manually and may therefore have incomplete coverage. We
+              have developed a method that ranks 12,460 genes in the human
+              genome on the basis of their potential relevance to a specific
+              query drug and its putative indications. Our method uses known
+              gene-drug interactions, networks of gene-gene interactions, and
+              available measures of drug-drug similarity. It ranks genes by
+              building a local network of known interactions and assessing the
+              similarity of the query drug (by both structure and indication)
+              with drugs that interact with gene products in the local network.
+              In a comprehensive benchmark, our method achieves an overall area
+              under the curve of 0.82. To showcase our method, we found novel
+              gene candidates for warfarin, gefitinib, carboplatin, and
+              gemcitabine, and we provide the molecular hypotheses for these
+              predictions.
+            </p>
+          </abstract_text>
+        </abstract>
+      </abstracts>
+    </fullrecord_metadata>
+    <item xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' coll_id='WOS' xsi:type='itemType_wos'>
+      <ids avail='Y'>478CJ</ids>
+      <bib_id>86 (2): 183-189 AUG 2009</bib_id>
+      <bib_pagecount type='Journal'>112</bib_pagecount>
+      <keywords_plus count='10'>
+        <keyword>INTERACTION NETWORKS</keyword>
+        <keyword>WIDE ASSOCIATION</keyword>
+        <keyword>CELL-LINES</keyword>
+        <keyword>WARFARIN</keyword>
+        <keyword>EXPRESSION</keyword>
+        <keyword>VARIANTS</keyword>
+        <keyword>CYTOTOXICITY</keyword>
+        <keyword>GEMCITABINE</keyword>
+        <keyword>CHALLENGES</keyword>
+        <keyword>PROFILES</keyword>
+      </keywords_plus>
+    </item>
+    <contributors count='1'>
+      <contributor>
+        <name orcid_id='0000-0003-0316-5866' role='researcher_id' seq_no='1'>
+          <display_name>Brunak, Soren</display_name>
+          <full_name>Brunak, Soren</full_name>
+          <first_name>Soren</first_name>
+          <last_name>Brunak</last_name>
+        </name>
+      </contributor>
+    </contributors>
+  </static_data>
+  <dynamic_data>
+    <citation_related>
+      <tc_list>
+        <silo_tc coll_id='WOS' local_count='44'/>
+      </tc_list>
+    </citation_related>
+    <cluster_related>
+      <identifiers>
+        <identifier type='issn' value='0009-9236'/>
+        <identifier type='doi' value='10.1038/clpt.2009.42'/>
+      </identifiers>
+    </cluster_related>
+  </dynamic_data>
+</REC>

--- a/spec/lib/web_of_science/map_abstract_spec.rb
+++ b/spec/lib/web_of_science/map_abstract_spec.rb
@@ -1,0 +1,107 @@
+describe WebOfScience::MapAbstract do
+  subject(:mapper) { described_class.new(wos_record) }
+
+  let(:wos_encoded_xml) { File.read('spec/fixtures/wos_client/wos_encoded_record.html') }
+  let(:wos_record) { WebOfScience::Record.new(encoded_record: wos_encoded_xml) }
+
+  let(:medline_encoded_xml) { File.read('spec/fixtures/wos_client/medline_encoded_record.html') }
+  let(:medline_record) { WebOfScience::Record.new(encoded_record: medline_encoded_xml) }
+
+  describe '#new' do
+    it 'works with WOS records' do
+      expect(mapper).to be_an described_class
+    end
+    it 'raises ArgumentError with nil params' do
+      expect { described_class.new }.to raise_error(ArgumentError)
+    end
+    it 'raises ArgumentError with anything other than WebOfScience::Record' do
+      expect { described_class.new('could be xml') }.to raise_error(ArgumentError)
+    end
+  end
+
+  shared_examples 'pub_hash' do
+    it 'works' do
+      expect(pub_hash).to be_an Hash
+    end
+  end
+
+  shared_examples 'abstracts' do
+    it 'works' do
+      expect(mapper.abstracts).not_to be_empty
+    end
+  end
+
+  shared_examples 'no_abstracts' do
+    it 'works' do
+      expect(mapper.abstracts).to be_empty
+    end
+  end
+
+  shared_examples 'abstract' do
+    it 'pub_hash has an abstract_restricted' do
+      expect(pub_hash[:abstract]).not_to be_nil
+    end
+  end
+
+  shared_examples 'no_abstract' do
+    it 'pub_hash has no abstract_restricted' do
+      expect(pub_hash[:abstract]).to be_nil
+    end
+  end
+
+  shared_examples 'abstract_restricted' do
+    it 'pub_hash has an abstract_restricted' do
+      expect(pub_hash[:abstract_restricted]).not_to be_nil
+    end
+  end
+
+  shared_examples 'no_abstract_restricted' do
+    it 'pub_hash has no abstract_restricted' do
+      expect(pub_hash[:abstract_restricted]).to be_nil
+    end
+  end
+
+  context 'WOS record with no abstract' do
+    subject(:mapper) { described_class.new(wos_record) }
+
+    let(:pub_hash) { mapper.pub_hash }
+
+    it 'works with WOS records' do
+      expect(mapper).to be_an described_class
+    end
+    it_behaves_like 'pub_hash'
+    it_behaves_like 'no_abstracts'
+    it_behaves_like 'no_abstract'
+    it_behaves_like 'no_abstract_restricted'
+  end
+
+  context 'WOS record with an abstract' do
+    subject(:mapper) { described_class.new(wos_record) }
+
+    let(:wos_xml) { File.read('spec/fixtures/wos_client/wos_record_000268565100019.xml') }
+    let(:wos_record) { WebOfScience::Record.new(record: wos_xml) }
+    let(:pub_hash) { mapper.pub_hash }
+
+    it 'works with WOS records' do
+      expect(mapper).to be_an described_class
+    end
+    it_behaves_like 'pub_hash'
+    it_behaves_like 'abstracts'
+    it_behaves_like 'no_abstract'
+    it_behaves_like 'abstract_restricted'
+  end
+
+  context 'MEDLINE records' do
+    subject(:mapper) { described_class.new(medline_record) }
+
+    let(:pub_hash) { mapper.pub_hash }
+
+    it 'works with MEDLINE records' do
+      expect(mapper).to be_an described_class
+    end
+    it_behaves_like 'pub_hash'
+    it_behaves_like 'abstracts'
+    it_behaves_like 'abstract'
+    it_behaves_like 'no_abstract_restricted'
+  end
+end

--- a/spec/lib/web_of_science/map_citation_spec.rb
+++ b/spec/lib/web_of_science/map_citation_spec.rb
@@ -1,0 +1,66 @@
+describe WebOfScience::MapCitation do
+  let(:wos_encoded_xml) { File.read('spec/fixtures/wos_client/wos_encoded_record.html') }
+  let(:wos_record) { WebOfScience::Record.new(encoded_record: wos_encoded_xml) }
+
+  let(:medline_encoded_xml) { File.read('spec/fixtures/wos_client/medline_encoded_record.html') }
+  let(:medline_record) { WebOfScience::Record.new(encoded_record: medline_encoded_xml) }
+
+  describe '#new' do
+    it 'works with WOS records' do
+      result = described_class.new(wos_record)
+      expect(result).to be_an described_class
+    end
+    it 'raises ArgumentError with nil params' do
+      expect { described_class.new }.to raise_error(ArgumentError)
+    end
+    it 'raises ArgumentError with anything other than WebOfScience::Record' do
+      expect { described_class.new('could be xml') }.to raise_error(ArgumentError)
+    end
+  end
+
+  shared_examples 'pub_hash' do
+    it 'works' do
+      expect(pub_hash).to be_an Hash
+    end
+  end
+
+  shared_examples 'common_citation_data' do
+    it 'has an year' do
+      expect(pub_hash[:year]).not_to be_nil
+    end
+    it 'has an date' do
+      expect(pub_hash[:date]).not_to be_nil
+    end
+    it 'has an pages' do
+      expect(pub_hash[:pages]).not_to be_nil
+    end
+    it 'has an title' do
+      expect(pub_hash[:title]).not_to be_nil
+    end
+    it 'has an journal' do
+      expect(pub_hash[:journal]).not_to be_nil
+    end
+  end
+
+  context 'WOS records' do
+    let(:pub_hash_class) { described_class.new(wos_record) }
+    let(:pub_hash) { pub_hash_class.pub_hash }
+
+    it 'works with WOS records' do
+      expect(pub_hash_class).to be_an described_class
+    end
+    it_behaves_like 'pub_hash'
+    it_behaves_like 'common_citation_data'
+  end
+
+  context 'MEDLINE records' do
+    let(:pub_hash_class) { described_class.new(medline_record) }
+    let(:pub_hash) { pub_hash_class.pub_hash }
+
+    it 'works with MEDLINE records' do
+      expect(pub_hash_class).to be_an described_class
+    end
+    it_behaves_like 'pub_hash'
+    it_behaves_like 'common_citation_data'
+  end
+end

--- a/spec/lib/web_of_science/map_names_spec.rb
+++ b/spec/lib/web_of_science/map_names_spec.rb
@@ -1,0 +1,57 @@
+describe WebOfScience::MapNames do
+  let(:wos_encoded_xml) { File.read('spec/fixtures/wos_client/wos_encoded_record.html') }
+  let(:wos_record) { WebOfScience::Record.new(encoded_record: wos_encoded_xml) }
+
+  let(:medline_encoded_xml) { File.read('spec/fixtures/wos_client/medline_encoded_record.html') }
+  let(:medline_record) { WebOfScience::Record.new(encoded_record: medline_encoded_xml) }
+
+  describe '#new' do
+    it 'works with WOS records' do
+      result = described_class.new(wos_record)
+      expect(result).to be_an described_class
+    end
+    it 'raises ArgumentError with nil params' do
+      expect { described_class.new }.to raise_error(ArgumentError)
+    end
+    it 'raises ArgumentError with anything other than WebOfScience::Record' do
+      expect { described_class.new('could be xml') }.to raise_error(ArgumentError)
+    end
+  end
+
+  shared_examples 'pub_hash' do
+    it 'works' do
+      expect(pub_hash).to be_an Hash
+    end
+  end
+
+  shared_examples 'contains_author_data' do
+    it 'has an authors' do
+      expect(pub_hash[:author]).not_to be_nil
+    end
+    it 'has an authorcount' do
+      expect(pub_hash[:authorcount]).not_to be_nil
+    end
+  end
+
+  context 'WOS records' do
+    let(:pub_hash_class) { described_class.new(wos_record) }
+    let(:pub_hash) { pub_hash_class.pub_hash }
+
+    it 'works with WOS records' do
+      expect(pub_hash_class).to be_an described_class
+    end
+    it_behaves_like 'pub_hash'
+    it_behaves_like 'contains_author_data'
+  end
+
+  context 'MEDLINE records' do
+    let(:pub_hash_class) { described_class.new(medline_record) }
+    let(:pub_hash) { pub_hash_class.pub_hash }
+
+    it 'works with MEDLINE records' do
+      expect(pub_hash_class).to be_an described_class
+    end
+    it_behaves_like 'pub_hash'
+    it_behaves_like 'contains_author_data'
+  end
+end

--- a/spec/lib/web_of_science/map_pub_hash_spec.rb
+++ b/spec/lib/web_of_science/map_pub_hash_spec.rb
@@ -28,9 +28,6 @@ describe WebOfScience::MapPubHash do
   end
 
   shared_examples 'contains_summary_data' do
-    xit 'has an abstract' do
-      expect(pub_hash[:abstract]).not_to be_nil
-    end
     it 'has an authors' do
       expect(pub_hash[:author]).not_to be_nil
     end

--- a/spec/lib/web_of_science/map_pub_hash_spec.rb
+++ b/spec/lib/web_of_science/map_pub_hash_spec.rb
@@ -1,0 +1,103 @@
+describe WebOfScience::MapPubHash do
+  let(:wos_encoded_xml) { File.read('spec/fixtures/wos_client/wos_encoded_record.html') }
+  let(:wos_record) { WebOfScience::Record.new(encoded_record: wos_encoded_xml) }
+
+  let(:medline_encoded_xml) { File.read('spec/fixtures/wos_client/medline_encoded_record.html') }
+  let(:medline_record) { WebOfScience::Record.new(encoded_record: medline_encoded_xml) }
+
+  describe '#new' do
+    it 'works with WOS records' do
+      result = described_class.new(wos_record)
+      expect(result).to be_an described_class
+    end
+    it 'raises ArgumentError with nil params' do
+      expect { described_class.new }.to raise_error(ArgumentError)
+    end
+    it 'raises ArgumentError with anything other than WebOfScience::Record' do
+      expect { described_class.new('could be xml') }.to raise_error(ArgumentError)
+    end
+  end
+
+  shared_examples 'pub_hash' do
+    it 'works' do
+      expect(pub_hash).to be_an Hash
+    end
+    it 'has "wos" provenance' do
+      expect(pub_hash[:provenance]).to eq 'wos'
+    end
+  end
+
+  shared_examples 'contains_summary_data' do
+    xit 'has an abstract' do
+      expect(pub_hash[:abstract]).not_to be_nil
+    end
+    it 'has an authors' do
+      expect(pub_hash[:author]).not_to be_nil
+    end
+    it 'has an authorcount' do
+      expect(pub_hash[:authorcount]).not_to be_nil
+    end
+    it 'has an doc type' do
+      expect(pub_hash[:type]).not_to be_nil
+    end
+    it 'has an identifiers' do
+      expect(pub_hash[:identifier]).not_to be_nil
+    end
+  end
+
+  shared_examples 'contains_publisher_data' do
+    it 'has a publisher' do
+      expect(pub_hash[:publisher]).not_to be_nil
+    end
+    it 'has a city' do
+      expect(pub_hash[:city]).not_to be_nil
+    end
+    it 'has a country' do
+      expect(pub_hash[:country]).not_to be_nil
+    end
+  end
+
+  shared_examples 'common_citation_data' do
+    it 'has an year' do
+      expect(pub_hash[:year]).not_to be_nil
+    end
+    it 'has an date' do
+      expect(pub_hash[:date]).not_to be_nil
+    end
+    it 'has an pages' do
+      expect(pub_hash[:pages]).not_to be_nil
+    end
+    it 'has an title' do
+      expect(pub_hash[:title]).not_to be_nil
+    end
+    it 'has an journal' do
+      expect(pub_hash[:journal]).not_to be_nil
+    end
+  end
+
+  context 'WOS records' do
+    let(:pub_hash_class) { described_class.new(wos_record) }
+    let(:pub_hash) { pub_hash_class.pub_hash }
+
+    it 'works with WOS records' do
+      expect(pub_hash_class).to be_an described_class
+    end
+    it_behaves_like 'pub_hash'
+    it_behaves_like 'common_citation_data'
+    it_behaves_like 'contains_publisher_data'
+    it_behaves_like 'contains_summary_data'
+  end
+
+  context 'MEDLINE records' do
+    let(:pub_hash_class) { described_class.new(medline_record) }
+    let(:pub_hash) { pub_hash_class.pub_hash }
+
+    it 'works with MEDLINE records' do
+      expect(pub_hash_class).to be_an described_class
+    end
+    it_behaves_like 'pub_hash'
+    it_behaves_like 'common_citation_data'
+    # it_behaves_like 'contains_publisher_data' # No, it does not.
+    it_behaves_like 'contains_summary_data'
+  end
+end

--- a/spec/lib/web_of_science/map_publisher_spec.rb
+++ b/spec/lib/web_of_science/map_publisher_spec.rb
@@ -1,0 +1,79 @@
+describe WebOfScience::MapPublisher do
+  let(:wos_encoded_xml) { File.read('spec/fixtures/wos_client/wos_encoded_record.html') }
+  let(:wos_record) { WebOfScience::Record.new(encoded_record: wos_encoded_xml) }
+
+  let(:medline_encoded_xml) { File.read('spec/fixtures/wos_client/medline_encoded_record.html') }
+  let(:medline_record) { WebOfScience::Record.new(encoded_record: medline_encoded_xml) }
+
+  describe '#new' do
+    it 'works with WOS records' do
+      result = described_class.new(wos_record)
+      expect(result).to be_an described_class
+    end
+    it 'raises ArgumentError with nil params' do
+      expect { described_class.new }.to raise_error(ArgumentError)
+    end
+    it 'raises ArgumentError with anything other than WebOfScience::Record' do
+      expect { described_class.new('could be xml') }.to raise_error(ArgumentError)
+    end
+  end
+
+  shared_examples 'it_extracts_publishers' do
+    describe '#publishers' do
+      let(:publishers) { publisher.publishers }
+
+      it 'works' do
+        expect(publishers).to be_an Array
+      end
+      it 'contains publisher information' do
+        expect(publishers.first).to be_an Hash
+      end
+      it 'contains publisher name' do
+        expect(publishers.first).to include('full_name' => 'ASSOC COLL RESEARCH LIBRARIES')
+      end
+    end
+  end
+
+  shared_examples 'pub_hash' do
+    it 'works' do
+      expect(pub_hash).to be_an Hash
+    end
+  end
+
+  shared_examples 'pub_hash_contains_publisher_data' do
+    it 'has a publisher' do
+      expect(pub_hash[:publisher]).not_to be_nil
+    end
+    it 'has a city' do
+      expect(pub_hash[:city]).not_to be_nil
+    end
+    it 'has a country' do
+      expect(pub_hash[:country]).not_to be_nil
+    end
+  end
+
+  context 'WOS records' do
+    let(:publisher) { described_class.new(wos_record) }
+    let(:pub_hash) { publisher.pub_hash }
+
+    it 'works with WOS records' do
+      expect(publisher).to be_an described_class
+    end
+    it_behaves_like 'it_extracts_publishers'
+    it_behaves_like 'pub_hash'
+    it_behaves_like 'pub_hash_contains_publisher_data'
+  end
+
+  context 'MEDLINE records' do
+    let(:publisher) { described_class.new(medline_record) }
+    let(:pub_hash) { publisher.pub_hash }
+
+    it 'works with MEDLINE records' do
+      expect(publisher).to be_an described_class
+    end
+    it_behaves_like 'pub_hash'
+    it 'has no publishers' do
+      expect(publisher.publishers).to be_empty
+    end
+  end
+end

--- a/spec/lib/web_of_science/record_spec.rb
+++ b/spec/lib/web_of_science/record_spec.rb
@@ -241,6 +241,17 @@ describe WebOfScience::Record do
     end
   end
 
+  describe '#pub_hash' do
+    let(:pub_hash) { wos_record_encoded.pub_hash }
+
+    it 'works' do
+      expect(pub_hash).to be_an Hash
+    end
+    it 'has "wos" provenance' do
+      expect(pub_hash[:provenance]).to eq 'wos'
+    end
+  end
+
   describe '#to_struct' do
     let(:struct) { wos_record_encoded.to_struct }
 


### PR DESCRIPTION
Fix #383 
Fix #368 

Isolating components of #375 
- this isolates only the `toPubHash` method from d86ae6f653ae189e11ed294c3b63468afc1ac926

TODO:
- [x] cherry-pick additional commits from #375 
- [x] squash commits into their final form
- [x] more specs

@Maatary 

An informal integration test was used to develop and revise this by checking how it handles some WOS records, e.g. using the `bundle exec rails c` console, the records should all parse without exceptions:
```ruby
altman_records = WOS.queries.search_by_name('Altman, Russ, B', ['Stanford University']);
altman_records.map(&:pub_hash)
# the next step is to create citations, e.g.
altman_records.map {|rec| ph = PubHash.new(rec.pub_hash); ph.to_apa_citation }
```