### PR TITLE
WOS provenance setting

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -85,15 +85,12 @@ sul_doc_types:
   book: book
   article: article
 
-cap_provenance: cap
-
-manual_source: manual
-
-sciencewire_source: sciencewire
-
-pubmed_source: pubmed
-
 batch_source: batch
+cap_provenance: cap
+manual_source: manual
+pubmed_source: pubmed
+sciencewire_source: sciencewire
+wos_source: wos
 
 sw_doc_types_to_skip:
   - Book Review


### PR DESCRIPTION
Required in #379 to populate the PubHash with a new source record provenance. 
- f291f9341a1da71fea30dcfbd8f7de946b316291

I assume we want to replace
```ruby
pub_hash[:provenance] = Settings.sciencewire_source
```
with say
```ruby
pub_hash[:provenance] = Settings.wos_source
```

What provenance do we want to use for Web of Science records?  This PR is a suggestion, I'm open to alternatives.  We seem to be using `wos` in our common vocab on this work.