### PR TITLE
Adjust scheduling of harvesting rake tasks on qa and prod so that will not run concurrently

### DIFF
--- a/config/deploy/cap-qa.rb
+++ b/config/deploy/cap-qa.rb
@@ -1,4 +1,4 @@
-server 'sul-pub-cap-qa.stanford.edu', user: 'pub', roles: %w(web db app harvester external_monitor)
+server 'sul-pub-cap-qa.stanford.edu', user: 'pub', roles: %w(web db app harvester_qa external_monitor)
 
 Capistrano::OneTimeKey.generate_one_time_key!
 

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,4 +1,4 @@
-server 'sul-pub-prod.stanford.edu', user: 'pub', roles: %w(web db app harvester external_monitor)
+server 'sul-pub-prod.stanford.edu', user: 'pub', roles: %w(web db app harvester_prod external_monitor)
 
 Capistrano::OneTimeKey.generate_one_time_key!
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -6,12 +6,17 @@ end
 
 set :output, 'log/cron.log'
 
-# fortnightly sciencewire harvest at 5pm-ish
-every 2.weeks, at: stagger(17), roles: [:harvester] do
+# fortnightly sciencewire harvest at 5pm in qa, on the 5th and 20th of the month
+every "0 17 5,20 * *", roles: [:harvester_qa] do
   rake 'sw:fortnightly_harvest'
 end
 
-# poll cap for new authorship information nightly at 4am-ish
-every 1.day, at: stagger(4), roles: [:harvester] do
+# fortnightly sciencewire harvest at 5pm in prod, on the 1st and 15th of the month
+every "0 17 1,15 * *", roles: [:harvester_prod] do
+  rake 'sw:fortnightly_harvest'
+end
+
+# poll cap for new authorship information nightly at 4am-ish in both prod and qa
+every 1.day, at: stagger(4), roles: [:harvester_qa, :harvester_prod] do
   rake 'cap:poll[1]'
 end


### PR DESCRIPTION
currently prod and cap-qa run their fortnightly harvests on the exact same day, just staggering the hour and minute start time -- this fixes the start hour and time but staggers them 5 days apart so they will not run concurrently