### PR TITLE
Replace rake task to sync cap_profile_ids, removed in #376, connected…

### DIFF
--- a/lib/tasks/cap_cutover.rake
+++ b/lib/tasks/cap_cutover.rake
@@ -59,4 +59,10 @@ namespace :cap_cutover do
     end
     Rails.logger.info total_running_count.to_s + ' in ' + distance_of_time_in_words_to_now(start_time)
   end
+
+  desc 'overwrite cap profile ids from CAP authorship feed - this is meant to be a very temporary, dangerous, and invasive procedure for creating qa machines for the School of Medicine testers.'
+  task overwrite_profile_ids: :environment do
+    return if Rails.env == 'production'
+    CapProfileIdRewriter.new.rewrite_cap_profile_ids_from_feed
+  end
 end

--- a/lib/tasks/cap_cutover.rake
+++ b/lib/tasks/cap_cutover.rake
@@ -62,7 +62,12 @@ namespace :cap_cutover do
 
   desc 'overwrite cap profile ids from CAP authorship feed - this is meant to be a very temporary, dangerous, and invasive procedure for creating qa machines for the School of Medicine testers.'
   task overwrite_profile_ids: :environment do
-    return if Rails.env == 'production'
+    if Rails.env == 'production'
+      puts 'This is a PRODUCTION system - are you sure? (Y/N)'
+      STDOUT.flush
+      input = STDIN.gets.chomp
+      return unless input.upcase == 'Y'
+    end
     CapProfileIdRewriter.new.rewrite_cap_profile_ids_from_feed
   end
 end


### PR DESCRIPTION
Replacing a rake task removed in #376
- slightly modified to protect prod environment

Connected to #356, #422
