### PR TITLE
WebOfScience::Record - use the wos_logger

### DIFF
--- a/lib/notification_manager.rb
+++ b/lib/notification_manager.rb
@@ -17,7 +17,7 @@ class NotificationManager
         log_exception(pubmed_logger, log_message, e)
       when CapAuthorsPoller, CapHttpClient
         log_exception(cap_logger, log_message, e)
-      when WebOfScience::Client, WebOfScience::Harvester, WebOfScience::ProcessRecords
+      when WebOfScience::Client, WebOfScience::Harvester, WebOfScience::ProcessRecords, WebOfScience::Record
         log_exception(wos_logger, log_message, e)
       else
         log_exception(Rails.logger, log_message, e)

--- a/lib/web_of_science/record.rb
+++ b/lib/web_of_science/record.rb
@@ -172,5 +172,9 @@ module WebOfScience
         JSON.parse(hash.to_json, object_class: OpenStruct)
       end
 
+      def logger
+        @logger ||= NotificationManager.wos_logger
+      end
+
   end
 end


### PR DESCRIPTION
Extracted from #379 

This will enable logging exceptions when processing WOS record data.