### PR TITLE
WebOfScience::Records - #sample returns random record

### DIFF
--- a/lib/web_of_science/records.rb
+++ b/lib/web_of_science/records.rb
@@ -14,6 +14,9 @@ module WebOfScience
     # @return [Boolean] WOS records empty?
     def_delegators :rec_nodes, :empty?
 
+    # @return [WebOfScience::Record]
+    def_delegators :to_a, :sample
+
     # @return xml [String] WOS records in XML
     def_delegators :doc, :to_xml
 


### PR DESCRIPTION
Extracted from #379 

This enables random sampling of records from WOS-records (the `:to_a` comes from `Enumerable` and `sample` is from `Array`; there's no need to test these ruby functions, it works nicely in the console).