### PR TITLE
WebOfScience::Mapper - base class for record data mappers

### DIFF
--- a/lib/web_of_science/mapper.rb
+++ b/lib/web_of_science/mapper.rb
@@ -1,0 +1,27 @@
+module WebOfScience
+
+  # Map WOS record data into the SUL PubHash data
+  class Mapper
+
+    # @param rec [WebOfScience::Record]
+    def initialize(rec)
+      raise(ArgumentError, 'rec must be a WebOfScience::Record') unless rec.is_a? WebOfScience::Record
+      @rec = rec
+    end
+
+    # @return [Hash]
+    def pub_hash
+      mapper
+    end
+
+    private
+
+      attr_reader :rec
+
+      def mapper
+        # subclasses can map data, otherwise this method should never get called
+        raise(NotImplementedError, 'Move along, this is not the mapper your looking for.')
+      end
+
+  end
+end

--- a/spec/lib/web_of_science/mapper_spec.rb
+++ b/spec/lib/web_of_science/mapper_spec.rb
@@ -1,0 +1,24 @@
+describe WebOfScience::Mapper do
+  subject(:mapper) { described_class.new(wos_record) }
+
+  let(:wos_encoded_xml) { File.read('spec/fixtures/wos_client/wos_encoded_record.html') }
+  let(:wos_record) { WebOfScience::Record.new(encoded_record: wos_encoded_xml) }
+
+  describe '#new' do
+    it 'works with WOS records' do
+      expect(mapper).to be_an described_class
+    end
+    it 'raises ArgumentError with nil params' do
+      expect { described_class.new }.to raise_error(ArgumentError)
+    end
+    it 'raises ArgumentError with anything other than WebOfScience::Record' do
+      expect { described_class.new('could be xml') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#pub_hash' do
+    it 'is not implemented in the base class' do
+      expect { mapper.pub_hash }.to raise_error(NotImplementedError)
+    end
+  end
+end


### PR DESCRIPTION
Extracted from #379 for easier review here

This is the base class for all the pub_hash mappers in #379 