### PR TITLE
Fix OK Computer checks on Contribution

### DIFF
--- a/app/models/contribution.rb
+++ b/app/models/contribution.rb
@@ -18,10 +18,11 @@ class Contribution < ActiveRecord::Base
   after_initialize :init
 
   # apply some default values and coercions (lowercasing)
+  # @note must use attributes[...] checks here instead of getter methods to support Contribution.select(:id)
   def init
-    self.featured   = false if featured.nil? # can't use ||= with boolean
-    self.status     = status.downcase if status
-    self.visibility = visibility.downcase if visibility
+    self.featured   = false if attributes['featured'].nil? # can't use ||=
+    self.status     = status.downcase if attributes['status']
+    self.visibility = visibility.downcase if attributes['visibility']
   end
 
   def cap_profile_id

--- a/spec/models/contribution_spec.rb
+++ b/spec/models/contribution_spec.rb
@@ -16,6 +16,14 @@ describe Contribution do
 
   subject { pub_with_contrib.contributions.first }
 
+  # used by OK Computer checks, once broken by after_initialize/#init method
+  describe '#select' do
+    it 'still works' do
+      pub_with_contrib
+      expect(described_class.select(:id).first!).to be_present
+    end
+  end
+
   describe '#cap_profile_id' do
     it 'returns the author.cap_profile_id' do
       expect(subject.cap_profile_id).to eq(subject.author.cap_profile_id)


### PR DESCRIPTION
The problem is calling attribute getter methods on objects that are initialized via `.select(:id)` since they only have a partial set of fields (i.e. one) in their `attributes` hash, meaning calling the
attribute getter method raises an error.  