### PR TITLE
db filtering

### DIFF
--- a/lib/notification_manager.rb
+++ b/lib/notification_manager.rb
@@ -18,7 +18,7 @@ class NotificationManager
       when CapAuthorsPoller, CapHttpClient
         log_exception(cap_logger, log_message, e)
       when WebOfScience::Client, WebOfScience::Harvester, WebOfScience::ProcessRecords, WebOfScience::Record
-        log_exception(wos_logger, log_message, e)
+        log_exception(WebOfScience.logger, log_message, e)
       else
         log_exception(Rails.logger, log_message, e)
       end
@@ -39,10 +39,6 @@ class NotificationManager
 
     def sciencewire_logger
       @@sciencewire_logger ||= Logger.new(Settings.SCIENCEWIRE.LOG)
-    end
-
-    def wos_logger
-      @@wos_logger ||= Logger.new(Settings.WOS.LOG)
     end
     # rubocop:enable Style/ClassVars
 

--- a/lib/tasks/wos.rake
+++ b/lib/tasks/wos.rake
@@ -3,7 +3,7 @@ namespace :wos do
   task :links, [:wos_id] => :environment do |_t, args|
     raise 'wos_id argument is required.' if args[:wos_id].blank?
     wos_ids = [args[:wos_id]]
-    links = WOS.links_client.links(wos_ids, fields: Clarivate::LinksClient::ALL_FIELDS)
+    links = WebOfScience.links_client.links(wos_ids, fields: Clarivate::LinksClient::ALL_FIELDS)
     puts JSON.pretty_generate(links)
   end
 
@@ -11,7 +11,7 @@ namespace :wos do
   task :publication, [:wos_id] => :environment do |_t, args|
     raise 'wos_id argument is required.' if args[:wos_id].blank?
     wos_ids = [args[:wos_id]]
-    records = WOS.queries.retrieve_by_id(wos_ids)
+    records = WebOfScience.queries.retrieve_by_id(wos_ids)
     records.each(&:print) # XML documents
   end
 end

--- a/lib/web_of_science.rb
+++ b/lib/web_of_science.rb
@@ -1,5 +1,5 @@
 # Web of Science (WOS) utilities
-module WOS
+module WebOfScience
   # rubocop:disable Style/ClassVars
 
   # @return [WebOfScience::Harvester]
@@ -22,5 +22,8 @@ module WOS
     @@queries ||= WebOfScience::Queries.new(client)
   end
 
+  def self.logger
+    @@logger ||= Logger.new(Settings.WOS.LOG)
+  end
   # rubocop:enable Style/ClassVars
 end

--- a/lib/web_of_science/client.rb
+++ b/lib/web_of_science/client.rb
@@ -9,10 +9,11 @@ module WebOfScience
   # http://ipscience-help.thomsonreuters.com/wosWebServicesExpanded/WebServicesExpandedOverviewGroup/Introduction.html
   # It uses the savon gem for SOAP, see http://savonrb.com/version2/client.html
   class Client
-
     API_VERSION = '3.0'.freeze # Based on USER GUIDE July 7, 2015
     AUTH_WSDL = 'http://search.webofknowledge.com/esti/wokmws/ws/WOKMWSAuthenticate?wsdl'.freeze
     SEARCH_WSDL = 'http://search.webofknowledge.com/esti/wokmws/ws/WokSearch?wsdl'.freeze
+
+    delegate :logger, to: :WebOfScience
 
     def initialize(auth_code, log_level = :info)
       @auth_code = auth_code
@@ -75,12 +76,5 @@ module WebOfScience
       @search = nil
       @session_id = nil
     end
-
-    private
-
-      def logger
-        @logger ||= NotificationManager.wos_logger
-      end
   end
 end
-

--- a/lib/web_of_science/harvester.rb
+++ b/lib/web_of_science/harvester.rb
@@ -5,6 +5,7 @@ module WebOfScience
   # This class is responsible for processing WebOfScience API response data
   # to integrate it into the application data models.
   class Harvester
+    delegate :logger, to: :WebOfScience
 
     # Harvest all publications for an author
     # @param author [Author]
@@ -136,10 +137,6 @@ module WebOfScience
           wos_client = WebOfScience::Client.new(Settings.WOS.AUTH_CODE)
           WebOfScience::Queries.new(wos_client)
         end
-      end
-
-      def logger
-        @logger ||= NotificationManager.wos_logger
       end
   end
 end

--- a/lib/web_of_science/process_records.rb
+++ b/lib/web_of_science/process_records.rb
@@ -4,6 +4,7 @@ module WebOfScience
   # Process records retrieved by any means; this is a progressive filtering of the harvested records to identify
   # those records that should create a new Publication.pub_hash, PublicationIdentifier(s) and Contribution(s).
   class ProcessRecords
+    delegate :logger, to: :WebOfScience
 
     # @param author [Author]
     # @param records [WebOfScience::Records]
@@ -125,10 +126,6 @@ module WebOfScience
       def publication_identifier?(type, value)
         return false if value.nil?
         PublicationIdentifier.where(identifier_type: type, identifier_value: value).count > 0
-      end
-
-      def logger
-        @logger ||= NotificationManager.wos_logger
       end
   end
 end

--- a/lib/web_of_science/record.rb
+++ b/lib/web_of_science/record.rb
@@ -7,6 +7,7 @@ module WebOfScience
     extend Forwardable
 
     delegate %i(database doi eissn issn pmid uid wos_item_id) => :identifiers
+    delegate logger: :WebOfScience
 
     # @return doc [Nokogiri::XML::Document] WOS record document
     attr_reader :doc
@@ -141,10 +142,5 @@ module WebOfScience
       def to_o(hash)
         JSON.parse(hash.to_json, object_class: OpenStruct)
       end
-
-      def logger
-        @logger ||= NotificationManager.wos_logger
-      end
-
   end
 end

--- a/spec/lib/notification_manager_spec.rb
+++ b/spec/lib/notification_manager_spec.rb
@@ -66,17 +66,13 @@ describe NotificationManager do
       described_class.error(exception, message, ScienceWireClient.new)
     end
   end
-  context '.wos_logger' do
+  context 'WebOfScience.logger' do
     let(:wos_client) { WebOfScience::Client.new(Settings.WOS.AUTH_CODE) }
 
-    before do
-      described_class.class_variable_set(:@@wos_logger, nil)
-    end
-    it 'creates a single logger' do
-      expect(Logger).to receive(:new).with(Settings.WOS.LOG).once
-      described_class.error(exception, message, wos_client)
-    end
+    before { WebOfScience.class_variable_set(:@@logger, nil) }
+
     it 'logs errors' do
+      expect(WebOfScience).to receive(:logger).and_return(null_logger)
       expect(null_logger).to receive(:error).exactly(3)
       described_class.error(exception, message, wos_client)
     end

--- a/spec/lib/web_of_science/client_spec.rb
+++ b/spec/lib/web_of_science/client_spec.rb
@@ -61,17 +61,11 @@ describe WebOfScience::Client do
     context 'when there are no matches returned for SessionID' do
       let(:null_logger) { Logger.new('/dev/null') }
 
-      before do
-        savon.expects(:close_session).returns(no_session_matches)
-        NotificationManager.class_variable_set(:@@wos_logger, nil)
-        allow(Logger).to receive(:new).and_return(null_logger)
-      end
-      it 'works' do
+      before { savon.expects(:close_session).returns(no_session_matches) }
+
+      it 'creates a logger and works' do
+        expect(WebOfScience).to receive(:logger).and_return(null_logger)
         expect(wos_client.session_close).to be_nil
-      end
-      it 'creates a logger' do
-        expect(NotificationManager).to receive(:wos_logger).and_call_original
-        wos_client.session_close
       end
     end
   end

--- a/spec/lib/web_of_science/client_spec.rb
+++ b/spec/lib/web_of_science/client_spec.rb
@@ -16,30 +16,27 @@ describe WebOfScience::Client do
 
   describe '#new' do
     it 'works' do
-      expect(wos_client).to be_an described_class
+      expect(wos_client).to be_a described_class
     end
   end
 
   describe '#auth' do
     it 'works' do
-      result = wos_client.auth
-      expect(result).to be_an Savon::Client
+      expect(wos_client.auth).to be_a Savon::Client
     end
   end
 
   describe '#authenticate' do
     it 'authenticates with the service' do
       savon.expects(:authenticate).returns(auth_xml)
-      response = wos_client.authenticate
-      expect(response).to be_successful
+      expect(wos_client.authenticate).to be_successful
     end
   end
 
   describe '#search' do
     it 'works' do
       savon.expects(:authenticate).returns(auth_xml)
-      result = wos_client.search
-      expect(result).to be_an Savon::Client
+      expect(wos_client.search).to be_a Savon::Client
     end
   end
 
@@ -47,7 +44,7 @@ describe WebOfScience::Client do
     it 'works' do
       savon.expects(:authenticate).returns(auth_xml)
       result = wos_client.session_id
-      expect(result).to be_an String
+      expect(result).to be_a String
       expect(result).to eq '2F669ZtP6fRizIymX8V'
     end
   end
@@ -59,8 +56,7 @@ describe WebOfScience::Client do
     end
     it 'works' do
       savon.expects(:close_session).returns('')
-      result = wos_client.session_close
-      expect(result).to be_nil
+      expect(wos_client.session_close).to be_nil
     end
     context 'when there are no matches returned for SessionID' do
       let(:null_logger) { Logger.new('/dev/null') }

--- a/spec/lib/web_of_science_spec.rb
+++ b/spec/lib/web_of_science_spec.rb
@@ -1,4 +1,4 @@
-describe WOS do
+describe WebOfScience do
   describe '#harvester' do
     it 'works' do
       result = described_class.harvester
@@ -24,6 +24,12 @@ describe WOS do
     it 'works' do
       result = described_class.queries
       expect(result).to be_an WebOfScience::Queries
+    end
+  end
+
+  describe '#logger' do
+    it 'works' do
+      expect(described_class.logger).to be_a Logger
     end
   end
 end


### PR DESCRIPTION
Move `wos.rb` to `web_of_science.rb`
- our other classes are in the `WebOfScience` module (and subdir)
- added logger method
- updated only invocations of `WOS.` to match (in rake task)

Does the filtering and tests that log messages are sent.

Fixes #419 