### PR TITLE
YARD corrections

### DIFF
--- a/app/api/sul_bib/authorship_api.rb
+++ b/app/api/sul_bib/authorship_api.rb
@@ -7,7 +7,7 @@ module SulBib
       # Extract a hash of optional contribution parameters from the request.
       # When this method is called for a PATCH request, it's important that it
       # does not set any defaults.
-      # @return contrib_options [Hash] May contain any of :features, :status and :visibility
+      # @return [Hash] May contain any of :features, :status and :visibility
       def contrib_attr
         # Gather optional contribution fields.
         contrib_attr = {}

--- a/app/api/sul_bib/publications_api.rb
+++ b/app/api/sul_bib/publications_api.rb
@@ -6,7 +6,7 @@ module SulBib
     helpers do
       # Used in GET and PUT to return an existing publication record
       # @param id [String] A unique publication ID
-      # @return pub [Publication] If found, returns a Publication record
+      # @return [Publication] If found, returns a Publication record
       #         returns an error if the publication is not found or if it has
       #         been deleted (unless the request is a 'DELETE')
       def publication_find(id)
@@ -21,7 +21,7 @@ module SulBib
 
       # Check for existing authors.
       # @param authorship_list [Array<Hash>]
-      # @return status [boolean] true if any of the authors exist.
+      # @return [boolean] true if any of the authors exist.
       def existing_authors?(authorship_list)
         # At least one of the authors in the authorship array must exist.
         return false if authorship_list.nil?
@@ -30,7 +30,7 @@ module SulBib
 
       # Check for existing authors or create new authors with a CAP profile ID.
       # @param authorship_list [Array<Hash>]
-      # @return status [boolean] true if any authors exist or are created.
+      # @return [boolean] true if any authors exist or are created.
       def validate_or_create_authors(authorship_list)
         # At least one of the authors in the authorship array must exist or have
         # a CAP profile that is used to create a new SULCAP author.

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -2,7 +2,7 @@ class AuthorsController < ApplicationController
   before_action :check_authorization
   before_action :ensure_json_request
 
-  # POST /authors/{cap_profile_id}/harvest.json
+  # POST /authors/:cap_profile_id/harvest.json
   def harvest
     if AuthorHarvestJob.perform_later(author_params[:cap_profile_id], harvest_alternate_names: alt_names)
       render json: {

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -85,7 +85,7 @@ class Author < ActiveRecord::Base
   # has_many :population_memberships, :dependent => :destroy
   # has_many :author_identifiers, :dependent => :destroy
 
-  # @param [Hash] `auth_hash` data as-is from CAP API
+  # @param [Hash] auth_hash data as-is from CAP API
   def update_from_cap_authorship_profile_hash(auth_hash)
     seed_hash = Author.build_attribute_hash_from_cap_profile(auth_hash)
     assign_attributes seed_hash
@@ -164,8 +164,8 @@ class Author < ActiveRecord::Base
 
   private
 
+    # @param [AuthorIdentity] author_identity is the candidate versus `self`'s identity
     # @return [Boolean] Is this author's identity different than our current identity?
-    # @param [AuthorIdentity] `author_identity` is the candidate versus `self`'s identity
     def author_identity_different?(author_identity)
       !(
         # not the identical identity where Author is assumed to be Stanford University

--- a/app/models/publication_identifier.rb
+++ b/app/models/publication_identifier.rb
@@ -2,7 +2,7 @@ class PublicationIdentifier < ActiveRecord::Base
   belongs_to :publication, required: true, inverse_of: :publication_identifiers
 
   # A pub_hash[:identifier] entry
-  # @return identifier [Hash]
+  # @return [Hash]
   def identifier
     ident_hash = {}
     ident_hash[:type] = identifier_type if identifier_type.present?

--- a/app/models/pubmed_source_record.rb
+++ b/app/models/pubmed_source_record.rb
@@ -185,7 +185,7 @@ class PubmedSourceRecord < ActiveRecord::Base
     #                   envelope element includes <Affliliation> and <Identifier>.
     #
     # @param author [Nokogiri::XML::Element] an <Author> element
-    # @return author_hash [Hash] with keys :firstname, :middlename and :lastname
+    # @return [Hash<Symbol => String>] with keys :firstname, :middlename and :lastname
     def author_to_hash(author)
       # <Author> examples provide many variations at No. 20 from
       # https://www.nlm.nih.gov/bsd/licensee/elements_descriptions.html

--- a/app/models/sciencewire_source_record.rb
+++ b/app/models/sciencewire_source_record.rb
@@ -16,17 +16,17 @@ class SciencewireSourceRecord < ActiveRecord::Base
     SciencewireSourceRecord.convert_sw_publication_doc_to_hash(publication_item)
   end
 
-  # @return publication [ScienceWirePublication] PublicationItem object
+  # @return [ScienceWirePublication] PublicationItem object
   def publication
     @publication ||= ScienceWirePublication.new publication_item
   end
 
-  # @return publication_item [Nokogiri::XML::Element] XML element for PublicationItem
+  # @return [Nokogiri::XML::Element] XML element for PublicationItem
   def publication_item
     @publication_item ||= publication_xml.at_xpath('//PublicationItem')
   end
 
-  # @return publication_xml [Nokogiri::XML::Document] XML document
+  # @return [Nokogiri::XML::Document] XML document
   def publication_xml
     @publication_xml ||= Nokogiri::XML(source_data)
   end
@@ -285,7 +285,7 @@ class SciencewireSourceRecord < ActiveRecord::Base
   # - 'Other'
   #
   # @param sw_doc_category [String] One of the document categories
-  # @return sul_doc_type [String] One of the `Settings.sul_doc_types`
+  # @return [String] One of the `Settings.sul_doc_types`
   def self.lookup_cap_doc_type_by_sw_doc_category(sw_doc_category)
     return Settings.sul_doc_types.inproceedings if sw_doc_category == 'Conference Proceeding Document'
     Settings.sul_doc_types.article

--- a/app/models/web_of_science_source_record.rb
+++ b/app/models/web_of_science_source_record.rb
@@ -4,7 +4,7 @@ class WebOfScienceSourceRecord < ActiveRecord::Base
 
   after_initialize :check_source_data
 
-  # @return doc [Nokogiri::XML::Document] XML document
+  # @return [Nokogiri::XML::Document] XML document
   def doc
     @doc ||= Nokogiri::XML(source_data)
   end
@@ -25,7 +25,7 @@ class WebOfScienceSourceRecord < ActiveRecord::Base
     super || self.source_fingerprint = Digest::SHA2.hexdigest(source_data)
   end
 
-  # @return xml [String] XML
+  # @return [String] XML
   def to_xml
     doc.to_xml(save_with: XML_OPTIONS).strip
   end

--- a/lib/agent/author_name.rb
+++ b/lib/agent/author_name.rb
@@ -66,7 +66,7 @@ module Agent
       # Add the name variants for:
       # 'Lastname,Firstname' or
       # 'Lastname,FirstInitial'
-      # @return names [Array<String>|String]
+      # @return [Array<String>|String] names
       def first_name_query
         return '' if last.empty? && first.empty?
         [
@@ -79,7 +79,7 @@ module Agent
       # 'Lastname,Firstname,Middlename' or
       # 'Lastname,Firstname,MiddleInitial' or
       # 'Lastname,FirstInitial,MiddleInitial'
-      # @return names [Array<String>|String]
+      # @return [Array<String>|String] names
       def middle_name_query
         return '' unless middle =~ /^[[:alpha:]]/
         [

--- a/lib/cap_authors_poller.rb
+++ b/lib/cap_authors_poller.rb
@@ -113,7 +113,8 @@ class CapAuthorsPoller
   end
 
   # Add author to job queue if it's harvestable and new/changed
-  # @param [String] `skip_message` logs this message if it skips adding author to queue
+  # @param [Author] author
+  # @param [String] skip_message logs this message if it skips adding author to queue
   def queue_author_for_harvest(author, skip_message)
     if (author.new_record? || author.changed?) && author.harvestable?
       @new_or_changed_authors_to_harvest_queue << author.id

--- a/lib/cap_authors_poller.rb
+++ b/lib/cap_authors_poller.rb
@@ -183,10 +183,10 @@ class CapAuthorsPoller
       poll_time.iso8601(3)
     end
 
-    # @param page_count [Integer]  default = 1  -- 1st page
-    # @param page_size [Integer]   default = 10 -- 10 records
-    # @param days_ago [Integer]    default = 1  -- within the last 24 hours
-    # @return json_response
+    # @param page_count [Integer] 1st page
+    # @param page_size [Integer] number of records
+    # @param days_ago [Integer] number of days old records to be included
+    # @return [Hash, Array] response parsed from JSON
     def get_recent_cap_authorship(page_count = 1, page_size = 10, days_ago = 1)
       poll_since = convert_days_ago_to_timestamp(days_ago)
       @cap_http_client.get_batch_from_cap_api(page_count, page_size, poll_since)

--- a/lib/cap_http_client.rb
+++ b/lib/cap_http_client.rb
@@ -41,22 +41,26 @@ class CapHttpClient
     raise
   end
 
+  # @return [Hash, Array] results of JSON.parse
   def get_batch_from_cap_api(page_count, page_size, since = '')
     request_path = "#{Settings.CAP.AUTHORSHIP_API_PATH}?p=#{page_count}&ps=#{page_size}"
     request_path << "&since=#{since}" unless since.blank?
     make_cap_request(request_path)
   end
 
+  # @return [Hash, Array] results of JSON.parse
   def get_auth_profile(cap_profile_id)
     make_cap_request("#{Settings.CAP.AUTHORSHIP_API_PATH}/#{cap_profile_id}")
   end
 
+  # @return [Hash, Array] results of JSON.parse
   def get_cap_profile_by_sunetid(sunetid)
     make_cap_request("#{Settings.CAP.AUTHORSHIP_API_PATH}?uids=#{sunetid}")
   end
 
   private
 
+    # @return [Hash, Array] results of JSON.parse
     def make_cap_request(request_path)
       json_response = {}
       timeout_retries = @base_timeout_retries

--- a/lib/csl/citation.rb
+++ b/lib/csl/citation.rb
@@ -32,7 +32,7 @@ module Csl
     # which has a different style for the subsequent citations.
     # @param csl_citation_data [Hash] a CSL citation document
     # @param csl_style [CSL::Style] a CSL citation style
-    # @return citation [String] a bibliographic citation
+    # @return [String] a bibliographic citation
     def generate_csl_citation(csl_citation_data, csl_style)
       item = CiteProc::CitationItem.new(id: 'sulpub')
       item.data = CiteProc::Item.new(csl_citation_data)

--- a/lib/harvester/base.rb
+++ b/lib/harvester/base.rb
@@ -9,7 +9,7 @@ module Harvester
             .each { |batch| harvest(batch) }
     end
 
-    # @param [Enumerable<Author>] authors
+    # @param [Enumerable<Author>] _authors
     # @return [void]
     def harvest(_authors)
       raise "harvest must be implemented in subclass"

--- a/lib/identifier_normalizer.rb
+++ b/lib/identifier_normalizer.rb
@@ -35,7 +35,7 @@ class IdentifierNormalizer
 
     # Choose a parser that can handle the PublicationIdentifier.identifier_type
     # @param pub_id [PublicationIdentifier]
-    # @return parser [IdentifierParser] a kind of IdentifierParser to handle the pub_id
+    # @return [IdentifierParser] a kind of IdentifierParser to handle the pub_id
     def identifier_parser(pub_id)
       case pub_id[:identifier_type].to_s.downcase
       when 'doi'

--- a/lib/identifier_normalizer.rb
+++ b/lib/identifier_normalizer.rb
@@ -1,6 +1,6 @@
 # IdentifierNormalizer
 # - normalize PublicationIdentifier data
-# - uses lib/identifier_parser_{type} to normalize that {type} of identifier
+# - uses lib/identifier_parser_[type] to normalize that type of identifier
 # - the base class in lib/identifier_parser will handle anything thrown at it
 #   - it does not change any data; it detects blank PublicationIdentifier
 # - exceptions and data modifications are logged into various log/identifier*.log files

--- a/lib/identifier_parser.rb
+++ b/lib/identifier_parser.rb
@@ -58,7 +58,7 @@ class IdentifierParser
   end
 
   # Construct an entry for Publication.pub_hash[:identifier]
-  # @return identifier [Hash]
+  # @return [Hash<Symbol => String>]
   def identifier
     identifier = {}
     identifier[:type] = type
@@ -68,7 +68,7 @@ class IdentifierParser
   end
 
   # Update the pub_id with parsed data
-  # @return pub_id [PublicationIdentifier]
+  # @return [PublicationIdentifier] updated pub id (not saved)
   def update
     pub_id[:identifier_value] = value
     pub_id[:identifier_uri] = uri
@@ -82,14 +82,14 @@ class IdentifierParser
   end
 
   # Extract a value
-  # @return [String|nil]
+  # @return [String, nil]
   def value
     # this base class uses the pub_id value
     @value ||= pub_id[:identifier_value]
   end
 
   # Extract a URI
-  # @return [String|nil]
+  # @return [String, nil]
   def uri
     # this base class uses the pub_id URI
     @uri ||= compose_uri
@@ -98,7 +98,7 @@ class IdentifierParser
   private
 
     # Compose a URI
-    # @return [String|nil]
+    # @return [String, nil]
     def compose_uri
       pub_id[:identifier_uri]
     end

--- a/lib/notification_manager.rb
+++ b/lib/notification_manager.rb
@@ -4,9 +4,9 @@ class NotificationManager
     ##
     # Handles notification of errors with behavior based on the callee
     #
-    # @param [Exception] `e` -- the original exception
-    # @param [String] `message` -- human-readable message
-    # @param [Class] `callee` -- the callee object
+    # @param [Exception] e -- the original exception
+    # @param [String] message -- human-readable message
+    # @param [Class] callee -- the callee object
     def error(e, message, callee = nil)
       log_message = callee.class.name + ': ' + message
 

--- a/lib/science_wire/api/publication_items.rb
+++ b/lib/science_wire/api/publication_items.rb
@@ -15,8 +15,8 @@ module ScienceWire
       end
 
       ##
+      # @param [String] sw_ids - CSV PublicationItemId values (no whitespace)
       # @param [String] format - either 'xml' or 'json'
-      # @param [String] ids - CSV PublicationItemId values (no whitespace)
       def publication_items(sw_ids, format = 'xml')
         raise ArgumentError, 'format must be "xml" or "json"' unless FORMATS.include?(format)
         path = PATH + "?format=#{format}&publicationItemIDs=#{sw_ids}"

--- a/lib/science_wire/id_suggestions.rb
+++ b/lib/science_wire/id_suggestions.rb
@@ -1,5 +1,4 @@
 module ScienceWire
-  ##
   # Facade class for creating an Array of ScienceWire suggestion ID's
   class IdSuggestions
     attr_reader :client
@@ -8,22 +7,19 @@ module ScienceWire
       @client = client
     end
 
-    ##
-    # @param [ScienceWire::AuthorAttributes]
+    # @param [ScienceWire::AuthorAttributes] author_attributes
     # @return [Array<Integer>]
     def id_suggestions(author_attributes)
       journal_suggestions(author_attributes) + conference_suggestions(author_attributes)
     end
 
-    ##
-    # @param [ScienceWire::AuthorAttributes]
+    # @param [ScienceWire::AuthorAttributes] author_attributes
     # @return [Array<Integer>]
     def journal_suggestions(author_attributes)
       suggestions(ScienceWire::Query::JournalDocumentSuggestion.new(author_attributes))
     end
 
-    ##
-    # @param [ScienceWire::AuthorAttributes]
+    # @param [ScienceWire::AuthorAttributes] author_attributes
     # @return [Array<Integer>]
     def conference_suggestions(author_attributes)
       suggestions(ScienceWire::Query::ConferenceProceedingDocumentSuggestion.new(author_attributes))
@@ -31,7 +27,6 @@ module ScienceWire
 
     private
 
-      ##
       # @return [Array<Integer>]
       def suggestions(query)
         client.matched_publication_item_ids_for_author_and_parse(

--- a/lib/science_wire_client.rb
+++ b/lib/science_wire_client.rb
@@ -151,7 +151,7 @@ class ScienceWireClient
     send_query_and_return_pub_hashes query
   end
 
-  # @params [Array<String>] wos_ids The WebOfScience Document Ids that are being requested
+  # @param [Array<String>] wos_ids The WebOfScience Document Ids that are being requested
   # @return [Nokogiri::XML::Document]
   def get_full_sciencewire_pubs_for_wos_ids(wos_ids)
     xml_query = %(<![CDATA[
@@ -193,7 +193,7 @@ class ScienceWireClient
     get_sciencewire_publication_response(queryId, queryResultRows)
   end
 
-  # @returns [Nokogiri::XML::Document] the ScienceWireQueryIDResponse
+  # @return [Nokogiri::XML::Document] the ScienceWireQueryIDResponse
   def send_sciencewire_publication_request(xml_query)
     wrapped_xml_query = '<?xml version="1.0"?>
     <ScienceWireQueryXMLParameter xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
@@ -212,7 +212,7 @@ class ScienceWireClient
 
   # @param [Integer] queryId used to identify a specific query result set
   # @param [Integer] queryResultRows the total number of results for a query
-  # @returns [Nokogiri::XML::Document] the ArrayOfPublicationItem response
+  # @return [Nokogiri::XML::Document] the ArrayOfPublicationItem response
   def get_sciencewire_publication_response(queryId, queryResultRows)
     xml_doc = begin
       if queryResultRows > 0
@@ -232,7 +232,7 @@ class ScienceWireClient
   end
 
   # @param sciencewire_ids [Array<Integer>] array of PublicationItemID integers
-  # @returns [Nokogiri::XML::Document] the ArrayOfPublicationItem response
+  # @return [Nokogiri::XML::Document] the ArrayOfPublicationItem response
   def get_full_sciencewire_pubs_for_sciencewire_ids(sciencewire_ids)
     # Get the documents in batches, because the request is made as a GET and a very long
     # list of PublicationItemId values might exceed a URL length limit (approx. 2000 chars), see commentary in:
@@ -266,7 +266,7 @@ class ScienceWireClient
   end
 
   # @param sciencewire_id [Integer] a PublicationItemID integer
-  # @returns [Nokogiri::XML::Element] a PublicationItem element
+  # @return [Nokogiri::XML::Element] a PublicationItem element
   def get_sw_xml_source_for_sw_id(sciencewire_id)
     xml_doc = get_full_sciencewire_pubs_for_sciencewire_ids([sciencewire_id])
     xml_doc.xpath('//PublicationItem').first

--- a/lib/science_wire_publication.rb
+++ b/lib/science_wire_publication.rb
@@ -4,7 +4,7 @@ class ScienceWirePublication
   # @return [String] XML for PublicationItem
   delegate :to_xml, to: :xml_doc
 
-  # @param [Nokogiri::XML::Element] a PublicationItem
+  # @param [Nokogiri::XML::Element] xml_doc a PublicationItem
   def initialize(xml_doc)
     @xml_doc = xml_doc
     raise(ArgumentError, 'xml_doc must be a <PublicationItem> Nokogiri::XML::Element') unless valid?
@@ -89,8 +89,8 @@ class ScienceWirePublication
     element_text 'AuthorList'
   end
 
-  # @return [Array<Hash>] an array of author names
-  #                       {lastname: '', firstname: '', middlename: ''}
+  # @return [Array<Hash>] array of author names
+  #                       lastname: '', firstname: '', middlename: ''
   def author_names
     authors.map do |name|
       ln, fn, mn = name.split(',')

--- a/lib/science_wire_publications.rb
+++ b/lib/science_wire_publications.rb
@@ -7,7 +7,7 @@ class ScienceWirePublications
   # @return [Integer] a count of //PublicationItem
   delegate :count, to: :publication_items
 
-  # @param [Nokogiri::XML] an ArrayOfPublicationItem
+  # @param xml_doc [Nokogiri::XML] an ArrayOfPublicationItem
   # @param remove_document_types [Array<String>] DocumentTypes to skip
   def initialize(xml_doc, remove_document_types = Settings.sw_doc_types_to_skip)
     @xml_doc = xml_doc

--- a/lib/web_of_science/harvester.rb
+++ b/lib/web_of_science/harvester.rb
@@ -74,7 +74,7 @@ module WebOfScience
       # Retrieve WOS Records for Author
 
       # @param author [Author]
-      # @return records [WebOfScience::Records]
+      # @return [WebOfScience::Records]
       def records_for_author(author)
         # TODO: iterate on author identities also, or leave that to the consumer of this class?
         names = author_name(author).text_search_query

--- a/lib/web_of_science/identifiers.rb
+++ b/lib/web_of_science/identifiers.rb
@@ -25,7 +25,7 @@ module WebOfScience
       @ids.freeze
     end
 
-    # Extract the {DB_PREFIX} from a WOS-UID in the form {DB_PREFIX}:{ITEM_ID}
+    # Extract the DB_PREFIX from a WOS-UID in the form "DB_PREFIX:ITEM_ID"
     # @return [String, nil]
     def database
       @database ||= begin

--- a/lib/web_of_science/map_publisher.rb
+++ b/lib/web_of_science/map_publisher.rb
@@ -5,7 +5,7 @@ module WebOfScience
   # WOS publisher information
   class MapPublisher < Mapper
 
-    # @return publishers [Array<Hash>]
+    # @return [Array<Hash>]
     def publishers
       @publishers ||= begin
         publishers = rec.doc.search('static_data/summary/publishers/publisher').map do |publisher|

--- a/lib/web_of_science/process_records.rb
+++ b/lib/web_of_science/process_records.rb
@@ -50,7 +50,7 @@ module WebOfScience
 
       ## 2
       # Save and select new WebOfScienceSourceRecords
-      # @param [Array<WebOfScience::Record>]
+      # @param [Array<WebOfScience::Record>] records
       # @return [Array<WebOfScience::Record>]
       def save_wos_records(records)
         # IMPORTANT: add nothing to PublicationIdentifiers here, or new_records will reject them
@@ -66,7 +66,7 @@ module WebOfScience
 
       ## 3
       # Select records that have no matching PublicationIdentifiers
-      # @param [Array<WebOfScience::Record>]
+      # @param [Array<WebOfScience::Record>] records
       # @return [Array<WebOfScience::Record>]
       def filter_by_identifiers(records)
         return [] if records.empty?
@@ -77,8 +77,8 @@ module WebOfScience
       end
 
       ## 4
-      # @param [WebOfScience::Record]
-      # @return [String|nil] WosUID for a new Publication
+      # @param [WebOfScience::Record] rec
+      # @return [String, nil] WosUID for a new Publication
       def create_publication(rec)
         return nil if WebOfScienceSourceRecord.find_by(uid: rec.uid).nil?
         # All of this is TBD, it might live here or in another class

--- a/lib/web_of_science/queries.rb
+++ b/lib/web_of_science/queries.rb
@@ -75,7 +75,7 @@ module WebOfScience
       WebOfScience::Records.new(records: '<records/>')
     end
 
-    # @param name [String] a CSV name pattern: {last name}, {first_name} [{middle_name} | {middle initial}]
+    # @param name [String] a CSV name pattern: last_name, first_name [middle_name | middle initial]
     # @param institutions [Array<String>] a set of institutions the author belongs to
     # @return [WebOfScience::Records]
     def search_by_name(name, institutions = [])

--- a/lib/web_of_science/record.rb
+++ b/lib/web_of_science/record.rb
@@ -12,7 +12,8 @@ module WebOfScience
 
     delegate %i(publishers) => :publisher
 
-    # @return doc [Nokogiri::XML::Document] WOS record document
+    # @!attribute [r] doc
+    #   @return [Nokogiri::XML::Document] WOS record document
     attr_reader :doc
 
     # @param record [String] record in XML
@@ -21,27 +22,27 @@ module WebOfScience
       @doc = WebOfScience::XmlParser.parse(record, encoded_record)
     end
 
-    # @return abstract_mapper [WebOfScience::MapAbstract]
+    # @return [WebOfScience::MapAbstract]
     def abstract_mapper
       @abstract_mapper ||= WebOfScience::MapAbstract.new(self)
     end
 
-    # @return authors [Array<Hash<String => String>>]
+    # @return [Array<Hash<String => String>>]
     def authors
       @authors ||= names.select { |name| name['role'] == 'author' }
     end
 
-    # @return doctypes [Array<String>]
+    # @return [Array<String>]
     def doctypes
       @doctypes ||= doc.search('static_data/summary/doctypes/doctype').map(&:text)
     end
 
-    # @return identifiers [Hash<String => String>]
+    # @return [Hash<String => String>]
     def identifiers
       @identifiers ||= WebOfScience::Identifiers.new self
     end
 
-    # @return names [Array<Hash<String => String>>]
+    # @return [Array<Hash<String => String>>]
     def names
       @names ||= begin
         names = doc.search('static_data/summary/names/name').map do |name|
@@ -52,7 +53,7 @@ module WebOfScience
     end
 
     # Pretty print the record in XML
-    # @return nil
+    # @return [nil]
     def print
       require 'rexml/document'
       rexml_doc = REXML::Document.new(doc.to_xml)
@@ -63,7 +64,7 @@ module WebOfScience
       nil
     end
 
-    # @return pub_info [Hash<String => String>]
+    # @return [Hash<String => String>]
     def pub_info
       @pub_info ||= begin
         info = doc.at('static_data/summary/pub_info')
@@ -81,7 +82,7 @@ module WebOfScience
     end
 
     # Extract the REC summary fields
-    # @return summary [Hash]
+    # @return [Hash<String => Object>]
     def summary
       @summary ||= {
         'abstracts' => abstracts,
@@ -94,12 +95,12 @@ module WebOfScience
     end
 
     # An OpenStruct for the summary fields
-    # @return summary [OpenStruct]
+    # @return [OpenStruct]
     def summary_struct
       to_o(summary)
     end
 
-    # @return titles [Hash<String => String>]
+    # @return [Hash<String => String>]
     def titles
       @titles ||= begin
         titles = doc.search('static_data/summary/titles/title')
@@ -108,7 +109,7 @@ module WebOfScience
     end
 
     # Extract the REC fields
-    # @return [Hash]
+    # @return [Hash<String => Object>]
     def to_h
       {
         'summary' => summary,
@@ -127,7 +128,7 @@ module WebOfScience
       to_o(to_h)
     end
 
-    # @return xml [String] XML
+    # @return [String] XML
     def to_xml
       doc.to_xml(save_with: WebOfScience::XmlParser::XML_OPTIONS).strip
     end

--- a/lib/web_of_science/records.rb
+++ b/lib/web_of_science/records.rb
@@ -16,10 +16,11 @@ module WebOfScience
     # @return [WebOfScience::Record]
     def_delegators :to_a, :sample
 
-    # @return xml [String] WOS records in XML
+    # @return [String] WOS records in XML
     def_delegators :doc, :to_xml
 
-    # @return doc [Nokogiri::XML::Document] WOS records document
+    # @!attribute [r] doc
+    #   @return [Nokogiri::XML::Document] WOS records document
     attr_reader :doc
 
     # @param records [String] records in XML
@@ -44,17 +45,17 @@ module WebOfScience
     end
 
     # Iterate over WebOfScience::WokRecord objects
-    # @yield wos_record [WebOfScience::Record]
+    # @yield [WebOfScience::Record]
     def each
       rec_nodes.each { |rec| yield WebOfScience::Record.new(record: rec.to_xml) }
     end
 
-    # @return uids [Array<String>] the rec_nodes UID values (in order)
+    # @return [Array<String>] the rec_nodes UID values (in order)
     def uids
       uid_nodes.map(&:text)
     end
 
-    # @return uid_nodes [Nokogiri::XML::NodeSet] the rec_nodes UID nodes
+    # @return [Nokogiri::XML::NodeSet] the rec_nodes UID nodes
     def uid_nodes
       rec_nodes.search('UID')
     end
@@ -99,7 +100,7 @@ module WebOfScience
 
     # Merge WoS records
     # @param record_setB [WebOfScience::Records]
-    # @return records [WebOfScience::Records] merged set of records
+    # @return [WebOfScience::Records] merged set of records
     def merge_records(record_setB)
       # create a new set of records, use a philosophy of immutability
       # Nokogiri::XML::Document.dup is a deep copy
@@ -110,7 +111,7 @@ module WebOfScience
     end
 
     # Pretty print the records in XML
-    # @return nil
+    # @return [nil]
     def print
       require 'rexml/document'
       rexml_doc = REXML::Document.new(doc.to_xml)
@@ -130,7 +131,7 @@ module WebOfScience
 
       # The UID for a WoS REC
       # @param rec [Nokogiri::XML::Element] a Wos 'REC' element
-      # @return UID [String] a Wos 'UID' value
+      # @return [String] a Wos 'UID' value
       def record_uid(rec)
         rec.search('UID').text
       end

--- a/lib/web_of_science/xml_parser.rb
+++ b/lib/web_of_science/xml_parser.rb
@@ -8,13 +8,13 @@ module WebOfScience
     XML_OPTIONS = Nokogiri::XML::Node::SaveOptions::AS_XML | Nokogiri::XML::Node::SaveOptions::NO_DECLARATION
 
     # @param element [Nokogiri::XML::Element]
-    # @return attributes [Array<Array[String, String]>]
+    # @return [Array<Array[String, String]>]
     def self.attributes_map(element)
       element.attributes.map { |name, att| [name, att.value] }
     end
 
     # @param element [Nokogiri::XML::Element]
-    # @return fields [Hash]
+    # @return [Hash]
     def self.attributes_with_children_hash(element)
       fields = attributes_map(element)
       fields += element.children.map { |c| [c.name, c.text] }


### PR DESCRIPTION
- `@return` doesn't get a name like `@param` does
- use `@!attribute [r]` for `attr_reader`, not just `@return`
- Commas, not pipes to delimit variations
- Added a few new YARD lines, expanded on others (e.g. `Hash<X => Y>` instead of just `Hash`)
- Default values are already interpreted by YARD from method declaration