### PR TITLE
WOS filter databases

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -44,6 +44,9 @@ SCIENCEWIRE:
 
 ## Web Of Science Auth Config
 WOS:
+  ACCEPTED_DBS:
+    - WOS
+    - MEDLINE
   AUTH_CODE: secret
   LOG: log/web_of_science.log
   LOG_LEVEL: info

--- a/lib/web_of_science/process_records.rb
+++ b/lib/web_of_science/process_records.rb
@@ -55,7 +55,8 @@ module WebOfScience
       # @return [Array<WebOfScience::Record>]
       def match_wos_records(records)
         return [] if records.count.zero?
-        records.select { |rec| WebOfScienceSourceRecord.where(uid: rec.uid).count.zero? }
+        matching_uids = WebOfScienceSourceRecord.where(uid: records.map(&:uid)).pluck(:uid)
+        records.reject { |rec| matching_uids.include? rec.uid }
       end
 
       ## 3

--- a/lib/web_of_science/process_records.rb
+++ b/lib/web_of_science/process_records.rb
@@ -34,7 +34,8 @@ module WebOfScience
 
       # @return [Array<String>] WosUIDs that create a new Publication
       def create_publications
-        new_wos_records = match_wos_records # cf. WebOfScienceSourceRecord
+        filtered_records = filter_databases
+        new_wos_records = match_wos_records(filtered_records) # cf. WebOfScienceSourceRecord
         saved_wos_records = save_wos_records(new_wos_records) # save WebOfScienceSourceRecord
         records = filter_by_identifiers(saved_wos_records) # cf. PublicationIdentifier
         records.map { |rec| create_publication(rec) }.compact
@@ -43,12 +44,21 @@ module WebOfScience
       ## 1
       # Filter and select new WebOfScienceSourceRecords
       # @return [Array<WebOfScience::Record>]
-      def match_wos_records
+      def filter_databases
+        return [] if records.count.zero?
+        return records if Settings.WOS.ACCEPTED_DBS.empty?
+        records.select { |rec| Settings.WOS.ACCEPTED_DBS.include? rec.database }
+      end
+
+      ## 2
+      # Filter and select new WebOfScienceSourceRecords
+      # @return [Array<WebOfScience::Record>]
+      def match_wos_records(records)
         return [] if records.count.zero?
         records.select { |rec| WebOfScienceSourceRecord.where(uid: rec.uid).count.zero? }
       end
 
-      ## 2
+      ## 3
       # Save and select new WebOfScienceSourceRecords
       # @param [Array<WebOfScience::Record>] records
       # @return [Array<WebOfScience::Record>]
@@ -64,7 +74,7 @@ module WebOfScience
         end
       end
 
-      ## 3
+      ## 4
       # Select records that have no matching PublicationIdentifiers
       # @param [Array<WebOfScience::Record>] records
       # @return [Array<WebOfScience::Record>]

--- a/spec/lib/web_of_science/process_records_spec.rb
+++ b/spec/lib/web_of_science/process_records_spec.rb
@@ -51,12 +51,10 @@ describe WebOfScience::ProcessRecords do
     # Happy paths
 
     it 'works' do
-      result = processor.execute
-      expect(result).not_to be_nil
+      expect(processor.execute).not_to be_nil
     end
     it 'returns an Array' do
-      result = processor.execute
-      expect(result).to be_an Array
+      expect(processor.execute).to be_an Array
     end
     it 'returns Array<String> with WosUIDs on success' do
       result = processor.execute
@@ -123,5 +121,25 @@ describe WebOfScience::ProcessRecords do
     end
 
     it_behaves_like '#execute'
+  end
+
+  context 'with records from excluded databases' do
+    subject(:processor) { described_class.new(author, records) }
+
+    let(:other_record_xml) do
+      xml = File.read('spec/fixtures/wos_client/wos_record_000288663100014.xml')
+      xml.gsub('WOS', 'EXCLUDED')
+    end
+    let(:other_records_xml) { "<records>#{other_record_xml}</records>" }
+    let(:other_records) { WebOfScience::Records.new(records: other_records_xml) }
+
+    let(:records) { other_records }
+
+    it 'does not create new WebOfScienceSourceRecords' do
+      expect { processor.execute }.not_to change { WebOfScienceSourceRecord.count }
+    end
+    it 'filters out excluded records' do
+      expect(processor.send(:filter_databases)).to be_empty
+    end
   end
 end


### PR DESCRIPTION
Fix #419 

Selects only WOS & MEDLINE records for processing, using a configuration setting to specify what databases are allowed to be processed.