### PR TITLE
Resolve passing of invalid values to Contribution model from Publication

### DIFF
--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -282,7 +282,7 @@ class Publication < ActiveRecord::Base
 
     def update_any_new_contribution_info_in_pub_hash_to_db
       Array(pub_hash[:authorship]).each do |contrib|
-        hash_for_update = contrib.slice(:status, :visibility, :featured)
+        hash_for_update = contrib.slice(:status, :visibility, :featured).each { |_k, v| v.downcase! if v.respond_to?(:downcase!) }
         # Find or create an Author of the contribution
         cap_profile_id = contrib[:cap_profile_id]
         author = Author.find_by_id(contrib[:sul_author_id])

--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -167,6 +167,14 @@ describe Publication do
       expect(c.status).to eq('new')
     end
 
+    it 'should downcase status and visibility values' do
+      publication.pub_hash = { authorship: [{ status: 'NEW', sul_author_id: author.id, visibility: 'PUBLIC' }] }
+      publication.send(:update_any_new_contribution_info_in_pub_hash_to_db)
+      c = publication.contributions.last
+      expect(c.status).to eq('new')
+      expect(c.visibility).to eq('public')
+    end
+
     it 'should update attributions of existing contributions to the database' do
       expect(publication.contributions.size).to eq(0)
       publication.contributions.create(author: author, cap_profile_id: author.cap_profile_id, status: 'unknown')


### PR DESCRIPTION
The values would have been coecred by Contribution, IF we passed them to the initializer.  Instead we use `first_or_initialize` and then `assign_attributes`, so we need to correct them in Publication first.

Fortunately, that is simple to accomplish.