### PR TITLE
Similar refactoring comes to publications_api_spec

### DIFF
--- a/spec/api/sul_bib/publications_api_spec.rb
+++ b/spec/api/sul_bib/publications_api_spec.rb
@@ -1,12 +1,8 @@
-
 describe SulBib::API, :vcr do
   let(:publication) { FactoryBot.create :publication }
-  let!(:publication_with_contributions) { create :publication_with_contributions, contributions_count: 2 }
-  let(:publication_list) { create_list(:contribution, 15, visibility: 'public', status: 'approved') }
   let(:author) { FactoryBot.create :author }
-  let(:author_with_sw_pubs) { create :author_with_sw_pubs }
   let(:headers) { { 'HTTP_CAPKEY' => Settings.API_KEY, 'CONTENT_TYPE' => 'application/json' } }
-  let(:valid_json_for_post) do
+  let(:valid_hash_for_post) do
     {
       type: 'book',
       title: 'some title',
@@ -23,30 +19,27 @@ describe SulBib::API, :vcr do
         visibility: 'public',
         featured: true
       }]
-    }.to_json
+    }
   end
+  let(:valid_json_for_post) { valid_hash_for_post.to_json }
 
   let(:invalid_json_for_post) do
-    pub = JSON.parse(valid_json_for_post.dup)
-    pub.delete 'authorship'
-    pub.to_json
+    valid_hash_for_post.reject { |k, _| k == :authorship }.to_json
   end
 
   let(:json_with_new_author) do
-    pub = JSON.parse(valid_json_for_post.dup)
-    pub['author'] = [{
-      name: 'henry lowe'
-    }]
-    pub['authorship'] = [{
-      cap_profile_id: '3810',
-      status: 'denied',
-      visibility: 'public',
-      featured: true
-    }]
-    pub.to_json
+    valid_hash_for_post.merge(
+      author: [{ name: 'henry lowe' }],
+      authorship: [{
+        cap_profile_id: '3810',
+       status: 'denied',
+       visibility: 'public',
+       featured: true
+      }]
+    ).to_json
   end
 
-  let(:json_with_isbn) do
+  let(:with_isbn_hash) do
     {
       abstract: '',
       abstract_restricted: '',
@@ -71,36 +64,36 @@ describe SulBib::API, :vcr do
       series: { number: '919', title: 'Series 1', volume: '1' },
       type: 'book',
       year: '2010'
-    }.to_json
+    }
   end
 
-  let(:json_with_isbn_changed_doi) do
-    pub = JSON.parse(json_with_isbn)
-    pub['identifier'] = [
-      { type: 'isbn', id: '1177188188181' },
-      { type: 'doi', url: '18819910019-updated' },
-      { type: 'SULPubId', id: '164', url: Settings.SULPUB_ID.PUB_URI + '/164' }
-    ]
-    pub.to_json
+  let(:with_isbn_changed_doi) do
+    valid_hash_for_post.merge(
+      identifier: [
+        { type: 'isbn', id: '1177188188181' },
+        { type: 'doi', url: '18819910019-updated' },
+        { type: 'SULPubId', id: '164', url: Settings.SULPUB_ID.PUB_URI + '/164' }
+      ]
+    )
   end
 
-  let(:json_with_isbn_deleted_doi) do
-    pub = JSON.parse(json_with_isbn_changed_doi)
-    pub['identifier'] = [
-      { type: 'isbn', id: '1177188188181' },
-      { type: 'SULPubId', id: '164', url: Settings.SULPUB_ID.PUB_URI + '/164' }
-    ]
-    pub.to_json
+  let(:with_isbn_deleted_doi) do
+    with_isbn_changed_doi.merge(
+      identifier: [
+        { type: 'isbn', id: '1177188188181' },
+        { type: 'SULPubId', id: '164', url: Settings.SULPUB_ID.PUB_URI + '/164' }
+      ]
+    )
   end
 
   let(:json_with_pubmedid) do
-    pub = JSON.parse(json_with_isbn)
-    pub['identifier'] = [
-      { type: 'isbn', id: '1177188188181' },
-      { type: 'doi', url: '18819910019' },
-      { type: 'pmid', id: '999999999' },
-    ]
-    pub.to_json
+    with_isbn_hash.merge(
+      identifier: [
+        { type: 'isbn', id: '1177188188181' },
+        { type: 'doi', url: '18819910019' },
+        { type: 'pmid', id: '999999999' },
+      ]
+    ).to_json
   end
 
   let(:article_with_authorship_without_authors) do
@@ -141,9 +134,7 @@ describe SulBib::API, :vcr do
     matching_fields = %w(visibility status featured cap_profile_id)
     pub_hash[:authorship].each_with_index do |pub_authorship, index|
       sub_authorship = submission['authorship'][index]
-      expect(sub_authorship).not_to be_nil
       expect(sub_authorship).not_to be_empty
-      expect(pub_authorship).not_to be_nil
       expect(pub_authorship).not_to be_empty
       matching_fields.each do |field|
         pub_field = pub_authorship[field.to_sym]
@@ -156,6 +147,9 @@ describe SulBib::API, :vcr do
   end
 
   describe 'POST /publications' do
+    let(:result) { JSON.parse(response.body) }
+    let(:last_pub) { Publication.last }
+
     context 'when valid post' do
       let(:submission) { JSON.parse(valid_json_for_post) }
 
@@ -165,12 +159,12 @@ describe SulBib::API, :vcr do
 
       it 'returns bibjson from the pub_hash for the new publication' do
         post_valid_json
-        expect(response.body).to eq(Publication.last.pub_hash.to_json)
+        expect(response.body).to eq(last_pub.pub_hash.to_json)
       end
 
       it 'creates a new contributions record in the db' do
         post_valid_json
-        expect(Contribution.where(publication_id: Publication.last.id, author_id: author.id).first.status).to eq('denied')
+        expect(Contribution.where(publication_id: last_pub.id, author_id: author.id).first.status).to eq('denied')
       end
 
       it 'increases number of contribution records by one' do
@@ -187,68 +181,64 @@ describe SulBib::API, :vcr do
 
       it 'creates an appropriate publication record from the posted bibjson' do
         post_valid_json
-        pub = Publication.last
-        expect(pub.title).to eq(submission['title'])
-        expect(pub.year).to eq(submission['year'])
-        expect(pub.pages).to eq(submission['pages'].sub('-', '–')) # em-dash
-        expect(pub.issn).to eq(submission['issn'])
+        expect(last_pub.title).to eq(submission['title'])
+        expect(last_pub.year).to eq(submission['year'])
+        expect(last_pub.pages).to eq(submission['pages'].sub('-', '–')) # em-dash
+        expect(last_pub.issn).to eq(submission['issn'])
       end
 
       it 'creates a matching pub_hash in the publication record from the posted bibjson' do
         post_valid_json
-        validate_authorship(Publication.last.pub_hash, submission)
+        validate_authorship(last_pub.pub_hash, submission)
       end
 
       it 'handles missing author using authorship from the posted bibjson' do
         post '/publications', article_with_authorship_without_authors, headers
         expect(response.status).to eq(201)
-        validate_authorship(Publication.last.pub_hash, JSON.parse(article_with_authorship_without_authors))
+        validate_authorship(last_pub.pub_hash, JSON.parse(article_with_authorship_without_authors))
       end
 
       it 'creates a pub with matching authorship info in hash and contributions table' do
         post_valid_json
-        pub = Publication.last
-        contrib = Contribution.where(publication_id: pub.id, author_id: author.id).first
+        authorship = JSON.parse(valid_json_for_post)['authorship'][0]
+        contrib = Contribution.find_by(publication_id: last_pub.id, author_id: author.id)
         # TODO: evaluate whether authorship array should result in one or more contributions?
-        expect(contrib.visibility).to eq(submission['authorship'][0]['visibility'])
-        expect(contrib.status).to eq(submission['authorship'][0]['status'])
-        expect(contrib.featured).to eq(submission['authorship'][0]['featured'])
-        expect(contrib.cap_profile_id).to eq(submission['authorship'][0]['cap_profile_id'])
+        expect(contrib.visibility).to eq(authorship['visibility'])
+        expect(contrib.status).to eq(authorship['status'])
+        expect(contrib.featured).to eq(authorship['featured'])
+        expect(contrib.cap_profile_id).to eq(authorship['cap_profile_id'])
       end
 
       it 'does not duplicate SULPubIds' do
         json_with_sul_pub_id = { type: 'book', identifier: [{ type: 'SULPubId', id: 'n', url: 'm' }], authorship: [{ sul_author_id: author.id, status: 'denied', visibility: 'public', featured: true }] }.to_json
         post '/publications', json_with_sul_pub_id, headers
         expect(response.status).to eq(201)
-        parsed_outgoing_json = JSON.parse(response.body)
-        expect(parsed_outgoing_json['identifier'].count { |x| x['type'] == 'SULPubId' }).to eq(1)
-        expect(parsed_outgoing_json['identifier'][0]['id']).not_to eq('n')
+        expect(result['identifier'].count { |x| x['type'] == 'SULPubId' }).to eq(1)
+        expect(result['identifier'][0]['id']).not_to eq('n')
       end
 
       it 'creates a pub with with isbn' do
-        post '/publications', json_with_isbn, headers
+        post '/publications', with_isbn_hash.to_json, headers
         expect(response.status).to eq(201)
-        pub = Publication.last
         # TODO: use the submission data to validate some of the identifier fields
         # submission = JSON.parse(json_with_isbn)
-        parsed_outgoing_json = JSON.parse(response.body)
-        expect(parsed_outgoing_json['identifier']).to include('id' => '1177188188181', 'type' => 'isbn')
-        expect(parsed_outgoing_json['identifier']).to include('type' => 'doi', 'url' => '18819910019')
-        expect(parsed_outgoing_json['identifier']).to include('type' => 'SULPubId', 'url' => "#{Settings.SULPUB_ID.PUB_URI}/#{pub.id}", 'id' => pub.id.to_s)
-        expect(parsed_outgoing_json['identifier'].size).to eq(3)
-        expect(pub.publication_identifiers.size).to eq(2)
-        expect(pub.publication_identifiers.map(&:identifier_type)).to include('doi', 'isbn')
-        expect(response.body).to eq(pub.pub_hash.to_json)
+        expect(result['identifier'].size).to eq(3)
+        expect(result['identifier']).to include(
+          a_hash_including('id' => '1177188188181', 'type' => 'isbn'),
+          a_hash_including('type' => 'doi', 'url' => '18819910019'),
+          a_hash_including('type' => 'SULPubId', 'url' => "#{Settings.SULPUB_ID.PUB_URI}/#{last_pub.id}", 'id' => last_pub.id.to_s)
+        )
+        expect(last_pub.publication_identifiers.size).to eq(2)
+        expect(last_pub.publication_identifiers.map(&:identifier_type)).to include('doi', 'isbn')
+        expect(response.body).to eq(last_pub.pub_hash.to_json)
       end
 
       it 'creates a pub with with pmid' do
         post '/publications', json_with_pubmedid, headers
         expect(response.status).to eq(201)
-        pub = Publication.last
-        parsed_outgoing_json = JSON.parse(response.body)
-        expect(parsed_outgoing_json['identifier']).to include('id' => '999999999', 'type' => 'pmid')
-        expect(pub.publication_identifiers.map(&:identifier_type)).to include('pmid')
-        expect(response.body).to eq(pub.pub_hash.to_json)
+        expect(result['identifier']).to include('id' => '999999999', 'type' => 'pmid')
+        expect(last_pub.publication_identifiers.map(&:identifier_type)).to include('pmid')
+        expect(response.body).to eq(last_pub.pub_hash.to_json)
       end
     end # end of the context
 
@@ -269,8 +259,7 @@ describe SulBib::API, :vcr do
         skip 'Administrative Systems firewall only allows IP-based requests'
         post '/publications', json_with_new_author, headers
         expect(response.status).to eq(201)
-        auth = Author.where(cap_profile_id: '3810').first
-        expect(auth.cap_last_name).to eq('Lowe')
+        expect(Author.find_by(cap_profile_id: '3810').cap_last_name).to eq('Lowe')
       end
     end
   end # end of the describe
@@ -279,6 +268,9 @@ describe SulBib::API, :vcr do
   # PUT
 
   describe 'PUT /publications/:id' do
+    let(:result) { JSON.parse(response.body) }
+    after { expect(response.status).to eq(200) }
+
     it 'does not duplicate SULPubIDs' do
       json_with_sul_pub_id = {
         type: 'book',
@@ -295,33 +287,31 @@ describe SulBib::API, :vcr do
         }]
       }.to_json
       put "/publications/#{publication.id}", json_with_sul_pub_id, headers
-      expect(response.status).to eq(200)
-      parsed_outgoing_json = JSON.parse(response.body)
-      expect(parsed_outgoing_json['identifier'].count { |x| x['type'] == 'SULPubId' }).to eq(1)
-      expect(parsed_outgoing_json['identifier'][0]['id']).not_to eq('n')
+      expect(result['identifier'].count { |x| x['type'] == 'SULPubId' }).to eq(1)
+      expect(result['identifier'][0]['id']).not_to eq('n')
     end
 
-    it 'updates an existing pub ' do
-      post '/publications', json_with_isbn, headers
+    it 'updates an existing pub' do
+      post '/publications', with_isbn_hash.to_json, headers
       id = Publication.last.id
-      put "/publications/#{id}", json_with_isbn_changed_doi, headers
-      expect(response.status).to eq(200)
-      parsed_outgoing_json = JSON.parse(response.body)
-      expect(parsed_outgoing_json['identifier'].size).to eq(3)
-      expect(parsed_outgoing_json['identifier']).to include('type' => 'isbn', 'id' => '1177188188181')
-      expect(parsed_outgoing_json['identifier']).to include('type' => 'doi', 'url' => '18819910019-updated')
-      expect(parsed_outgoing_json['identifier']).to include('type' => 'SULPubId', 'id' => id.to_s, 'url' => "#{Settings.SULPUB_ID.PUB_URI}/#{id}")
+      put "/publications/#{id}", with_isbn_changed_doi.to_json, headers
+      expect(result['identifier'].size).to eq(3)
+      expect(result['identifier']).to include(
+        a_hash_including('type' => 'isbn', 'id' => '1177188188181'),
+        a_hash_including('type' => 'doi', 'url' => '18819910019-updated'),
+        a_hash_including('type' => 'SULPubId', 'id' => id.to_s, 'url' => "#{Settings.SULPUB_ID.PUB_URI}/#{id}")
+      )
     end
 
     it 'deletes an identifier from the db if it is not in the incoming json' do
-      post '/publications', json_with_isbn, headers
+      post '/publications', with_isbn_hash.to_json, headers
       id = Publication.last.id
-      put "/publications/#{id}", json_with_isbn_deleted_doi, headers
-      expect(response.status).to eq(200)
-      parsed_outgoing_json = JSON.parse(response.body)
-      expect(parsed_outgoing_json['identifier'].size).to eq(2)
-      expect(parsed_outgoing_json['identifier']).to include('type' => 'isbn', 'id' => '1177188188181')
-      expect(parsed_outgoing_json['identifier']).to include('type' => 'SULPubId', 'url' => "#{Settings.SULPUB_ID.PUB_URI}/#{id}", 'id' => id.to_s)
+      put "/publications/#{id}", with_isbn_deleted_doi.to_json, headers
+      expect(result['identifier'].size).to eq(2)
+      expect(result['identifier']).to include(
+        a_hash_including('type' => 'isbn', 'id' => '1177188188181'),
+        a_hash_including('type' => 'SULPubId', 'url' => "#{Settings.SULPUB_ID.PUB_URI}/#{id}", 'id' => id.to_s)
+      )
     end
   end
 
@@ -329,33 +319,23 @@ describe SulBib::API, :vcr do
   # GET
 
   describe 'GET /publications/:id' do
-    it ' returns 200 for valid call ' do
-      get "/publications/#{publication.id}",
-          { format: 'json' },
-          headers
+    it 'returns 200 for valid call' do
+      get "/publications/#{publication.id}", { format: 'json' }, headers
       expect(response.status).to eq(200)
     end
     it 'returns a publication bibjson doc by id' do
-      publication
-      get "/publications/#{publication.id}",
-          { format: 'json' },
-          'HTTP_CAPKEY' => Settings.API_KEY
+      get "/publications/#{publication.id}", { format: 'json' }, headers
       expect(response.body).to eq(publication.pub_hash.to_json)
     end
 
     it 'returns a pub with valid bibjson for sw harvested records' do
-      auth = author_with_sw_pubs
-      auth.contributions.destroy_all # wipe the slate clean
-      ScienceWireHarvester.new.harvest_pubs_for_author_ids([auth.id])
+      author.contributions.destroy_all # wipe the slate clean
+      ScienceWireHarvester.new.harvest_pubs_for_author_ids([author.id])
       new_pub = Publication.last
-      get "/publications/#{new_pub.id}",
-          { format: 'json' },
-          headers
+      get "/publications/#{new_pub.id}", { format: 'json' }, headers
       expect(response.status).to eq(200)
       expect(response.body).to eq(new_pub.pub_hash.to_json)
-      result = JSON.parse(response.body)
-      expect(result['provenance']).to eq('sciencewire')
-      expect(result['type']).to eq('article')
+      expect(JSON.parse(response.body)).to include('provenance' => 'sciencewire', 'type' => 'article')
     end
 
     it 'returns only those pubs changed since specified date'
@@ -364,69 +344,46 @@ describe SulBib::API, :vcr do
 
     context "when pub id doesn't exist" do
       it 'returns not found code' do
-        get '/publications/88888888888',
-            { format: 'json' },
-            headers
+        get '/publications/88888888888', { format: 'json' }, headers
         expect(response.status).to eq(404)
       end
     end
   end # end of the describe
 
   describe 'GET /publications' do
+    let(:result) { JSON.parse(response.body) }
+
     context 'with no params specified' do
       it 'returns first page' do
-        get '/publications/',
-            { format: 'json' },
-            headers
-        result = JSON.parse(response.body)
-        expect(result['metadata']['page']).to eq(1)
-        expect(JSON.parse(response.body)['records']).to be
+        get '/publications/', { format: 'json' }, headers
+        expect(result['records']).to be
       end
-    end # end of context
+    end
 
-    context 'when there are 150 records' do
-      it "raises an error if a capkey isn't provided" do
-        publication_list
-        get '/publications?page=1&per=7',
-            format: 'json'
-        expect(response.status).to eq(401)
-      end
+    it "raises an error if a capkey isn't provided" do
+      get '/publications?page=1&per=7', format: 'json' # no headers
+      expect(response.status).to eq(401)
+    end
 
-      it 'returns a one page collection of 100 bibjson records when no paging is specified' do
-        publication_list
-        get '/publications?page=1&per=7',
-            { format: 'json' },
-            headers
-        expect(response.status).to eq(200)
+    context 'when there are many records' do
+      before { create_list(:contribution, 15, visibility: 'public', status: 'approved') }
+      after { expect(response.status).to eq(200) }
+
+      it 'returns one page with specified number of records' do
+        get '/publications?page=1&per=7', { format: 'json' }, headers
         expect(response.headers['Content-Type']).to be =~ %r{application/json}
-
-        result = JSON.parse(response.body)
-
-        expect(result['metadata']['records']).to eq('7')
-        expect(result['metadata']['page']).to eq(1)
+        expect(result['metadata']).to include('records' => '7', 'page' => 1)
         expect(result['records'][2]['author']).to be
       end
 
       it 'filters by active authors' do
-        publication_list
-        get '/publications?page=1&per=1&capActive=true',
-            { format: 'json' },
-            headers
-        expect(response.status).to eq(200)
-        result = JSON.parse(response.body)
-        expect(result['metadata']['records']).to eq('1')
-        expect(result['metadata']['page']).to eq(1)
+        get '/publications?page=1&per=1&capActive=true', { format: 'json' }, headers
+        expect(result['metadata']).to include('records' => '1', 'page' => 1)
       end
 
       it 'paginates by active authors' do
-        publication_list
-        get '/publications?page=2&per=1&capActive=true',
-            { format: 'json' },
-            headers
-        expect(response.status).to eq(200)
-        result = JSON.parse(response.body)
-        expect(result['metadata']['records']).to eq('1')
-        expect(result['metadata']['page']).to eq(2)
+        get '/publications?page=2&per=1&capActive=true', { format: 'json' }, headers
+        expect(result['metadata']).to include('records' => '1', 'page' => 2)
       end
     end # end of context
   end # end of the describe

--- a/spec/factories/author.rb
+++ b/spec/factories/author.rb
@@ -18,10 +18,6 @@ FactoryBot.define do
     emails_for_harvest 'alice.edler@stanford.edu'
   end
 
-  factory :author_with_sw_pubs, parent: :author do
-    id 33
-  end
-
   factory :inactive_author, parent: :author do
     active_in_cap false
   end


### PR DESCRIPTION
- common `let` statements (that are about their return values, not about establishing a context)
- removed unused `let` statement
- converted another to a `before` block, since the return values weren't being used, it was really about establishing context
- AVOID SERIALIZING/DESERIALING JSON... SERIALLY
- Manipulate hashes, serialize to JSON later
- Corrected some description statements that were lying about the numbers inolved
- Removed a single-use factory that was materially no different than the base factory, but had a name that suggested it did something special.
- harness the power of RSpec `include`

These changes are not as comprehensive as the previous ones on authorship_api_spec, but
they are a great improvement in performance and readability.