### PR TITLE
Add unique constraint to Author cap_profile_id

### DIFF
--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -1,5 +1,6 @@
 class Author < ActiveRecord::Base
   has_paper_trail on: [:destroy]
+  validates :cap_profile_id, uniqueness: true
 
   has_many :author_identities, dependent: :destroy
   #

--- a/db/migrate/20171208233331_author_cap_profile_id_uniqueness.rb
+++ b/db/migrate/20171208233331_author_cap_profile_id_uniqueness.rb
@@ -1,0 +1,6 @@
+class AuthorCapProfileIdUniqueness < ActiveRecord::Migration
+  def change
+    remove_index :authors, :cap_profile_id
+    add_index :authors, :cap_profile_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171207233451) do
+ActiveRecord::Schema.define(version: 20171208233331) do
 
   create_table "author_identities", force: :cascade do |t|
     t.integer  "author_id",     limit: 4,               null: false
@@ -53,7 +53,7 @@ ActiveRecord::Schema.define(version: 20171207233451) do
 
   add_index "authors", ["active_in_cap"], name: "index_authors_on_active_in_cap", using: :btree
   add_index "authors", ["california_physician_license"], name: "index_authors_on_california_physician_license", using: :btree
-  add_index "authors", ["cap_profile_id"], name: "index_authors_on_cap_profile_id", using: :btree
+  add_index "authors", ["cap_profile_id"], name: "index_authors_on_cap_profile_id", unique: true, using: :btree
   add_index "authors", ["sunetid"], name: "index_authors_on_sunetid", using: :btree
   add_index "authors", ["university_id"], name: "index_authors_on_university_id", using: :btree
 

--- a/spec/lib/cap_authors_poller_spec.rb
+++ b/spec/lib/cap_authors_poller_spec.rb
@@ -1,4 +1,3 @@
-
 describe CapAuthorsPoller, :vcr do
   # The author is defined in /spec/factories/author.rb
   let(:author) { create :author }
@@ -82,14 +81,12 @@ describe CapAuthorsPoller, :vcr do
     context 'with an existing author' do
       before do
         expect(Author).to receive(:find_by_cap_profile_id).with(author.cap_profile_id).and_return(author)
-        expect(author).to receive(:'save!').and_call_original
+        expect(author).to receive(:'save!')
       end
 
       it 'updates an existing author' do
         expect(author).to receive(:harvestable?).and_return(true)
-        count = subject.instance_variable_get('@authors_updated_count')
-        subject.process_record(author_record)
-        expect(subject.instance_variable_get('@authors_updated_count')).to eq(count + 1)
+        expect { subject.process_record(author_record) }.to change { subject.instance_variable_get('@authors_updated_count') }.by(1)
       end
 
       it 'adds author.id to the harvest queue when harvesting is enabled' do
@@ -103,9 +100,7 @@ describe CapAuthorsPoller, :vcr do
       it 'skips harvesting for an existing author if not marked harvestable' do
         allow(author).to receive(:changed?).and_return(true)
         expect(author).to receive(:harvestable?).and_return(false)
-        count = subject.instance_variable_get('@no_sw_harvest_count')
-        subject.process_record(author_record)
-        expect(subject.instance_variable_get('@no_sw_harvest_count')).to eq(count + 1)
+        expect { subject.process_record(author_record) }.to change { subject.instance_variable_get('@no_sw_harvest_count') }.by(1)
       end
 
       context 'with an authorship record' do
@@ -120,14 +115,12 @@ describe CapAuthorsPoller, :vcr do
       before do
         expect(Author).to receive(:find_by_cap_profile_id).with(author.cap_profile_id).and_return(nil)
         expect(Author).to receive(:fetch_from_cap_and_create).with(author.cap_profile_id, instance_of(CapHttpClient)).and_return(author)
-        expect(author).to receive(:'save!').and_call_original
+        expect(author).to receive(:'save!')
         allow(author).to receive(:new_record?).and_return(true)
       end
 
       it 'creates a new author' do
-        count = subject.instance_variable_get('@new_author_count')
-        subject.process_record(author_record)
-        expect(subject.instance_variable_get('@new_author_count')).to eq(count + 1)
+        expect { subject.process_record(author_record) }.to change { subject.instance_variable_get('@new_author_count') }.by(1)
       end
 
       it 'harvests for new authors marked harvestable' do
@@ -139,17 +132,13 @@ describe CapAuthorsPoller, :vcr do
 
       it 'skips harvests for new authors not marked harvestable' do
         expect(author).to receive(:harvestable?).and_return(false)
-        count = subject.instance_variable_get('@no_sw_harvest_count')
-        subject.process_record(author_record)
-        expect(subject.instance_variable_get('@no_sw_harvest_count')).to eq(count + 1)
+        expect { subject.process_record(author_record) }.to change { subject.instance_variable_get('@no_sw_harvest_count') }.by(1)
       end
 
       context 'with an authorship record' do
         it 'recognizes authorship contributions' do
-          count = subject.instance_variable_get('@new_auth_with_contribs')
-          subject.process_record(authorship_record)
-          expect(subject.instance_variable_get('@new_auth_with_contribs')).to eq(count + 1)
           expect(subject).not_to receive(:update_existing_contributions)
+          expect { subject.process_record(authorship_record) }.to change { subject.instance_variable_get('@new_auth_with_contribs') }.by(1)
         end
       end
     end

--- a/spec/models/author_spec.rb
+++ b/spec/models/author_spec.rb
@@ -1,4 +1,3 @@
-
 describe Author do
   let(:auth_hash) do
     JSON.parse(File.open('fixtures/cap_poll_author_3810.json', 'r').read)
@@ -6,6 +5,13 @@ describe Author do
 
   let(:missing_fields) do
     JSON.parse(File.open('fixtures/cap_poll_author_3810_missing.json', 'r').read)
+  end
+
+  describe '#cap_profile_id' do
+    it 'validates uniqueness' do
+      Author.find_or_create_by!(cap_profile_id: 1)
+      expect { Author.create!(cap_profile_id: 1) }.to raise_error ActiveRecord::RecordInvalid
+    end
   end
 
   describe '#first_name' do


### PR DESCRIPTION
Belt and suspenders approach here:
- model validation
- database constraint

I verified that there are no duplicate `cap_profile_id` values on
production server, so no data repair/salvage will be necessary:
```ruby
Author.select(:id, :cap_profile_id).group(:cap_profile_id).having("count(*) > 1")
=> []
```

This will help simplify API logic that runs in circles worrying that maybe `cap_profile_id` is not unique enough.