### PR TITLE
WebOfScienceSourceRecord#record returns a WebOfScience::Record

### DIFF
--- a/app/models/web_of_science_source_record.rb
+++ b/app/models/web_of_science_source_record.rb
@@ -21,6 +21,11 @@ class WebOfScienceSourceRecord < ActiveRecord::Base
     end
   end
 
+  # @return [WebOfScience::Record]
+  def record
+    @record ||= WebOfScience::Record.new(record: source_data)
+  end
+
   def source_fingerprint
     super || self.source_fingerprint = Digest::SHA2.hexdigest(source_data)
   end

--- a/spec/models/web_of_science_source_record_spec.rb
+++ b/spec/models/web_of_science_source_record_spec.rb
@@ -36,6 +36,9 @@ RSpec.describe WebOfScienceSourceRecord, type: :model do
     it 'has a Nokogiri::XML::Document' do
       expect(wos_src_rec.doc).to be_an Nokogiri::XML::Document
     end
+    it 'has a WebOfScience::Record' do
+      expect(wos_src_rec.record).to be_a WebOfScience::Record
+    end
     it 'has an XML String' do
       expect(wos_src_rec.to_xml).to be_an String
     end


### PR DESCRIPTION
Connected to #506 or anything that needs to instantiate a `WebOfScience::Record` from the active record db data.