### PR TITLE
NotificationManager#error - rescue StandardError

### DIFF
--- a/lib/notification_manager.rb
+++ b/lib/notification_manager.rb
@@ -22,7 +22,7 @@ class NotificationManager
       else
         log_exception(Rails.logger, log_message, e)
       end
-    rescue => e2
+    rescue StandardError => e2
       log_exception(Rails.logger, e2.message, e2)
     ensure
       Honeybadger.notify(e, context: { message: log_message })


### PR DESCRIPTION

Split out of #454 

The app has a lot of `rescue` code that should only handle `StandardError`, this is the only one in the `NotificationManager`.