### PR TITLE
Allow Config gem to pull from ENV values/overrides

### DIFF
--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -1,1 +1,6 @@
-Config.setup { }
+Config.setup do |config|
+  config.use_env = true
+  config.env_prefix = 'SETTINGS'
+  config.env_separator = '__'
+  config.env_converter = nil # our keys mix ALLCAPS and downcase
+end


### PR DESCRIPTION
Conceivably this helps encapsulate overrides for Travis.

Example test you can perform locally, say in `spec/config_spec.rb`:
```ruby
describe 'config gem, how do u work?' do
  it 'overrides from ENV' do
    expect(Settings.WOS.enabled).to eq(true)
  end
  it 'reads from ENV' do
    expect(Settings.whatever).to be_nil
  end
  it 'handles underscores' do
    expect(Settings.SULPUB_ID.PUB_URI).to eq('http://sulcap.stanford.edu/publications')
  end
end
```
Then run these to see the difference in behavior:
```bash
rspec spec/config_spec.rb # passes
SETTINGS__WOS__enabled=false rspec spec/config_spec.rb # 1st fails
SETTINGS__whatever=foobar rspec spec/config_spec.rb    # 2nd fails
SETTINGS__SULPUB_ID__PUB_URI=www.google.com rspec spec/config_spec.rb # 3rd fails
```

The gem behavior is defined [here](https://github.com/railsconfig/config#fine-tuning).  Note that the separator double-underscore instead of dot, in keeping w/ our convention (some shells, ENVs and config mgmt tools don't allow dot).  