### PR TITLE
CAP API settings are public

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,13 +17,13 @@ CAP:
   LOG: log/cap.log
   PROFILE_ID_REWRITE_LOG: log/cap_profile_id_rewrite.log
   PORT: 443
-  TOKEN_PASS: something
   TOKEN_PATH: /oauth/token
-  TOKEN_URI: something
-  TOKEN_USER: something
+  TOKEN_URI: authz.stanford.edu
+  TOKEN_USER: sul
+  TOKEN_PASS: something
   AUTHORSHIP_API_PATH: /cap-api/api/cap/v1/authors
   AUTHORSHIP_API_PORT: 443
-  AUTHORSHIP_API_URI: something
+  AUTHORSHIP_API_URI: cap-uat.stanford.edu
 
 ## PubMed Auth Config
 PUBMED:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -103,7 +103,8 @@ VCR.configure do |c|
   c.filter_sensitive_data('private_access_token') do |interaction|
     if interaction.request.body == "grant_type=client_credentials"
       regex = %r("access_token":"(.*?)")
-      regex.match(interaction.response.body).captures.first
+      matches = regex.match(interaction.response.body)
+      matches.captures.first if matches.present?
     end
   end
   c.filter_sensitive_data('private_bearer_token') do |interaction|


### PR DESCRIPTION
Connected to #490 

Outcome of review on #454 to allow some CAP API settings to be public.

- updated the travis.ci ENV values.
- this needs to work with the old cap-client, which does not accept the `https://` prefix.