### PR TITLE
Factory bot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ group :test do
   gem 'coveralls', '~> 0.8', require: false
   gem 'database_cleaner'
   gem 'equivalent-xml'
-  gem 'factory_girl_rails', '~> 4.9'
+  gem 'factory_bot_rails'
   gem 'rspec-rails', '~> 3.7'
   gem 'simplecov', '~> 0.13', require: false
   gem 'single_cov'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,10 +178,10 @@ GEM
     erubis (2.7.0)
     eventmachine (1.2.5)
     execjs (2.7.0)
-    factory_girl (4.9.0)
+    factory_bot (4.8.2)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.9.0)
-      factory_girl (~> 4.9.0)
+    factory_bot_rails (4.8.2)
+      factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
@@ -479,7 +479,7 @@ DEPENDENCIES
   dlss_cops
   dotiw
   equivalent-xml
-  factory_girl_rails (~> 4.9)
+  factory_bot_rails
   faraday
   grape (~> 0.19)
   high_voltage
@@ -521,4 +521,4 @@ DEPENDENCIES
   yaml_db
 
 BUNDLED WITH
-   1.16.0.pre.2
+   1.16.0

--- a/spec/api/sul_bib/authorship_api_spec.rb
+++ b/spec/api/sul_bib/authorship_api_spec.rb
@@ -12,7 +12,7 @@ describe SulBib::API, :vcr do
   # Use let! to force the method's invocation before each example.
   let!(:publication_with_contributions) do
     pub = create :publication_with_contributions, contributions_count: contribution_count
-    # FactoryGirl knows nothing about the Publication.pub_hash sync issue, so
+    # FactoryBot knows nothing about the Publication.pub_hash sync issue, so
     # it must be forced to update that data with the contributions.
     pub.pubhash_needs_update!
     pub.save # to update the pub.pub_hash

--- a/spec/api/sul_bib/publications_api_spec.rb
+++ b/spec/api/sul_bib/publications_api_spec.rb
@@ -1,9 +1,9 @@
 
 describe SulBib::API, :vcr do
-  let(:publication) { FactoryGirl.create :publication }
+  let(:publication) { FactoryBot.create :publication }
   let!(:publication_with_contributions) { create :publication_with_contributions, contributions_count: 2 }
   let(:publication_list) { create_list(:contribution, 15, visibility: 'public', status: 'approved') }
-  let(:author) { FactoryGirl.create :author }
+  let(:author) { FactoryBot.create :author }
   let(:author_with_sw_pubs) { create :author_with_sw_pubs }
   let(:headers) { { 'HTTP_CAPKEY' => Settings.API_KEY, 'CONTENT_TYPE' => 'application/json' } }
   let(:valid_json_for_post) do

--- a/spec/api/sul_bib/sourcelookup_spec.rb
+++ b/spec/api/sul_bib/sourcelookup_spec.rb
@@ -46,7 +46,7 @@ describe SulBib::API, :vcr do
     describe '?doi' do
       let(:doi_value) { '10.1016/j.mcn.2012.03.008' }
       let(:doi_identifier) do
-        FactoryGirl.create(:publication_identifier,
+        FactoryBot.create(:publication_identifier,
                            identifier_type: 'doi',
                            identifier_value: doi_value,
                            identifier_uri: "http://dx.doi.org/#{doi_value}")

--- a/spec/factories/author.rb
+++ b/spec/factories/author.rb
@@ -1,12 +1,12 @@
-FactoryGirl.define do
+FactoryBot.define do
   sequence(:random_id) do |n|
     @random_ids ||= (10_000..1_000_000).to_a.shuffle
     @random_ids[n]
   end
 
   factory :author do
-    sunetid { FactoryGirl.generate(:random_id) }
-    cap_profile_id { FactoryGirl.generate(:random_id) }
+    sunetid { FactoryBot.generate(:random_id) }
+    cap_profile_id { FactoryBot.generate(:random_id) }
     active_in_cap true
     email 'alice.edler@stanford.edu'
     official_first_name 'Alice'

--- a/spec/factories/author_identity.rb
+++ b/spec/factories/author_identity.rb
@@ -1,5 +1,5 @@
 # we use sequences so that we can get a variety of alternate identities
-FactoryGirl.define do
+FactoryBot.define do
   factory :author_identity do
     sequence(:first_name)   { |n| "Alice#{n}" }
     sequence(:middle_name)  { |n| "Jim#{n}" }

--- a/spec/factories/batch_uploaded_source_records.rb
+++ b/spec/factories/batch_uploaded_source_records.rb
@@ -1,6 +1,6 @@
 # Read about factories at https://github.com/thoughtbot/factory_girl
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :batch_uploaded_source_record do
     sunet_id 'MyString'
     author_id 1

--- a/spec/factories/contribution.rb
+++ b/spec/factories/contribution.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :contribution do
     status 'approved'
     visibility 'public'

--- a/spec/factories/pub_hash.rb
+++ b/spec/factories/pub_hash.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :pub_hash do
     initialize_with do
       new(provenance: 'sciencewire',

--- a/spec/factories/publication.rb
+++ b/spec/factories/publication.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :publication do
     title 'How I learned Rails'
     year '1972'
@@ -31,7 +31,7 @@ FactoryGirl.define do
       contributions_count 15
     end
     after(:create) do |publication, evaluator|
-      FactoryGirl.create_list(:contribution, evaluator.contributions_count, publication: publication)
+      FactoryBot.create_list(:contribution, evaluator.contributions_count, publication: publication)
     end
   end
 

--- a/spec/factories/publication_identifier.rb
+++ b/spec/factories/publication_identifier.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :publication_identifier do
     publication
     after(:create) do |pub_id|

--- a/spec/factories/pubmed_source_records.rb
+++ b/spec/factories/pubmed_source_records.rb
@@ -1,6 +1,6 @@
 # Read about factories at https://github.com/thoughtbot/factory_girl
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :pubmed_source_record do
     source_data 'MyText'
     pmid 1

--- a/spec/factories/sciencewire_source_records.rb
+++ b/spec/factories/sciencewire_source_records.rb
@@ -1,6 +1,6 @@
 # Read about factories at https://github.com/thoughtbot/factory_girl
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :sciencewire_source_record do
     sciencewire_id      1
     source_data         'MyText'

--- a/spec/factories/user_submitted_source_records.rb
+++ b/spec/factories/user_submitted_source_records.rb
@@ -1,6 +1,6 @@
 # Read about factories at https://github.com/thoughtbot/factory_girl
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :user_submitted_source_record do
     pmid nil
     publication_id 1234

--- a/spec/lib/doi_search_spec.rb
+++ b/spec/lib/doi_search_spec.rb
@@ -2,7 +2,7 @@
 describe DoiSearch do
   let(:doi_value) { '10.1016/j.mcn.2012.03.007' }
   let(:doi_identifier) do
-    FactoryGirl.create(:publication_identifier,
+    FactoryBot.create(:publication_identifier,
                        identifier_type: 'doi',
                        identifier_value: doi_value,
                        identifier_uri: "http://dx.doi.org/#{doi_value}")

--- a/spec/lib/harvester/base_spec.rb
+++ b/spec/lib/harvester/base_spec.rb
@@ -1,5 +1,5 @@
 describe Harvester::Base do
-  let(:authors) { FactoryGirl.create_list(:author, 5, cap_import_enabled: true) }
+  let(:authors) { FactoryBot.create_list(:author, 5, cap_import_enabled: true) }
   let(:subclass) { Class.new(described_class) }
   let(:instance) { subclass.new }
 

--- a/spec/lib/identifier_normalizer_spec.rb
+++ b/spec/lib/identifier_normalizer_spec.rb
@@ -1,7 +1,7 @@
 describe IdentifierNormalizer do
   subject(:normalizer) { described_class.new }
 
-  let(:doi_identifier) { FactoryGirl.create(:doi_publication_identifier) }
+  let(:doi_identifier) { FactoryBot.create(:doi_publication_identifier) }
   let(:doi_pub) { doi_identifier.publication }
 
   # Data used in factory - to capture desired results
@@ -118,7 +118,7 @@ describe IdentifierNormalizer do
       normalizer.delete_blanks = true
       doi_identifier.save
     end
-    let(:doi_identifier) { FactoryGirl.create(:doi_empty_publication_identifier) }
+    let(:doi_identifier) { FactoryBot.create(:doi_empty_publication_identifier) }
 
     it_behaves_like 'deletes_pub_id'
     it_behaves_like 'deletes_pub_hash_entry'
@@ -130,7 +130,7 @@ describe IdentifierNormalizer do
     end
 
     context 'valid value, empty URI' do
-      let(:doi_identifier) { FactoryGirl.create(:doi_empty_uri_publication_identifier) }
+      let(:doi_identifier) { FactoryBot.create(:doi_empty_uri_publication_identifier) }
 
       it_behaves_like 'preserves_value'
       it_behaves_like 'updates_uri'
@@ -138,7 +138,7 @@ describe IdentifierNormalizer do
     end
 
     context 'valid URI, empty value' do
-      let(:doi_identifier) { FactoryGirl.create(:doi_empty_value_publication_identifier) }
+      let(:doi_identifier) { FactoryBot.create(:doi_empty_value_publication_identifier) }
 
       it_behaves_like 'updates_value'
       it_behaves_like 'preserves_uri'
@@ -152,7 +152,7 @@ describe IdentifierNormalizer do
     end
 
     context 'valid denormalized value, empty URI' do
-      let(:doi_identifier) { FactoryGirl.create(:doi_denormalized_value_publication_identifier) }
+      let(:doi_identifier) { FactoryBot.create(:doi_denormalized_value_publication_identifier) }
 
       it_behaves_like 'updates_value'
       it_behaves_like 'updates_uri'
@@ -166,7 +166,7 @@ describe IdentifierNormalizer do
       normalizer.delete_invalid = true
       doi_identifier.save
     end
-    let(:doi_identifier) { FactoryGirl.create(:doi_invalid_publication_identifier) }
+    let(:doi_identifier) { FactoryBot.create(:doi_invalid_publication_identifier) }
 
     it_behaves_like 'deletes_pub_id'
     it_behaves_like 'deletes_pub_hash_entry'
@@ -181,22 +181,22 @@ describe IdentifierNormalizer do
       expect(result).to be_an IdentifierParserDOI
     end
     it 'works for isbn' do
-      identifier = FactoryGirl.create(:isbn_publication_identifier)
+      identifier = FactoryBot.create(:isbn_publication_identifier)
       result = normalizer.send(:identifier_parser, identifier)
       expect(result).to be_an IdentifierParserISBN
     end
     it 'works for pmid' do
-      identifier = FactoryGirl.create(:pmid_publication_identifier)
+      identifier = FactoryBot.create(:pmid_publication_identifier)
       result = normalizer.send(:identifier_parser, identifier)
       expect(result).to be_an IdentifierParserPMID
     end
     it 'works for SulPubId' do
-      identifier = FactoryGirl.create(:sul_publication_identifier)
+      identifier = FactoryBot.create(:sul_publication_identifier)
       result = normalizer.send(:identifier_parser, identifier)
       expect(result).to be_an IdentifierParser
     end
     it 'works for PublicationItemID' do
-      identifier = FactoryGirl.create(:publicationItemID_publication_identifier)
+      identifier = FactoryBot.create(:publicationItemID_publication_identifier)
       result = normalizer.send(:identifier_parser, identifier)
       expect(result).to be_an IdentifierParser
     end

--- a/spec/lib/identifier_parser_doi_spec.rb
+++ b/spec/lib/identifier_parser_doi_spec.rb
@@ -10,7 +10,7 @@ describe IdentifierParserDOI do
                        identifier_type: identifier_type,
                        identifier_value: identifier_value,
                        identifier_uri: identifier_uri
-                      )
+                     )
   end
   let(:parser) { described_class.new(identifier) }
 

--- a/spec/lib/identifier_parser_doi_spec.rb
+++ b/spec/lib/identifier_parser_doi_spec.rb
@@ -6,7 +6,7 @@ describe IdentifierParserDOI do
   let(:identifier_value) { '10.1038/ncomms3199' }
   let(:identifier_uri) { "http://dx.doi.org/#{identifier_value}" }
   let(:identifier) do
-    FactoryGirl.create(:publication_identifier,
+    FactoryBot.create(:publication_identifier,
                        identifier_type: identifier_type,
                        identifier_value: identifier_value,
                        identifier_uri: identifier_uri

--- a/spec/lib/identifier_parser_isbn_spec.rb
+++ b/spec/lib/identifier_parser_isbn_spec.rb
@@ -10,7 +10,7 @@ describe IdentifierParserISBN do
                        identifier_type: identifier_type,
                        identifier_value: identifier_value,
                        identifier_uri: identifier_uri
-                      )
+                     )
   end
   let(:parser) { described_class.new(identifier) }
 
@@ -39,7 +39,7 @@ describe IdentifierParserISBN do
       FactoryBot.create(:publication_identifier,
                          identifier_type: identifier_type,
                          identifier_value: identifier_value
-                        )
+                       )
     end
 
     it_behaves_like 'parser_works'
@@ -53,7 +53,7 @@ describe IdentifierParserISBN do
       FactoryBot.create(:publication_identifier,
                          identifier_type: identifier_type,
                          identifier_uri: identifier_value
-                        )
+                       )
     end
     let(:parser) { described_class.new(identifier) }
 

--- a/spec/lib/identifier_parser_isbn_spec.rb
+++ b/spec/lib/identifier_parser_isbn_spec.rb
@@ -6,7 +6,7 @@ describe IdentifierParserISBN do
   let(:identifier_value) { '9781904842781' }
   let(:identifier_uri) { nil }
   let(:identifier) do
-    FactoryGirl.create(:publication_identifier,
+    FactoryBot.create(:publication_identifier,
                        identifier_type: identifier_type,
                        identifier_value: identifier_value,
                        identifier_uri: identifier_uri
@@ -36,7 +36,7 @@ describe IdentifierParserISBN do
 
   context '#update using only a valid value' do
     let(:identifier) do
-      FactoryGirl.create(:publication_identifier,
+      FactoryBot.create(:publication_identifier,
                          identifier_type: identifier_type,
                          identifier_value: identifier_value
                         )
@@ -50,7 +50,7 @@ describe IdentifierParserISBN do
 
   context '#update using a valid value, but in the URI' do
     let(:identifier) do
-      FactoryGirl.create(:publication_identifier,
+      FactoryBot.create(:publication_identifier,
                          identifier_type: identifier_type,
                          identifier_uri: identifier_value
                         )

--- a/spec/lib/identifier_parser_pmid_spec.rb
+++ b/spec/lib/identifier_parser_pmid_spec.rb
@@ -6,7 +6,7 @@ describe IdentifierParserPMID do
   let(:identifier_value) { '10002407' }
   let(:identifier_uri) { "https://www.ncbi.nlm.nih.gov/pubmed/#{identifier_value}" }
   let(:identifier) do
-    FactoryGirl.create(:publication_identifier,
+    FactoryBot.create(:publication_identifier,
                        identifier_type: identifier_type,
                        identifier_value: identifier_value,
                        identifier_uri: identifier_uri

--- a/spec/lib/identifier_parser_pmid_spec.rb
+++ b/spec/lib/identifier_parser_pmid_spec.rb
@@ -10,7 +10,7 @@ describe IdentifierParserPMID do
                        identifier_type: identifier_type,
                        identifier_value: identifier_value,
                        identifier_uri: identifier_uri
-                      )
+                     )
   end
   let(:parser) { described_class.new(identifier) }
 

--- a/spec/lib/identifier_parser_spec.rb
+++ b/spec/lib/identifier_parser_spec.rb
@@ -6,7 +6,7 @@ describe IdentifierParser do
   let(:identifier_value) { 'a value' }
   let(:identifier_uri) { 'a uri' }
   let(:identifier) do
-    FactoryGirl.create(:publication_identifier,
+    FactoryBot.create(:publication_identifier,
                        identifier_type: identifier_type,
                        identifier_value: identifier_value,
                        identifier_uri: identifier_uri
@@ -39,7 +39,7 @@ describe IdentifierParser do
 
   context '#update using a WoSItemID' do
     let(:identifier) do
-      FactoryGirl.create(:publication_identifier,
+      FactoryBot.create(:publication_identifier,
                          identifier_type:  'WoSItemID',
                          identifier_value: 'A1976CM52800051',
                          identifier_uri:   'https://ws.isiknowledge.com/cps/openurl/service?url_ver=Z39.88-2004&rft_id=info:ut/A1976CM52800051'
@@ -51,7 +51,7 @@ describe IdentifierParser do
 
   context '#update using a PublicationItemID' do
     let(:identifier) do
-      FactoryGirl.create(:publication_identifier,
+      FactoryBot.create(:publication_identifier,
                          identifier_type:  'PublicationItemID',
                          identifier_value: '13276514',
                          identifier_uri:   nil

--- a/spec/lib/identifier_parser_spec.rb
+++ b/spec/lib/identifier_parser_spec.rb
@@ -10,7 +10,7 @@ describe IdentifierParser do
                        identifier_type: identifier_type,
                        identifier_value: identifier_value,
                        identifier_uri: identifier_uri
-                      )
+                     )
   end
   let(:parser) { described_class.new(identifier) }
 
@@ -43,7 +43,7 @@ describe IdentifierParser do
                          identifier_type:  'WoSItemID',
                          identifier_value: 'A1976CM52800051',
                          identifier_uri:   'https://ws.isiknowledge.com/cps/openurl/service?url_ver=Z39.88-2004&rft_id=info:ut/A1976CM52800051'
-                        )
+                       )
     end
 
     it_behaves_like 'it_changes_nothing'
@@ -55,7 +55,7 @@ describe IdentifierParser do
                          identifier_type:  'PublicationItemID',
                          identifier_value: '13276514',
                          identifier_uri:   nil
-                        )
+                       )
     end
 
     it_behaves_like 'it_changes_nothing'

--- a/spec/lib/pubmed_harvester_spec.rb
+++ b/spec/lib/pubmed_harvester_spec.rb
@@ -1,6 +1,6 @@
 
 describe PubmedHarvester, :vcr do
-  let(:author) { FactoryGirl.create :author }
+  let(:author) { FactoryBot.create :author }
 
   let(:pub_hash) do
     {
@@ -15,7 +15,7 @@ describe PubmedHarvester, :vcr do
   end
 
   let(:publication) do
-    FactoryGirl.create :pub_with_sw_id_and_pmid, pub_hash: pub_hash
+    FactoryBot.create :pub_with_sw_id_and_pmid, pub_hash: pub_hash
   end
 
   before(:each) do

--- a/spec/lib/web_of_science/harvester_spec.rb
+++ b/spec/lib/web_of_science/harvester_spec.rb
@@ -29,21 +29,21 @@ describe WebOfScience::Harvester do
     # public data from
     # - https://stanfordwho.stanford.edu
     # - https://med.stanford.edu/profiles/russ-altman
-    author = FactoryGirl.create(:author,
+    author = FactoryBot.create(:author,
                                  preferred_first_name: 'Russ',
                                  preferred_last_name: 'Altman',
                                  preferred_middle_name: 'Biagio',
                                  email: 'Russ.Altman@stanford.edu',
                                  cap_import_enabled: true)
     # create some `author.alternative_identities`
-    FactoryGirl.create(:author_identity,
+    FactoryBot.create(:author_identity,
                        author: author,
                        first_name: 'R',
                        middle_name: 'B',
                        last_name: 'Altman',
                        email: nil,
                        institution: 'Stanford University')
-    FactoryGirl.create(:author_identity,
+    FactoryBot.create(:author_identity,
                        author: author,
                        first_name: 'Russ',
                        middle_name: nil,

--- a/spec/lib/web_of_science/process_records_spec.rb
+++ b/spec/lib/web_of_science/process_records_spec.rb
@@ -3,21 +3,21 @@ describe WebOfScience::ProcessRecords, :vcr do
     # public data from
     # - https://stanfordwho.stanford.edu
     # - https://med.stanford.edu/profiles/russ-altman
-    author = FactoryGirl.create(:author,
+    author = FactoryBot.create(:author,
                                  preferred_first_name: 'Russ',
                                  preferred_last_name: 'Altman',
                                  preferred_middle_name: 'Biagio',
                                  email: 'Russ.Altman@stanford.edu',
                                  cap_import_enabled: true)
     # create some `author.alternative_identities`
-    FactoryGirl.create(:author_identity,
+    FactoryBot.create(:author_identity,
                        author: author,
                        first_name: 'R',
                        middle_name: 'B',
                        last_name: 'Altman',
                        email: nil,
                        institution: 'Stanford University')
-    FactoryGirl.create(:author_identity,
+    FactoryBot.create(:author_identity,
                        author: author,
                        first_name: 'Russ',
                        middle_name: nil,

--- a/spec/models/author_identity_spec.rb
+++ b/spec/models/author_identity_spec.rb
@@ -1,6 +1,6 @@
 
 RSpec.describe AuthorIdentity, type: :model do
-  subject { FactoryGirl.create :author_identity }
+  subject { FactoryBot.create :author_identity }
 
   context 'basics' do
     it 'has working factories' do
@@ -107,7 +107,7 @@ RSpec.describe AuthorIdentity, type: :model do
     end
 
     it 'will handle missing required fields (firstName and lastName) in importSettings' do
-      # FactoryGirl creates (at least) 1 Author Identity, so we check for transactionality
+      # FactoryBot creates (at least) 1 Author Identity, so we check for transactionality
       prev = subject.author.alternative_identities
 
       expect { subject.author.mirror_author_identities([{ 'firstName' => subject.author.preferred_first_name }]) }.to raise_error(ActiveRecord::RecordInvalid)
@@ -118,7 +118,7 @@ RSpec.describe AuthorIdentity, type: :model do
     end
 
     it 'will not change alternative_identities if data are missing' do
-      subject.author.author_identities.clear # explicitly clear FactoryGirl addition(s)
+      subject.author.author_identities.clear # explicitly clear FactoryBot addition(s)
       expect { subject.author.mirror_author_identities([{ 'firstName' => subject.author.preferred_first_name }]) }.to raise_error(ActiveRecord::RecordInvalid)
       expect(subject.author.alternative_identities.length).to be == 0
     end

--- a/spec/models/author_spec.rb
+++ b/spec/models/author_spec.rb
@@ -54,7 +54,7 @@ describe Author do
       # The contributions are are defined in /spec/factories/contribution.rb
       pub = create :publication_with_contributions, contributions_count: 1
       pub.sciencewire_id = nil
-      # FactoryGirl knows nothing about the Publication.pub_hash sync issue, so
+      # FactoryBot knows nothing about the Publication.pub_hash sync issue, so
       # it must be forced to update that data with the contributions.
       pub.pubhash_needs_update!
       pub.save # to update the pub.pub_hash

--- a/spec/models/contribution_spec.rb
+++ b/spec/models/contribution_spec.rb
@@ -3,7 +3,7 @@ describe Contribution do
     # The publication is defined in /spec/factories/publication.rb
     # The contributions are are defined in /spec/factories/contribution.rb
     pub = create :publication_with_contributions, contributions_count: 1
-    # FactoryGirl knows nothing about the Publication.pub_hash sync issue, so
+    # FactoryBot knows nothing about the Publication.pub_hash sync issue, so
     # it must be forced to update that data with the contributions.
     pub.pubhash_needs_update!
     pub.save # to update the pub.pub_hash

--- a/spec/models/publication_identifier_spec.rb
+++ b/spec/models/publication_identifier_spec.rb
@@ -1,5 +1,5 @@
 describe PublicationIdentifier do
-  subject(:pub_id) { FactoryGirl.create(:doi_publication_identifier) }
+  subject(:pub_id) { FactoryBot.create(:doi_publication_identifier) }
 
   let(:doi_type) { pub_id.identifier_type }
   let(:doi_value) { pub_id.identifier_value }

--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -1,6 +1,6 @@
 describe Publication do
-  let(:publication) { FactoryGirl.create :publication }
-  let(:author) { FactoryGirl.create :author }
+  let(:publication) { FactoryBot.create :publication }
+  let(:author) { FactoryBot.create :author }
 
   let(:pub_hash) do
     {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,7 +49,7 @@ require File.expand_path('../../config/environment', __FILE__)
 ActiveRecord::Migration.maintain_test_schema!
 
 require 'rspec/rails'
-require 'factory_girl_rails'
+require 'factory_bot_rails'
 
 RSpec.configure do |config|
   config.include RSpec::Rails::RequestExampleGroup, type: :request, file_path: %r{spec/api}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,7 +55,7 @@ RSpec.configure do |config|
   config.include RSpec::Rails::RequestExampleGroup, type: :request, file_path: %r{spec/api}
   config.include RSpec::Rails::RequestExampleGroup, type: :request, file_path: %r{spec/lib}
 
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   # config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/support/identifier_parser_shared_examples.rb
+++ b/spec/support/identifier_parser_shared_examples.rb
@@ -109,7 +109,7 @@ shared_examples 'invalid_value' do
       FactoryBot.create(:publication_identifier,
                          identifier_type: identifier_type,
                          identifier_value: invalid_value
-                        )
+                       )
     end
 
     it 'raises IdentifierParserInvalidError when value and uri do not validate' do
@@ -133,7 +133,7 @@ shared_examples 'other_identifiers_raise_exception' do
                          identifier_type: 'Huh?',
                          identifier_value: 'some-value',
                          identifier_uri: 'some-uri'
-                        )
+                       )
     end
 
     it_behaves_like 'invalid_type'
@@ -145,7 +145,7 @@ shared_examples 'other_identifiers_raise_exception' do
                          identifier_type:  'WoSItemID',
                          identifier_value: 'A1976CM52800051',
                          identifier_uri:   'https://ws.isiknowledge.com/cps/openurl/service?url_ver=Z39.88-2004&rft_id=info:ut/A1976CM52800051'
-                        )
+                       )
     end
 
     it_behaves_like 'invalid_type'
@@ -157,7 +157,7 @@ shared_examples 'other_identifiers_raise_exception' do
                          identifier_type:  'PublicationItemID',
                          identifier_value: '13276514',
                          identifier_uri:   nil
-                        )
+                       )
     end
 
     it_behaves_like 'invalid_type'
@@ -170,7 +170,7 @@ shared_examples 'update_works_with_only_valid_uri' do
       FactoryBot.create(:publication_identifier,
                          identifier_type: identifier_type,
                          identifier_uri: identifier_uri
-                        )
+                       )
     end
 
     it_behaves_like 'parser_works'
@@ -186,7 +186,7 @@ shared_examples 'update_works_with_only_valid_value' do
       FactoryBot.create(:publication_identifier,
                          identifier_type: identifier_type,
                          identifier_value: identifier_value
-                        )
+                       )
     end
 
     it_behaves_like 'parser_works'
@@ -202,7 +202,7 @@ shared_examples 'update_works_with_only_valid_value_in_uri' do
       FactoryBot.create(:publication_identifier,
                          identifier_type: identifier_type,
                          identifier_uri: identifier_value
-                        )
+                       )
     end
 
     it_behaves_like 'parser_works'

--- a/spec/support/identifier_parser_shared_examples.rb
+++ b/spec/support/identifier_parser_shared_examples.rb
@@ -106,7 +106,7 @@ end
 shared_examples 'invalid_value' do
   context 'identifier is invalid' do
     let(:invalid_identifier) do
-      FactoryGirl.create(:publication_identifier,
+      FactoryBot.create(:publication_identifier,
                          identifier_type: identifier_type,
                          identifier_value: invalid_value
                         )
@@ -119,7 +119,7 @@ shared_examples 'invalid_value' do
 end
 
 shared_examples 'blank_identifiers_raise_exception' do
-  let(:blank_identifier) { FactoryGirl.create(:blank_publication_identifier, identifier_type: identifier_type) }
+  let(:blank_identifier) { FactoryBot.create(:blank_publication_identifier, identifier_type: identifier_type) }
 
   it 'raises IdentifierParserEmptyError when value and uri are blank' do
     expect { described_class.new(blank_identifier) }.to raise_error(IdentifierParserEmptyError)
@@ -129,7 +129,7 @@ end
 shared_examples 'other_identifiers_raise_exception' do
   context '#update using an identifier it does not handle' do
     let(:identifier) do
-      FactoryGirl.create(:publication_identifier,
+      FactoryBot.create(:publication_identifier,
                          identifier_type: 'Huh?',
                          identifier_value: 'some-value',
                          identifier_uri: 'some-uri'
@@ -141,7 +141,7 @@ shared_examples 'other_identifiers_raise_exception' do
 
   context '#update using a WoSItemID' do
     let(:identifier) do
-      FactoryGirl.create(:publication_identifier,
+      FactoryBot.create(:publication_identifier,
                          identifier_type:  'WoSItemID',
                          identifier_value: 'A1976CM52800051',
                          identifier_uri:   'https://ws.isiknowledge.com/cps/openurl/service?url_ver=Z39.88-2004&rft_id=info:ut/A1976CM52800051'
@@ -153,7 +153,7 @@ shared_examples 'other_identifiers_raise_exception' do
 
   context '#update using a PublicationItemID' do
     let(:identifier) do
-      FactoryGirl.create(:publication_identifier,
+      FactoryBot.create(:publication_identifier,
                          identifier_type:  'PublicationItemID',
                          identifier_value: '13276514',
                          identifier_uri:   nil
@@ -167,7 +167,7 @@ end
 shared_examples 'update_works_with_only_valid_uri' do
   context '#update using only a valid URI' do
     let(:identifier) do
-      FactoryGirl.create(:publication_identifier,
+      FactoryBot.create(:publication_identifier,
                          identifier_type: identifier_type,
                          identifier_uri: identifier_uri
                         )
@@ -183,7 +183,7 @@ end
 shared_examples 'update_works_with_only_valid_value' do
   context '#update using only a valid value' do
     let(:identifier) do
-      FactoryGirl.create(:publication_identifier,
+      FactoryBot.create(:publication_identifier,
                          identifier_type: identifier_type,
                          identifier_value: identifier_value
                         )
@@ -199,7 +199,7 @@ end
 shared_examples 'update_works_with_only_valid_value_in_uri' do
   context '#update using a valid value, but in the URI' do
     let(:identifier) do
-      FactoryGirl.create(:publication_identifier,
+      FactoryBot.create(:publication_identifier,
                          identifier_type: identifier_type,
                          identifier_uri: identifier_value
                         )


### PR DESCRIPTION
Migrate `FactoryGirl` to `FactoryBot`, per [1]
- ignore a drop of -0.2% in code coverage
  - it can't be easily identified or fixed among these changes

[1] https://github.com/thoughtbot/factory_bot_rails#transitioning-from-factory_girl_rails
