### PR TITLE
Convert with_active_author to a scope, 1 SQL query, not 2

### DIFF
--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -1,5 +1,6 @@
 class Publication < ActiveRecord::Base
   has_paper_trail on: [:destroy]
+  scope :with_active_author, -> { joins(:authors).where('authors.active_in_cap' => true).uniq }
 
   after_create do
     set_sul_pub_id_in_hash
@@ -49,11 +50,6 @@ class Publication < ActiveRecord::Base
 
   def self.updated_after(date)
     where('publications.updated_at > ?', date)
-  end
-
-  def self.with_active_author
-    ids = joins(:authors).where('authors.active_in_cap' => true).select('publications.id').uniq.pluck(:id)
-    unscoped.where(id: ids)
   end
 
   def self.find_or_create_by_pmid(pmid)


### PR DESCRIPTION
Old behavior generated two queries unnecessarily, and with scalability issues:

```sql
SELECT DISTINCT `publications`.`id` FROM `publications`
  INNER JOIN `contributions` ON `contributions`.`publication_id` = `publications`.`id`
  INNER JOIN `authors` ON `authors`.`id` = `contributions`.`author_id` 
  WHERE `authors`.`active_in_cap` = 1
SELECT `publications`.* FROM `publications`
  WHERE `publications`.`id` IN (434, 435, 436, 437, 438, 439, 440, 441, 442, 443, 444, 445, 446, 447, 448, 449, 450, 451, 452, 453, 454, 455, 456, 457, 458, 459, 460, 461, 462, 463, 464, 465, 466, 467, 468, 469, 470, 471, 472, 473, 474, 475, 476, 477, 478, 479, 480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 492, 493, 494, 495, 496, 497, 498, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 512, 513, 514, 515, 516, 517, 518, 519, 520, 521, 522, 523, 524, 525, 526, 527, 528, 529, 530, 531, 532, 533, 534, 535, 536, 537, 538, 539, 540, 541, 542, 543, 544, 545, 546, 547, 548, 549, 550, 551, 552, 553, 554, 555, 556, 557, 558, 559, 560, 561, 562, 563, 564, 565, 566, 567, 568, 569, 570, 571, 572, 573, 574, 575, 576, 577, 578, 579, 580, 581, 582, 583, 584, 585, 586, 587, 588, 589, 590, 591, 592, 593, 594, 595, 596, 597, 598, 599, 600, 601, 602, 603, 604, 605, 606, 607, 608, 609, 610, 611, 612, 613, 614, 615, 616, 617, 618, 619, 620, 621, 622, 623, 624, 625, 626, 627, 628, 629, 630, 631, 632, 633, 634, 635, 636, 637, 638, 639, 640, 641, 642, 643, 644, 645, 646, 647, 648, 649, 650, 651, 652, 653, 654, 655, 656, 657, 658, 659, 660, 661, 662, 663, 664, 665, 666, 667, 668, 669, 670, 671, 672, 673, 674, 675, 676, 677, 678, 679, 680, 681, 682, 683, 684, 685, 686, 687, 688, 689, 690, 691, 692, 693, 694, 695, 696, 697, 698, 699, 700, 701, 702, 703, 704, 705, 706, 707, 708, 709, 710, 711, 712, 713, 714, 715, 716, 717, 718, 719, 720, 721, 722, 723, 724, 725, 726, 727, 728, 729, 730, 731, 732, 733, 734, 735, 736, 737, 738, 739, 740, 741, 742, 743, 744, 745, 746, 747, 748, 749, 750, 751, 752, 753, 754, 755, 756, 757, 758, 759, 760, 761, 762, 763, 764, 765, 766, 767, 768, 769, 770, 771, 772, 773, 774, 775, 776, 777, 778, 779, 780, 781, 782, 783, 784, 785, 786, 787, 788, 789, 790, 791, 792, 793, 794, 795, 796, 797, 798, 799, 800, 801, 802, 803, 804, 805, 806, 807, 808, 809, 810, 811, 812, 813, 814, 815, 816, 817, 818, 819, 820, 821, 822, 823, 824, 825, 826, 827, 828, 829, 830, 831, 832, 833, 834, 835, 836, 837, 838, 839, 840, 841, 842, 843, 844, 845, 846, 847, 848, 849, 850, 851, 852, 853, 854, 855, 856, 857, 858, 859, 860, 861, 862, 863, 864, 865, 866, 867, 868, 869, 870, 871, 872, 873, 874, 875, 876, 877, 878, 879)

```
*vs.*

```sql
SELECT DISTINCT `publications`.* FROM `publications`
  INNER JOIN `contributions` ON `contributions`.`publication_id` = `publications`.`id`
  INNER JOIN `authors` ON `authors`.`id` = `contributions`.`author_id`
  WHERE `authors`.`active_in_cap` = 1
```

Obviously we don't want to pull up IDs into memory then recompose an SQL query with literal enumeration of hundreds or thousands of values when we could just have the DB do the right thing the first time.

Scopes are the ActiveRecord convention for these type of filters.  See:
http://guides.rubyonrails.org/active_record_querying.html#scopes