### PR TITLE
WebOfScienceSourceRecord#source_data converted to mediumtext length

### DIFF
--- a/db/migrate/20171213201429_wos_src_record_medium_text.rb
+++ b/db/migrate/20171213201429_wos_src_record_medium_text.rb
@@ -1,0 +1,9 @@
+class WosSrcRecordMediumText < ActiveRecord::Migration
+  def up
+    change_column :web_of_science_source_records, :source_data, :mediumtext
+  end
+
+  def down
+    change_column :web_of_science_source_records, :source_data, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171208233331) do
+ActiveRecord::Schema.define(version: 20171213201429) do
 
   create_table "author_identities", force: :cascade do |t|
     t.integer  "author_id",     limit: 4,               null: false
@@ -212,11 +212,11 @@ ActiveRecord::Schema.define(version: 20171208233331) do
   create_table "web_of_science_source_records", force: :cascade do |t|
     t.boolean  "active"
     t.string   "database",           limit: 255
-    t.text     "source_data",        limit: 65535
+    t.text     "source_data",        limit: 16777215
     t.string   "source_fingerprint", limit: 255
     t.string   "uid",                limit: 255
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
     t.string   "doi",                limit: 255
     t.string   "pmid",               limit: 255
   end


### PR DESCRIPTION
Fix #547

Note that the source data is also assigned to `Publication#xml`, which is already a `:mediumtext` field
- https://github.com/sul-dlss/sul_pub/blob/master/db/schema.rb#L138
- to fix #547, only the WOS source record needs to be extended

The WOS harvest failed to save some long records.  This PR expands the source record capacity to handle large WOS records.  A review of the harvest logs identified some large records that failed to save; the largest of those records should now fit in this expanded field.  (The logs had some db ROLLBACK errors that were all related to this.)