### PR TITLE
WebOfScience::ProcessRecords - separate pub creation from pubmed additions

### DIFF
--- a/fixtures/vcr_cassettes/WebOfScience_ProcessRecords/with_WOS_records/behaves_like_pubs_with_pmid_have_mesh_headings/persists_PMID_and_publication_pub_hash_has_MESH_headings.yml
+++ b/fixtures/vcr_cassettes/WebOfScience_ProcessRecords/with_WOS_records/behaves_like_pubs_with_pmid_have_mesh_headings/persists_PMID_and_publication_pub_hash_has_MESH_headings.yml
@@ -1,0 +1,203 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    body:
+      encoding: UTF-8
+      string: "&id=&id=21253920"
+    headers:
+      User-Agent:
+      - Faraday v0.13.1
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 14 Dec 2017 23:25:00 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 14 Dec 2017 23:25:00 GMT
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - private
+      Ncbi-Phid:
+      - 990D57EAA3304E510000000002B702B0
+      Ncbi-Sid:
+      - 990D57EAA33084C1_0695SID
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Set-Cookie:
+      - ncbi_sid=990D57EAA33084C1_0695SID; domain=.nih.gov; path=/; expires=Fri, 14
+        Dec 2018 23:25:00 GMT
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '1372'
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" ?>
+        <!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2018//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_180101.dtd">
+        <PubmedArticleSet>
+        <PubmedArticle>
+            <MedlineCitation Status="MEDLINE" Owner="NLM">
+                <PMID Version="1">21253920</PMID>
+                <DateCompleted>
+                    <Year>2011</Year>
+                    <Month>08</Month>
+                    <Day>01</Day>
+                </DateCompleted>
+                <DateRevised>
+                    <Year>2011</Year>
+                    <Month>03</Month>
+                    <Day>22</Day>
+                </DateRevised>
+                <Article PubModel="Print-Electronic">
+                    <Journal>
+                        <ISSN IssnType="Electronic">1496-8975</ISSN>
+                        <JournalIssue CitedMedium="Internet">
+                            <Volume>58</Volume>
+                            <Issue>4</Issue>
+                            <PubDate>
+                                <Year>2011</Year>
+                                <Month>Apr</Month>
+                            </PubDate>
+                        </JournalIssue>
+                        <Title>Canadian journal of anaesthesia = Journal canadien d'anesthesie</Title>
+                        <ISOAbbreviation>Can J Anaesth</ISOAbbreviation>
+                    </Journal>
+                    <ArticleTitle>Kinked Perifix® FX Springwound epidural catheters.</ArticleTitle>
+                    <Pagination>
+                        <MedlinePgn>413-4</MedlinePgn>
+                    </Pagination>
+                    <ELocationID EIdType="doi" ValidYN="Y">10.1007/s12630-011-9462-1</ELocationID>
+                    <AuthorList CompleteYN="Y">
+                        <Author ValidYN="Y">
+                            <LastName>Hilton</LastName>
+                            <ForeName>Gillian</ForeName>
+                            <Initials>G</Initials>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Jette</LastName>
+                            <ForeName>Christine G</ForeName>
+                            <Initials>CG</Initials>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Ouyang</LastName>
+                            <ForeName>Yi-Bing</ForeName>
+                            <Initials>YB</Initials>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Riley</LastName>
+                            <ForeName>Edward T</ForeName>
+                            <Initials>ET</Initials>
+                        </Author>
+                    </AuthorList>
+                    <Language>eng</Language>
+                    <PublicationTypeList>
+                        <PublicationType UI="D016422">Letter</PublicationType>
+                        <PublicationType UI="D013485">Research Support, Non-U.S. Gov't</PublicationType>
+                    </PublicationTypeList>
+                    <ArticleDate DateType="Electronic">
+                        <Year>2011</Year>
+                        <Month>01</Month>
+                        <Day>21</Day>
+                    </ArticleDate>
+                </Article>
+                <MedlineJournalInfo>
+                    <Country>United States</Country>
+                    <MedlineTA>Can J Anaesth</MedlineTA>
+                    <NlmUniqueID>8701709</NlmUniqueID>
+                    <ISSNLinking>0832-610X</ISSNLinking>
+                </MedlineJournalInfo>
+                <CitationSubset>IM</CitationSubset>
+                <MeshHeadingList>
+                    <MeshHeading>
+                        <DescriptorName UI="D000767" MajorTopicYN="N">Anesthesia, Epidural</DescriptorName>
+                        <QualifierName UI="Q000295" MajorTopicYN="Y">instrumentation</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D000773" MajorTopicYN="N">Anesthesia, Obstetrical</DescriptorName>
+                        <QualifierName UI="Q000295" MajorTopicYN="Y">instrumentation</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D002404" MajorTopicYN="N">Catheterization</DescriptorName>
+                        <QualifierName UI="Q000295" MajorTopicYN="Y">instrumentation</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D005260" MajorTopicYN="N">Female</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D011247" MajorTopicYN="N">Pregnancy</DescriptorName>
+                    </MeshHeading>
+                </MeshHeadingList>
+            </MedlineCitation>
+            <PubmedData>
+                <History>
+                    <PubMedPubDate PubStatus="received">
+                        <Year>2010</Year>
+                        <Month>12</Month>
+                        <Day>09</Day>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="accepted">
+                        <Year>2011</Year>
+                        <Month>01</Month>
+                        <Day>10</Day>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="entrez">
+                        <Year>2011</Year>
+                        <Month>1</Month>
+                        <Day>22</Day>
+                        <Hour>6</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="pubmed">
+                        <Year>2011</Year>
+                        <Month>1</Month>
+                        <Day>22</Day>
+                        <Hour>6</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="medline">
+                        <Year>2011</Year>
+                        <Month>8</Month>
+                        <Day>2</Day>
+                        <Hour>6</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                </History>
+                <PublicationStatus>ppublish</PublicationStatus>
+                <ArticleIdList>
+                    <ArticleId IdType="pubmed">21253920</ArticleId>
+                    <ArticleId IdType="doi">10.1007/s12630-011-9462-1</ArticleId>
+                </ArticleIdList>
+            </PubmedData>
+        </PubmedArticle>
+
+        </PubmedArticleSet>
+    http_version: 
+  recorded_at: Thu, 14 Dec 2017 23:25:01 GMT
+recorded_with: VCR 4.0.0

--- a/lib/web_of_science/process_records.rb
+++ b/lib/web_of_science/process_records.rb
@@ -65,14 +65,15 @@ module WebOfScience
       # @param [Array<WebOfScience::Record>] records
       # @return [Array<WebOfScience::Record>]
       def save_wos_records(records)
-        # IMPORTANT: add nothing to PublicationIdentifiers here, or new_records will reject them
+        # IMPORTANT: add nothing to PublicationIdentifiers here, or filter_by_identifiers will reject them
         return [] if records.empty?
         # We only want the 'pmid' for "WOS" records ("MEDLINE" records have one already)
         process_links(records.select { |rec| rec.database == 'WOS' })
         records.select do |rec|
-          saved = WebOfScienceSourceRecord.new(source_data: rec.to_xml).save!
-          # TODO: add all identifiers to src-record, including links-API identifiers
-          saved
+          attr = { source_data: rec.to_xml }
+          attr[:doi] = rec.doi if rec.doi.present?
+          attr[:pmid] = rec.pmid if rec.pmid.present?
+          WebOfScienceSourceRecord.new(attr).save!
         end
       end
 

--- a/lib/web_of_science/process_records.rb
+++ b/lib/web_of_science/process_records.rb
@@ -153,12 +153,23 @@ module WebOfScience
       #       identifiers will get added to PublicationIdentifier after a Publication is created.
       #
       # @param records [Array<WebOfScience::Record>]
+      # @return [void]
       def process_links(records)
         return if records.empty?
         links = links_client.links records.map(&:uid)
-        records.each { |rec| rec.identifiers.update links[rec.uid] }
+        records.each { |rec| process_link(rec, links[rec.uid]) }
       rescue StandardError => err
         message = "Author: #{author.id}, ProcessLinks failed"
+        NotificationManager.error(err, message, self)
+      end
+
+      # @param record [WebOfScience::Record]
+      # @param links [Hash<String => String>] other identifiers (from Links API)
+      # @return [void]
+      def process_link(record, links)
+        record.identifiers.update links
+      rescue StandardError => err
+        message = "Author: #{author.id}, #{record.uid}, ProcessLink failed"
         NotificationManager.error(err, message, self)
       end
 

--- a/spec/lib/web_of_science/process_records_spec.rb
+++ b/spec/lib/web_of_science/process_records_spec.rb
@@ -77,7 +77,7 @@ describe WebOfScience::ProcessRecords, :vcr do
       processor.execute
       records.each do |rec|
         pub = Publication.find_by(wos_uid: rec.uid)
-        expect(pub.pub_hash).to include(:mesh_headings)
+        expect(pub.pub_hash).to include(:authorship)
       end
     end
 

--- a/spec/lib/web_of_science/process_records_spec.rb
+++ b/spec/lib/web_of_science/process_records_spec.rb
@@ -100,13 +100,30 @@ describe WebOfScience::ProcessRecords, :vcr do
         expect(NotificationManager).to receive(:error)
         processor.execute
       end
-      it 'returns an Array' do
-        result = processor.execute
-        expect(result).to be_an Array
+      it 'returns empty Array' do
+        expect(processor.execute).to be_an Array
+        expect(processor.execute).to be_empty
+      end
+    end
+
+    context 'create_publication fails' do
+      before do
+        allow(Publication).to receive(:new).and_raise(ActiveRecord::RecordInvalid)
+      end
+
+      it 'does not create new Publications' do
+        expect { processor.execute }.not_to change { Publication.count }
+      end
+      it 'does not create new Contributions' do
+        expect { processor.execute }.not_to change { Contribution.count }
+      end
+      it 'logs errors' do
+        expect(NotificationManager).to receive(:error)
+        processor.execute
       end
       it 'returns empty Array' do
-        result = processor.execute
-        expect(result).to be_empty
+        expect(processor.execute).to be_an Array
+        expect(processor.execute).to be_empty
       end
     end
   end

--- a/spec/lib/web_of_science/process_records_spec.rb
+++ b/spec/lib/web_of_science/process_records_spec.rb
@@ -28,10 +28,10 @@ describe WebOfScience::ProcessRecords, :vcr do
   end
 
   let(:links_client) { Clarivate::LinksClient.new }
-  let(:null_logger) { Logger.new('/dev/null') }
 
   before do
-    allow(processor).to receive(:logger).and_return(null_logger)
+    null_logger = Logger.new('/dev/null')
+    allow(WebOfScience).to receive(:logger).and_return(null_logger)
     allow(processor).to receive(:links_client).and_return(links_client)
   end
 
@@ -39,9 +39,6 @@ describe WebOfScience::ProcessRecords, :vcr do
     # ---
     # Happy paths
 
-    it 'works' do
-      expect(processor.execute).not_to be_nil
-    end
     it 'returns an Array' do
       expect(processor.execute).to be_an Array
     end
@@ -100,7 +97,7 @@ describe WebOfScience::ProcessRecords, :vcr do
         expect { processor.execute }.not_to change { WebOfScienceSourceRecord.count }
       end
       it 'logs errors' do
-        expect(null_logger).to receive(:error)
+        expect(NotificationManager).to receive(:error)
         processor.execute
       end
       it 'returns an Array' do


### PR DESCRIPTION
Fix #549 

### Rationale
- first create publication and contribution records
- then enhance select records with PubMed data
- isolate the Publication creation from PubMed failures
  - provide better exception log messages using NotificationManager
- isolate WOS links update failures to individual records
  - add record-specific log messages (could help identify problematic records)

### Extras
- fixed a typo in a spec for "creates new contribution in the pub_hash[:authorship]"