### PR TITLE
Rework cap_profile_id_rewriter, disable it for now

### DIFF
--- a/lib/cap_profile_id_rewriter.rb
+++ b/lib/cap_profile_id_rewriter.rb
@@ -1,102 +1,96 @@
-# TODO: This code could be migrated into a runner script in `scripts/`
-require 'dotiw'
+# @deprecated
+# This class was only ever used on Stage/Cap-QA servers.  It exists because our non-production
+# servers connect to non-production CAP Profile servers to retrieve authors, and those servers
+# have different (`cap_profile_id`) primary keys than their production counterparts.  So if we
+# clone data from production, we still have to realign `cap_profile_id` to match the new backend.
+#
+# This code:
+# - Matches existing authors on :sunetid, :university_id, :california_physician_license
+#   - overwrites attributes including cap_profile_id
+#   - updates `cap_profile_id` in related contributions (presumed changed)
+# - Creates new authors where data is unmatched
 class CapProfileIdRewriter
   include ActionView::Helpers::DateHelper
 
-  def logger
-    @logger ||= Logger.new(Settings.CAP.PROFILE_ID_REWRITE_LOG)
+  # We intentionally deferred adapting this class to tolerate or workaround cap_profile_id
+  # uniqueness, since it is unclear when, if ever, we would be using this again.
+  # If it becomes needed, development will need to solve the problem
+  def initialize
+    raise 'CapProfileIdRewriter disabled'
   end
 
+  # @param [Integer] starting the "page" of results to start from
+  # @return [void]
   def rewrite_cap_profile_ids_from_feed(starting = 0)
-    @cap_http_client = CapHttpClient.new
-    logger.info 'Started cap profile id rewrite'
+    logger.info "Started cap profile id rewrite at #{start_time}"
     logger.info 'CAP API client config: '
-    logger.info @cap_http_client.auth.to_json
-
-    @page_count = starting
-    @last_page = false
-    initialize_counts_for_logging
-    until @last_page
-      @page_count += 1
-      process_next_batch_of_authorship_data(@page_count, 1000)
-      logger.debug "#{@total_running_count} in #{distance_of_time_in_words_to_now(@start_time, true)}"
-      logger.info @total_running_count.to_s + ' records were processed in ' + distance_of_time_in_words_to_now(@start_time)
-
-      # if page_count === 1 then break end
+    logger.info client.auth.to_json
+    counts[:page_count] = starting
+    until process_next_batch_of_authorship_data(counts[:page_count], 1000)
+      counts[:page_count] += 1
+      logger.info "#{counts[:total_running_count]} records processed in #{distance_of_time_in_words_to_now(start_time, true)}"
     end
-    write_counts_to_log
-
   rescue => e
     NotificationManager.log_exception(logger, "cap profile id rewrite import failed", e)
+  ensure
+    write_counts_to_log
   end
 
-  def initialize_counts_for_logging
-    @start_time = Time.zone.now
-    @total_running_count = 0
-    @new_author_count = 0
-    @authors_updated_count = 0
-    @no_import_settings_count = 0
-    @no_email_in_import_settings = 0
-    @active_true_count = 0
-    @active_false_count = 0
-    @no_profile_email_count =
-      @no_active_count = 0
-    @import_enabled_count = 0
-    @import_disabled_count = 0
-  end
+  private
 
-  def write_counts_to_log
-    process_time = distance_of_time_in_words_to_now(@start_time)
-    stats = "Finished cap profile id rewrite\n"
-    stats += "#{@total_running_count} records were processed in #{process_time}\n"
-    stats += "#{@new_author_count} authors were created.\n"
-    stats += "#{@no_import_settings_count} records with no import settings.\n"
-    stats += "#{@no_email_in_import_settings} records with no email in import settings.\n"
-    stats += "#{@active_true_count} records with 'active' true.\n"
-    stats += "#{@active_false_count} records with 'active' false.\n"
-    stats += "#{@no_active_count} records with no 'active' field in profile.\n"
-    stats += "#{@authors_updated_count} authors were updated.\n"
-    stats += "#{@import_enabled_count} authors had import enabled.\n"
-    stats += "#{@import_disabled_count} authors had import disabled.\n"
-    logger.info stats
+    # @return [Logger]
+    def logger
+      @logger ||= Logger.new(Settings.CAP.PROFILE_ID_REWRITE_LOG)
+    end
 
-    summary = "#{@new_author_count} authors were created.\n"
-    summary += "#{@page_count} pages of 1000 records were processed in #{process_time}.\n"
-    summary += "#{@total_running_count} total records were processed in #{process_time}.\n"
-    logger.info summary
-  end
+    # @return [ActiveSupport::TimeWithZone]
+    def start_time
+      @start_time ||= Time.zone.now
+    end
 
-  def process_next_batch_of_authorship_data(page_count, page_size)
-    json_response = @cap_http_client.get_batch_from_cap_api(page_count, page_size, nil)
+    # @return [Hash<Symbol => Integer>]
+    def counts
+      @counts ||= Hash.new { 0 } # default 0
+    end
 
-    if json_response['values'].blank?
-      logger.warn "Authorship import ended unexpectedly: unexpected json: #{json_response}"
-      # TODO: send an email here.
-      raise
-    else
+    # @return [CapHttpClient]
+    def client
+      @client ||= CapHttpClient.new
+    end
+
+    def write_counts_to_log
+      stats = "Finished cap profile id rewrite\n"
+      stats += "#{counts[:total_running_count]} records were processed in #{distance_of_time_in_words_to_now(start_time)}\n"
+      stats += "#{counts[:authors_updated_count]} authors were updated.\n"
+      stats += "#{counts[:new_author_count]} authors were created.\n"
+      stats += "Pages of 1000 records were processed up to page #{counts[:page_count]}.\n"
+      logger.info stats
+    end
+
+    # @param [Integer] page
+    # @param [Integer] page_size
+    # @return [Boolean] true when JSON response indicates 'lastPage'
+    def process_next_batch_of_authorship_data(page, page_size)
+      json_response = client.get_batch_from_cap_api(page, page_size, nil)
+      if json_response['values'].blank?
+        logger.warn "Authorship import ended unexpectedly: unexpected json: #{json_response}"
+        raise
+      end
       json_response['values'].each do |record|
-        @total_running_count += 1
-
+        counts[:total_running_count] += 1
         attrs = Author.build_attribute_hash_from_cap_profile(record)
+        good_keys = [:sunetid, :university_id, :california_physician_license].select { |key| attrs[key].present? }
+        author = good_keys.inject(nil) { |memo, key| memo || Author.find_by(key => attrs[key]) } # first hit wins
 
-        author = Author.where(sunetid: attrs[:sunetid]).first unless attrs[:sunetid].blank?
-        if author.nil? && !attrs[:university_id].blank?
-          author = Author.where(university_id: attrs[:university_id]).first
-        end
-        if author.nil? && !attrs[:california_physician_license].blank?
-          author = Author.where(california_physician_license: attrs[:california_physician_license]).first
-        end
         if author
-          author.update_attributes(attrs)
+          author.update_attributes!(attrs) # update_attributes! does validations, but update_attribute skips them
           author.contributions.each { |contrib| contrib.update_attribute(:cap_profile_id, author.cap_profile_id) }
-          @authors_updated_count += 1
-        else
-          # SKIP new authors?
-          author = Author.create(attrs)
-          @new_author_count += 1
+          counts[:authors_updated_count] += 1
+        else # SKIP new authors?
+          Author.create!(attrs)
+          counts[:new_author_count] += 1
         end
       end
-      @last_page = json_response['lastPage']
+      json_response['lastPage']
     end
-  end
 end


### PR DESCRIPTION
DISABLES cap_profile_id_rewriter class, per agreement.

- Only one method here is ever invoked. Make everything else private.
- Remove unnecessary `dotiw` dependency. The `DateHelper` is good enough.
- Completely avoid all the kludgey instance variables and initialization.
- Cut out all the logging of variables that NEVER CHANGE. They are uninformative.
- Cut out the DUPLICATE log lines.
- Add YARD
- Ensure logs get written, even after a `rescue`
- Consolidate `Author` finding logic
- Add `!` to critical operations

We have a blocker in production data to the **existing** logic of this class, specifically documented in #546.

Ironically, this class that complicates making `cap_profile_id` unique, also requires `cap_profile_id` to be present AND requires 3 other fields to be unique.