### PR TITLE
Validate cap_profile_id presence, too

### DIFF
--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -1,6 +1,6 @@
 class Author < ActiveRecord::Base
   has_paper_trail on: [:destroy]
-  validates :cap_profile_id, uniqueness: true
+  validates :cap_profile_id, uniqueness: true, presence: true
 
   has_many :author_identities, dependent: :destroy
   #

--- a/spec/api/sul_bib/authorship_api_spec.rb
+++ b/spec/api/sul_bib/authorship_api_spec.rb
@@ -315,24 +315,6 @@ describe SulBib::API, :vcr do
     end
   end # shared_examples 'it issues errors for cap_profile_id'
 
-  # When the database constraints for cap_profile_id are setup
-  # correctly and the AuthorshipAPI uses cap_profile_id before sul_author_id
-  # to find an author, it's virtually impossible to hit the errors tested
-  # by these specs.  However, the database constraints do not, yet,
-  # enforce NOT NULL and UNIQUE on the cap_profile_id.
-  shared_examples 'it checks author for a cap_profile_id' do
-    let(:request_data) do
-      author.cap_profile_id = ''
-      author.save!
-      valid_data_for_post.merge(sul_author_id: author.id)
-    end
-    it 'logs a warning for an author without a cap_profile_id' do
-      expect(Rails.logger).to receive(:warn).once
-      http_request
-      expect(author.cap_profile_id).to be_nil
-    end
-  end
-
   shared_examples 'it handles invalid authorship attributes' do
     let(:request_data) do
       update_authorship_for_pub_with_contributions.merge(visibility: 'invalid value')
@@ -380,7 +362,6 @@ describe SulBib::API, :vcr do
       it_behaves_like 'it issues errors when sul_author_id does not exist'
       it_behaves_like 'it issues errors for cap_profile_id'
       it_behaves_like 'it checks author for the correct cap_profile_id'
-      it_behaves_like 'it checks author for a cap_profile_id'
       it_behaves_like 'it handles invalid authorship attributes'
 
       it 'returns 500 error when publication contribution fails to save' do
@@ -491,7 +472,6 @@ describe SulBib::API, :vcr do
       it_behaves_like 'it issues errors when sul_author_id does not exist'
       it_behaves_like 'it issues errors for cap_profile_id'
       it_behaves_like 'it checks author for the correct cap_profile_id'
-      it_behaves_like 'it checks author for a cap_profile_id'
       it_behaves_like 'it handles invalid authorship attributes'
 
       context 'if there are contribution record errors' do

--- a/spec/models/author_spec.rb
+++ b/spec/models/author_spec.rb
@@ -12,6 +12,9 @@ describe Author do
       Author.find_or_create_by!(cap_profile_id: 1)
       expect { Author.create!(cap_profile_id: 1) }.to raise_error ActiveRecord::RecordInvalid
     end
+    it 'validates presence' do
+      expect { Author.create!(cap_profile_id: '') }.to raise_error ActiveRecord::RecordInvalid
+    end
   end
 
   describe '#first_name' do


### PR DESCRIPTION
All author records on prod indeed have `cap_profile_id`.

I don't know if we are going to care about this in this work cycle, but I already had this commit on a different branch, so I cherry-picked it here.

With the rewriter locked down, I think we could merge this without difficulty.