### PR TITLE
WebOfScienceSourceRecord - set identifiers, if not already set

### DIFF
--- a/app/models/web_of_science_source_record.rb
+++ b/app/models/web_of_science_source_record.rb
@@ -23,9 +23,15 @@ class WebOfScienceSourceRecord < ActiveRecord::Base
     # Assign default attributes using source_data
     def init_from_source
       raise 'Missing source_data' if source_data.nil?
-      self.database ||= record.database
       self.source_fingerprint ||= Digest::SHA2.hexdigest(source_data)
+      self.database ||= record.database
       self.uid ||= record.uid
+      init_optional_attributes
     end
 
+    # Assign optional attributes using source_data
+    def init_optional_attributes
+      self.doi ||= record.doi if record.doi.present?
+      self.pmid ||= record.pmid if record.pmid.present?
+    end
 end

--- a/spec/models/web_of_science_source_record_spec.rb
+++ b/spec/models/web_of_science_source_record_spec.rb
@@ -26,12 +26,32 @@ RSpec.describe WebOfScienceSourceRecord, type: :model do
     end
   end
 
+  context 'sets identifiers' do
+    before do
+      identifiers = WebOfScience::Identifiers.new(wos_record)
+      allow(identifiers).to receive(:doi).and_return('doi')
+      allow(identifiers).to receive(:pmid).and_return('123')
+      allow(WebOfScience::Identifiers).to receive(:new).and_return(identifiers)
+    end
+    it 'sets doi' do
+      expect(wos_src_rec.doi).to eq 'doi'
+    end
+    it 'sets pmid' do
+      expect(wos_src_rec.pmid).to eq 123
+    end
+    it 'allows select' do
+      wos_src_rec.save!
+      expect(described_class.select(:doi).first).to be_an described_class
+      expect(described_class.select(:pmid).first).to be_an described_class
+    end
+  end
+
   context 'source record validation' do
     it 'works' do
       expect(wos_src_rec.valid?).to be true
     end
     it 'allows select' do
-      expect(wos_src_rec.save!).to be true
+      wos_src_rec.save!
       expect(described_class.select(:id).first).to be_an described_class
     end
   end


### PR DESCRIPTION
Extracted from #551 to focus on this change alone.

Update: rebased on #559 (converted PMID to Integer) and fixed spec