### PR TITLE
WebOfScienceSourceRecord#pmid converted to Integer

### DIFF
--- a/db/migrate/20171215001732_wos_source_record_integer_pmid.rb
+++ b/db/migrate/20171215001732_wos_source_record_integer_pmid.rb
@@ -1,0 +1,9 @@
+class WosSourceRecordIntegerPmid < ActiveRecord::Migration
+  def up
+    change_column :web_of_science_source_records, :pmid, :integer
+  end
+
+  def down
+    change_column :web_of_science_source_records, :pmid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171213201429) do
+ActiveRecord::Schema.define(version: 20171215001732) do
 
   create_table "author_identities", force: :cascade do |t|
     t.integer  "author_id",     limit: 4,               null: false
@@ -218,7 +218,7 @@ ActiveRecord::Schema.define(version: 20171213201429) do
     t.datetime "created_at",                          null: false
     t.datetime "updated_at",                          null: false
     t.string   "doi",                limit: 255
-    t.string   "pmid",               limit: 255
+    t.integer  "pmid",               limit: 4
   end
 
   add_index "web_of_science_source_records", ["doi"], name: "web_of_science_doi_index", using: :btree


### PR DESCRIPTION
All the PMID fields are Integers - overlooked when first creating it.

cf. https://github.com/sul-dlss/sul_pub/blob/master/db/schema.rb
```
$ grep 'pmid' db/schema.rb 
    t.integer  "pmid",                    limit: 4
  add_index "publications", ["pmid"], name: "index_publications_on_pmid", using: :btree
    t.integer  "pmid",               limit: 4
  add_index "pubmed_source_records", ["pmid"], name: "index_pubmed_source_records_on_pmid", using: :btree
    t.integer  "pmid",               limit: 4
  add_index "sciencewire_source_records", ["pmid"], name: "index_sciencewire_source_records_on_pmid", using: :btree
    t.integer  "pmid",               limit: 4
    t.integer  "pmid",               limit: 4
  add_index "web_of_science_source_records", ["pmid"], name: "web_of_science_pmid_index", using: :btree
```