### PR TITLE
WebOfScienceSourceRecord - safe init callback and cleanup field accessors

### DIFF
--- a/spec/models/web_of_science_source_record_spec.rb
+++ b/spec/models/web_of_science_source_record_spec.rb
@@ -30,6 +30,10 @@ RSpec.describe WebOfScienceSourceRecord, type: :model do
     it 'works' do
       expect(wos_src_rec.valid?).to be true
     end
+    it 'allows select' do
+      expect(wos_src_rec.save!).to be true
+      expect(described_class.select(:id).first).to be_an described_class
+    end
   end
 
   context 'utility methods' do


### PR DESCRIPTION
Fix #562 

- use `WebOfScience::Record` for defaults and other util methods
