### PR TITLE
WebOfScience::Client - manage session throttle limits

### DIFF
--- a/lib/web_of_science/client.rb
+++ b/lib/web_of_science/client.rb
@@ -13,9 +13,12 @@ module WebOfScience
     AUTH_WSDL = 'http://search.webofknowledge.com/esti/wokmws/ws/WOKMWSAuthenticate?wsdl'.freeze
     SEARCH_WSDL = 'http://search.webofknowledge.com/esti/wokmws/ws/WokSearch?wsdl'.freeze
 
+    API_SESSION_QUERY_LIMIT = 2000
+
     def initialize(auth_code, log_level = Settings.WOS.LOG_LEVEL.to_sym)
       @auth_code = auth_code
       @log_level = log_level
+      @session_queries = 0
     end
 
     # A client for the authorization endpoint, using WSDL
@@ -41,6 +44,7 @@ module WebOfScience
     # A client for the search endpoint, using WSDL
     # @return [Savon::Client]
     def search
+      check_throttle_limits
       @search ||= Savon.client(
         wsdl: SEARCH_WSDL,
         headers: { 'Cookie' => "SID=\"#{session_id}\"", 'SOAPAction' => '' },
@@ -63,7 +67,7 @@ module WebOfScience
 
     # Calls close_session on the authentication endpoint
     # Resets the session_id and the search client
-    # @return [nil]
+    # @return [void]
     def session_close
       begin
         auth.globals[:headers]['Cookie'] = "SID=\"#{session_id}\""
@@ -72,13 +76,28 @@ module WebOfScience
         # Savon::SOAPFault: (soap:Server) No matches returned for SessionID
         logger.warn(fault.inspect)
       end
-      @auth = nil
-      @search = nil
-      @session_id = nil
+      session_reset
     end
 
     def logger
       @logger ||= Logger.new('log/web_of_science_client.log')
     end
+
+    private
+
+      attr_reader :session_queries
+
+      def check_throttle_limits
+        @session_queries += 1
+        session_close if session_queries > API_SESSION_QUERY_LIMIT
+      end
+
+      def session_reset
+        @auth = nil
+        @search = nil
+        @session_id = nil
+        @session_queries = 0
+      end
+
   end
 end

--- a/spec/lib/web_of_science/client_spec.rb
+++ b/spec/lib/web_of_science/client_spec.rb
@@ -59,10 +59,15 @@ describe WebOfScience::Client do
       savon.expects(:authenticate).returns(auth_xml)
       wos_client.session_id
     end
-    it 'works' do
+    it 'resets the client' do
       savon.expects(:close_session).returns('')
-      expect(wos_client.session_close).to be_nil
+      expect { wos_client.session_close }
+        .to change { wos_client.instance_variable_get('@session_id') }
+      expect(wos_client.instance_variable_get('@auth')).to be_nil
+      expect(wos_client.instance_variable_get('@search')).to be_nil
+      expect(wos_client.instance_variable_get('@session_queries')).to eq 0
     end
+
     context 'when there are no matches returned for SessionID' do
       let(:null_logger) { Logger.new('/dev/null') }
 
@@ -70,7 +75,8 @@ describe WebOfScience::Client do
 
       it 'creates a logger and works' do
         expect(wos_client).to receive(:logger).and_return(null_logger)
-        expect(wos_client.session_close).to be_nil
+        expect { wos_client.session_close }
+          .to change { wos_client.instance_variable_get('@session_id') }
       end
     end
   end


### PR DESCRIPTION
Fix #522 

- the idea here is that every time there is _any_ query on the WOS-API, it must hit the `WebOfScience::Client#search` method, so it can count the queries.