### PR TITLE
WebOfScience::Client - savon clients log to WebOfScience.logger

### DIFF
--- a/lib/web_of_science/client.rb
+++ b/lib/web_of_science/client.rb
@@ -27,6 +27,7 @@ module WebOfScience
         wsdl: AUTH_WSDL,
         headers: { 'Authorization' => "Basic #{@auth_code}", 'SOAPAction' => [''] },
         env_namespace: :soapenv,
+        logger: logger,
         log: true,
         log_level: @log_level,
         pretty_print_xml: true
@@ -46,6 +47,7 @@ module WebOfScience
         wsdl: SEARCH_WSDL,
         headers: { 'Cookie' => "SID=\"#{session_id}\"", 'SOAPAction' => '' },
         env_namespace: :soapenv,
+        logger: logger,
         log: true,
         log_level: @log_level,
         pretty_print_xml: true

--- a/spec/lib/web_of_science/client_spec.rb
+++ b/spec/lib/web_of_science/client_spec.rb
@@ -14,6 +14,11 @@ describe WebOfScience::Client do
   let(:auth_xml) { File.read('spec/fixtures/wos_client/authenticate.xml') }
   let(:no_session_matches) { File.read('spec/fixtures/wos_client/wos_session_close_fault_response.xml') }
 
+  before do
+    null_logger = Logger.new('/dev/null')
+    allow(WebOfScience).to receive(:logger).and_return(null_logger)
+  end
+
   describe '#new' do
     it 'works' do
       expect(wos_client).to be_a described_class

--- a/spec/lib/web_of_science_spec.rb
+++ b/spec/lib/web_of_science_spec.rb
@@ -29,7 +29,8 @@ describe WebOfScience do
 
   describe '#logger' do
     it 'works' do
-      expect(Logger).to receive(:new).with(Settings.WOS.LOG).once.and_call_original
+      null_logger = Logger.new('/dev/null')
+      expect(Logger).to receive(:new).with(Settings.WOS.LOG).once.and_return(null_logger)
       expect(described_class.logger).to be_a Logger
     end
   end

--- a/spec/lib/web_of_science_spec.rb
+++ b/spec/lib/web_of_science_spec.rb
@@ -28,9 +28,13 @@ describe WebOfScience do
   end
 
   describe '#logger' do
+    before do
+      described_class.class_variable_set('@@logger', nil)
+    end
     it 'works' do
       null_logger = Logger.new('/dev/null')
       expect(Logger).to receive(:new).with(Settings.WOS.LOG).once.and_return(null_logger)
+      expect(described_class.logger).to be_a Logger
       expect(described_class.logger).to be_a Logger
     end
   end


### PR DESCRIPTION
Without this, they log to STDOUT.