### PR TITLE
Gemfile - rspec without require

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ gem 'retina_tag'
 group :development, :test do
   gem 'dlss_cops' # includes rubocop
   gem 'rails_db'
+  gem 'rspec-rails', '~> 3.7', require: false
 end
 
 group :development do
@@ -74,7 +75,6 @@ group :test do
   gem 'database_cleaner'
   gem 'equivalent-xml'
   gem 'factory_bot_rails'
-  gem 'rspec-rails', '~> 3.7'
   gem 'simplecov', '~> 0.13', require: false
   gem 'single_cov'
   gem 'vcr'


### PR DESCRIPTION
Trying to fix this when the app is deployed without the `:test` bundle, but rake requires rspec tasks.

```
[pub@sul-pub-dev current]$ bundle exec rake cap:poll[1]
Unable to load RSpec.
```
