### PR TITLE
WOS harvest efficiency

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -51,7 +51,7 @@ WOS:
     - MEDLINE
   AUTH_CODE: secret
   LOG: log/web_of_science.log
-  LOG_LEVEL: info
+  LOG_LEVEL: warn
 
 DOI:
   BASE_URI: https://dx.doi.org/

--- a/lib/web_of_science/process_records.rb
+++ b/lib/web_of_science/process_records.rb
@@ -96,7 +96,6 @@ module WebOfScience
         pub = Publication.new(
           active: true,
           pub_hash: record.pub_hash,
-          xml: record.to_xml,
           wos_uid: record.uid
         )
         create_contribution(pub)


### PR DESCRIPTION
- the XML doesn't need to be saved in Publication, it's already in WebOfScienceSourceRecord
- the savon clients 'info' log level is high volume and low information content
  - it will just fill logs with mostly useless details
  - the only value is the session-ID and response status, but we don't care for 200 responses anyway
