### PR TITLE
[WIP] WebOfScience::Harvester - extract WebOfScience::ProcessAuthor

### DIFF
--- a/lib/web_of_science/harvester.rb
+++ b/lib/web_of_science/harvester.rb
@@ -29,7 +29,7 @@ module WebOfScience
       # TODO: iterate on author identities also, or leave that to the consumer of this class?
       raise(ArgumentError, 'author must be an Author') unless author.is_a? Author
       logger.info "#{self.class} - processing author: #{author.id}"
-      uids = author_record_uids(author)
+      uids = WebOfScience::ProcessAuthor.new(author).uids
       uids = process_uids(author, uids)
       logger.info "#{self.class} - processed author: #{author.id}"
       uids
@@ -89,61 +89,6 @@ module WebOfScience
       def process_records(author, records)
         processor = WebOfScience::ProcessRecords.new(author, records)
         processor.execute
-      end
-
-      # ----
-      # Retrieve WOS Records for Author
-
-      # @param author [Author]
-      # @return [Array<String>]
-      def author_record_uids(author)
-        records = queries.search(author_query(author))
-        records.uids
-      end
-
-      # @param author [Author]
-      # @return [Hash]
-      def author_query(author)
-        names = author_name(author).text_search_query
-        institution = author_institution(author).normalize_name
-        user_query = "AU=(#{names}) AND AD=(#{institution})"
-        params = queries.params_for_fields(empty_fields)
-        params[:queryParameters][:userQuery] = user_query
-        params
-      end
-
-      # @param author [Author]
-      # @return [Agent::AuthorName]
-      def author_name(author)
-        Agent::AuthorName.new(
-          author.last_name,
-          author.first_name,
-          Settings.HARVESTER.USE_MIDDLE_NAME ? author.middle_name : ''
-        )
-      end
-
-      # @param author [Author]
-      # @return [Agent::AuthorInstitution]
-      def author_institution(author)
-        return default_institution if author.institution.blank?
-        Agent::AuthorInstitution.new(author.institution)
-      end
-
-      # @return [Agent::AuthorInstitution]
-      def default_institution
-        @default_institution ||= begin
-          Agent::AuthorInstitution.new(
-            Settings.HARVESTER.INSTITUTION.name,
-            Agent::AuthorAddress.new(Settings.HARVESTER.INSTITUTION.address.to_hash)
-          )
-        end
-      end
-
-      # ----
-      # Utility methods
-
-      def empty_fields
-        @empty_fields ||= Settings.WOS.ACCEPTED_DBS.map { |db| { collectionName: db, fieldName: [''] } }
       end
 
   end

--- a/lib/web_of_science/process_author.rb
+++ b/lib/web_of_science/process_author.rb
@@ -1,0 +1,43 @@
+module WebOfScience
+
+  # Use author name-institution logic to find WOS publications for an Author
+  class ProcessAuthor
+
+    def initialize(author)
+      raise(ArgumentError, 'author must be an Author') unless author.is_a? Author
+      @names = Agent::AuthorName.new(
+        author.last_name,
+        author.first_name,
+        Settings.HARVESTER.USE_MIDDLE_NAME ? author.middle_name : ''
+      ).text_search_query
+      @institution = Agent::AuthorInstitution.new(author.institution).normalize_name
+    end
+
+    # Find all WOS-UIDs for an author
+    # @return [Array<String>] WosUIDs
+    def uids
+      # TODO: iterate on author identities also, or leave that to the consumer of this class?
+      records = queries.search(author_query)
+      records.uids
+    end
+
+    private
+
+      delegate :queries, to: :WebOfScience
+
+      attr_reader :names
+      attr_reader :institution
+
+      # @return [Hash]
+      def author_query
+        params = queries.params_for_fields(empty_fields)
+        params[:queryParameters][:userQuery] = "AU=(#{names}) AND AD=(#{institution})"
+        params
+      end
+
+      def empty_fields
+        Settings.WOS.ACCEPTED_DBS.map { |db| { collectionName: db, fieldName: [''] } }
+      end
+
+  end
+end


### PR DESCRIPTION
Fix #582 - for more efficient WOS harvests by author name-institution.

- find all the WOS-UIDs for an author by the name-institution search
  - only retrieve the UIDs, not the entire source record
- then re-route the harvest through the process_uids method
  - find or create contributions to any existing publications
  - retrieve and process only the new WOS-UID without contributions
  - use the retrieve_by_uid query on the WOS-API to get full records

Ran this branch on my laptop using a prod-db dump and it seemed to work OK, using a limited sample of 100 authors.  Not sure what the requirements need to be for an integration test to pass.  These counts indicate that it created new records.  We should assume that most of these WOS-records have already been harvested, so it's not surprising that this Publication count is _much_ lower than the source record count.
```
PRODUCTION [1] pry(main)> WebOfScienceSourceRecord.count
=> 4443
PRODUCTION [2] pry(main)> Publication.pluck(:wos_uid).compact.count
=> 771
```