### PR TITLE
WebOfScience::Queries - surface query messages in the public API

### DIFF
--- a/lib/web_of_science/harvester.rb
+++ b/lib/web_of_science/harvester.rb
@@ -88,7 +88,8 @@ module WebOfScience
         names = author_name(author).text_search_query
         institution = author_institution(author).normalize_name
         user_query = "AU=(#{names}) AND AD=(#{institution})"
-        wos_queries.search(user_query)
+        query = wos_queries.params_for_search(user_query)
+        wos_queries.search(query)
       end
 
       # @param author [Author]

--- a/lib/web_of_science/queries.rb
+++ b/lib/web_of_science/queries.rb
@@ -71,18 +71,10 @@ module WebOfScience
       retrieve_by_id(uids)
     end
 
-    # @param user_query [String] a custom user query
-    # @param message [Hash] optional search params (defaults to search_params)
-    # @return [WebOfScience::Records]
-    def search(user_query, message = search_params)
-      message[:queryParameters][:userQuery] = user_query
-      retrieve_records(:search, message)
-    end
-
     # @param doi [String] a digital object identifier (DOI)
     # @return [WebOfScience::Records]
     def search_by_doi(doi)
-      message = search_params("DO=#{doi}")
+      message = params_for_search("DO=#{doi}")
       message[:retrieveParameters][:count] = 10
       response = wos_client.search.call(:search, message: message)
       records = records(response, :search_response)
@@ -99,8 +91,50 @@ module WebOfScience
     def search_by_name(name, institutions = [])
       user_query = "AU=(#{name_query(name)})"
       user_query += " AND AD=(#{institutions.join(' OR ')})" unless institutions.empty?
-      message = search_params(user_query)
+      message = params_for_search(user_query)
       retrieve_records(:search, message)
+    end
+
+    # @param message [Hash] search params (see WebOfScience::Queries#params_for_search)
+    # @return [WebOfScience::Records]
+    def search(message)
+      retrieve_records(:search, message)
+    end
+
+    # @param user_query [String] (defaults to '')
+    # @return [Hash] search query parameters for full records
+    def params_for_search(user_query = '')
+      {
+        queryParameters: {
+          databaseId: database,
+          userQuery: user_query,
+          timeSpan: time_span,
+          queryLanguage: QUERY_LANGUAGE
+        },
+        retrieveParameters: retrieve_parameters
+      }
+    end
+
+    # Params to retrieve specific fields, not the full records; modify the retrieveParameters.
+    # The `viewField` option can only be used without reference to the `FullRecord` namespace.
+    # Also, the `viewField` must precede the `option` params in retrieveParameters.
+    #
+    # Using a `viewField` with an empty 'fieldName' results in returning only record-UIDs.
+    #
+    # @example
+    # fields = [{ collectionName: "WOS", fieldName: [""] }, { collectionName: "MEDLINE", fieldName: [""] }]
+    #
+    # @param fields [Array<Hash>] as above
+    # @return [Hash] search query parameters for specific fields
+    def params_for_fields(fields)
+      params = params_for_search
+      params[:retrieveParameters] = {
+        firstRecord: 1,
+        count: 100,
+        viewField: fields,
+        option: [{ key: 'RecordIDs', value: 'On' }]
+      }
+      params
     end
 
     private
@@ -110,13 +144,14 @@ module WebOfScience
 
       def retrieve_records(operation, message)
         response = wos_client.search.call(operation, message: message)
-        retrieve_additional_records(response, "#{operation}_response".to_sym)
+        retrieve_additional_records(message, response, "#{operation}_response".to_sym)
       end
 
+      # @param message [Hash] search params
       # @param response [Savon::Response]
       # @param response_type [Symbol]
       # @return [WebOfScience::Records]
-      def retrieve_additional_records(response, response_type)
+      def retrieve_additional_records(message, response, response_type)
         records = records(response, response_type)
         record_total = records_found(response, response_type)
         if record_total > MAX_RECORDS
@@ -128,11 +163,11 @@ module WebOfScience
           iterations -= 1 if (record_total % MAX_RECORDS).zero?
           [*1..iterations].each do |i|
             first_record = (MAX_RECORDS * i) + 1
-            message = {
+            retrieve_message = {
               queryId: query_id,
-              retrieveParameters: retrieve_parameters(first_record: first_record)
+              retrieveParameters: message[:retrieveParameters].merge(firstRecord: first_record)
             }
-            response_i = wos_client.search.call(retrieve_operation, message: message)
+            response_i = wos_client.search.call(retrieve_operation, message: retrieve_message)
             records_i = records(response_i, "#{retrieve_operation}_response".to_sym)
             records = records.merge_records records_i
           end
@@ -223,20 +258,6 @@ module WebOfScience
             value: 'http://scientific.thomsonreuters.com/schema/wok5.4/public/FullRecord'
           }
         ]
-      end
-
-      # @param user_query [String]
-      # @return [Hash] search query parameters
-      def search_params(user_query = '')
-        {
-          queryParameters: {
-            databaseId: database,
-            userQuery: user_query,
-            timeSpan: time_span,
-            queryLanguage: QUERY_LANGUAGE
-          },
-          retrieveParameters: retrieve_parameters
-        }
       end
 
       # @return [Hash] time span dates


### PR DESCRIPTION
Extracting this from #583 to focus only on the query changes in this PR.

### Rationale
- push the query message details into the public API
  - allow clients to inspect and modify the query message details
  - this becomes important in the harvester - to retrieve only WOS-UIDs for queries, not full records
- provide new options to query for record fields (or no fields at all)
  - prior to this change, it was only possible to retrieve full records
  - retrieving full records is too expensive when they have already been harvested
  - the `viewField` is described in the WOS API doc on p. 37 and it can be used to retrieve only the UID

### Changes
- changes the `search` method signature, which might break existing clients
  - need to check specs and all calls to any methods that change
- adds utility method to return empty records
  - all the public APIs should use it when there's nothing to return

Checking for use of `WebOfScience::Queries#search`, using:
- `git grep 'WebOfScience.queries'`
- `git grep 'wos_queries'`

Most of the calls on `WebOfScience::Queries` do not use the generic `search` method, they use more specific methods.  Only the `WebOfScience::Harvester` needs to be changed (done).  
  
  
  