### PR TITLE
WebOfScience::Client - log to a different log file for routine client logs

### DIFF
--- a/lib/web_of_science/client.rb
+++ b/lib/web_of_science/client.rb
@@ -13,8 +13,6 @@ module WebOfScience
     AUTH_WSDL = 'http://search.webofknowledge.com/esti/wokmws/ws/WOKMWSAuthenticate?wsdl'.freeze
     SEARCH_WSDL = 'http://search.webofknowledge.com/esti/wokmws/ws/WokSearch?wsdl'.freeze
 
-    delegate :logger, to: :WebOfScience
-
     def initialize(auth_code, log_level = Settings.WOS.LOG_LEVEL.to_sym)
       @auth_code = auth_code
       @log_level = log_level
@@ -77,6 +75,10 @@ module WebOfScience
       @auth = nil
       @search = nil
       @session_id = nil
+    end
+
+    def logger
+      @logger ||= Logger.new('log/web_of_science_client.log')
     end
   end
 end

--- a/spec/lib/web_of_science/client_spec.rb
+++ b/spec/lib/web_of_science/client_spec.rb
@@ -16,7 +16,7 @@ describe WebOfScience::Client do
 
   before do
     null_logger = Logger.new('/dev/null')
-    allow(WebOfScience).to receive(:logger).and_return(null_logger)
+    allow(wos_client).to receive(:logger).and_return(null_logger)
   end
 
   describe '#new' do
@@ -69,7 +69,7 @@ describe WebOfScience::Client do
       before { savon.expects(:close_session).returns(no_session_matches) }
 
       it 'creates a logger and works' do
-        expect(WebOfScience).to receive(:logger).and_return(null_logger)
+        expect(wos_client).to receive(:logger).and_return(null_logger)
         expect(wos_client.session_close).to be_nil
       end
     end


### PR DESCRIPTION
Split out of #583 

This is motivated by debugging the WOS harvest.  The WOS savon client logs contain a lot of repetitive noise.  Splitting out that logging to a separate file makes it easier to see actual WOS harvest log content without all the noise.