### PR TITLE
WOS record and mappers use less memory

### DIFF
--- a/lib/web_of_science/identifiers.rb
+++ b/lib/web_of_science/identifiers.rb
@@ -167,10 +167,18 @@ module WebOfScience
 
       def parse_medline(doc)
         return unless database == 'MEDLINE'
-        ids['pmid'].sub!('MEDLINE:', '') if ids['pmid'].present?
-        ids['pmid'] ||= uid.sub('MEDLINE:', '')
+        parse_medline_issn(doc)
+        parse_medline_pmid
+      end
+
+      def parse_medline_issn(doc)
         issn = doc.xpath('/REC/static_data/item/MedlineJournalInfo/ISSNLinking')
         ids['issn'] ||= issn.text if issn.present?
+      end
+
+      def parse_medline_pmid
+        ids['pmid'].sub!('MEDLINE:', '') if ids['pmid'].present?
+        ids['pmid'] ||= uid.sub('MEDLINE:', '')
       end
 
       def parse_wos

--- a/lib/web_of_science/map_abstract.rb
+++ b/lib/web_of_science/map_abstract.rb
@@ -3,37 +3,40 @@ module WebOfScience
   # Map WOS record abstract data into the SUL PubHash data
   class MapAbstract < Mapper
 
-    # @return [Array<String>]
-    def abstracts
-      # Note: rec.doc.xpath(nil).map(&:text) => []
-      rec.doc.xpath(path).map(&:text)
+    attr_reader :abstracts
+
+    # publication abstract details
+    # @return [Hash]
+    def pub_hash
+      return {} if abstracts.empty?
+      # Often there is only one abstract; if there is more than one,
+      # assume the first abstract is the most useful abstract.
+      abstract = abstracts.first.strip
+      case database
+      when 'MEDLINE'
+        { abstract: abstract }
+      else
+        { abstract_restricted: abstract }
+      end
     end
 
     private
 
-      # publication abstract details
-      # @return [Hash]
-      def mapper
-        return {} if abstracts.empty?
-        # Often there is only one abstract; if there is more than one,
-        # assume the first abstract is the most useful abstract.
-        abstract = abstracts.first.strip
-        case rec.database
-        when 'MEDLINE'
-          { abstract: abstract }
-        else
-          { abstract_restricted: abstract }
-        end
+      # Extract content from record, try not to hang onto the entire record
+      # @param rec [WebOfScience::Record]
+      def extract(rec)
+        super(rec)
+        @abstracts = rec.doc.xpath(path).map(&:text)
       end
 
       # The XPath for abstracts data from any WOK database record
       # @return [String, nil]
       def path
-        case rec.database
+        case database
         when 'MEDLINE', 'WOS'
           '/REC/static_data/fullrecord_metadata/abstracts/abstract/abstract_text'
         else
-          rec.logger.error("Unknown WOK database: #{rec.database}")
+          logger.error("Unknown WOK database: #{database}")
           nil
         end
       end

--- a/lib/web_of_science/map_abstract.rb
+++ b/lib/web_of_science/map_abstract.rb
@@ -6,7 +6,7 @@ module WebOfScience
     # @return [Array<String>]
     def abstracts
       # Note: rec.doc.xpath(nil).map(&:text) => []
-      @abstracts ||= rec.doc.xpath(path).map(&:text)
+      rec.doc.xpath(path).map(&:text)
     end
 
     private
@@ -15,16 +15,14 @@ module WebOfScience
       # @return [Hash]
       def mapper
         return {} if abstracts.empty?
-        @abstract ||= begin
-          # Often there is only one abstract; if there is more than one,
-          # assume the first abstract is the most useful abstract.
-          abstract = abstracts.first.strip
-          case rec.database
-          when 'MEDLINE'
-            { abstract: abstract }
-          else
-            { abstract_restricted: abstract }
-          end
+        # Often there is only one abstract; if there is more than one,
+        # assume the first abstract is the most useful abstract.
+        abstract = abstracts.first.strip
+        case rec.database
+        when 'MEDLINE'
+          { abstract: abstract }
+        else
+          { abstract_restricted: abstract }
         end
       end
 

--- a/lib/web_of_science/map_citation.rb
+++ b/lib/web_of_science/map_citation.rb
@@ -8,15 +8,13 @@ module WebOfScience
       # publication citation details
       # @return [Hash]
       def mapper
-        @citation ||= begin
-          c = {}
-          c[:year] = rec.pub_info['pubyear']
-          c[:date] = rec.pub_info['sortdate']
-          c[:pages] = pages if pages.present?
-          c[:title] = rec.titles['item'].strip
-          c[:journal] = journal
-          c
-        end
+        c = {}
+        c[:year] = rec.pub_info['pubyear']
+        c[:date] = rec.pub_info['sortdate']
+        c[:pages] = pages if pages.present?
+        c[:title] = rec.titles['item'].strip
+        c[:journal] = journal
+        c
       end
 
       # Journal information

--- a/lib/web_of_science/map_mesh.rb
+++ b/lib/web_of_science/map_mesh.rb
@@ -5,14 +5,12 @@ module WebOfScience
 
     # @return [Array<String>]
     def mesh
-      @mesh ||= begin
-        mesh_headings.map do |mesh_heading|
-          {
-            'descriptor' => mesh_descriptors(mesh_heading),
-            'qualifier' => mesh_qualifiers(mesh_heading),
-            'treecode' => mesh_treecodes(mesh_heading)
-          }
-        end
+      mesh_headings.map do |mesh_heading|
+        {
+          'descriptor' => mesh_descriptors(mesh_heading),
+          'qualifier' => mesh_qualifiers(mesh_heading),
+          'treecode' => mesh_treecodes(mesh_heading)
+        }
       end
     end
 
@@ -21,7 +19,7 @@ module WebOfScience
       # publication abstract details
       # @return [Hash]
       def mapper
-        @mesh_headings ||= mesh.empty? ? {} : { mesh_headings: mesh.map(&:deep_symbolize_keys) }
+        mesh.empty? ? {} : { mesh_headings: mesh.map(&:deep_symbolize_keys) }
       end
 
       # @return [Nokogiri::XML::NodeSet]

--- a/lib/web_of_science/map_names.rb
+++ b/lib/web_of_science/map_names.rb
@@ -9,8 +9,8 @@ module WebOfScience
       # @return [Hash]
       def mapper
         # - use names, with role, to include 'author' and other roles, possibly 'editor' also
-        # - the PubHash class has methods to separate them when creating citations
-        @names ||= {
+        # - the Csl::Citation has methods to separate them to create citations
+        {
           author: names,
           authorcount: rec.authors.count
         }

--- a/lib/web_of_science/map_pub_hash.rb
+++ b/lib/web_of_science/map_pub_hash.rb
@@ -24,7 +24,7 @@ module WebOfScience
 
       # publication abstract
       def pub_hash_abstract
-        pub.update rec.abstract_mapper.pub_hash
+        pub.update WebOfScience::MapAbstract.new(rec).pub_hash
       end
 
       # publication agents

--- a/lib/web_of_science/map_pub_hash.rb
+++ b/lib/web_of_science/map_pub_hash.rb
@@ -30,7 +30,7 @@ module WebOfScience
       # publication agents
       def pub_hash_agents
         pub.update WebOfScience::MapNames.new(rec).pub_hash
-        pub.update rec.publisher.pub_hash
+        pub.update WebOfScience::MapPublisher.new(rec).pub_hash
       end
 
       # publication citation details

--- a/lib/web_of_science/map_publisher.rb
+++ b/lib/web_of_science/map_publisher.rb
@@ -5,9 +5,34 @@ module WebOfScience
   # WOS publisher information
   class MapPublisher < Mapper
 
-    # @return [Array<Hash>]
-    def publishers
-      @publishers ||= begin
+    attr_reader :publishers
+
+    # Map WOS publisher data into the SUL PubHash data
+    def pub_hash
+      pub
+    end
+
+    private
+
+      attr_reader :pub
+      attr_reader :medline_country
+
+      # Extract content from record, try not to hang onto the entire record
+      # @param rec [WebOfScience::Record]
+      def extract(rec)
+        super(rec)
+        @publishers = extract_publishers(rec)
+        @medline_country = extract_medline_country(rec)
+        @pub = pub_hash_publisher
+      end
+
+      def extract_medline_country(rec)
+        return '' unless database == 'MEDLINE'
+        country = rec.doc.xpath('/REC/static_data/item/MedlineJournalInfo/Country')
+        country.present? ? country.text : ''
+      end
+
+      def extract_publishers(rec)
         publishers = rec.doc.search('static_data/summary/publishers/publisher').map do |publisher|
           # parse the publisher address(es)
           addresses = publisher.search('address_spec').map do |address|
@@ -27,20 +52,6 @@ module WebOfScience
         end
         publishers.flatten
       end
-    end
-
-    private
-
-      attr_reader :pub
-
-      # Map WOS publisher data into the SUL PubHash data
-      def mapper
-        @pub || begin
-          @pub = {}
-          pub_hash_publisher
-          pub
-        end
-      end
 
       # Extract publisher information into these fields:
       # :publisher=>"OXFORD UNIV PRESS"
@@ -48,12 +59,14 @@ module WebOfScience
       # :stateprovince=>""
       # :country=>"UNITED KINGDOM"
       def pub_hash_publisher
-        return if publishers.blank?
+        return {} if publishers.blank?
         # The WOS record allows for multiple publishers, for some reason, but journals usually have only one
         # publisher and our other data sources only provide one publisher; so choose the first one here.
         publisher = publishers.first
-        pub[:publisher] = publisher['full_name']
-        publisher_address(publisher['address'])
+        data = {}
+        data[:publisher] = publisher['full_name']
+        data.update publisher_address(publisher['address'])
+        data
       end
 
       # Useful snippet to see a bunch of addresses
@@ -64,54 +77,47 @@ module WebOfScience
 
       # @param address [Hash]
       def publisher_address(address)
-        return if address.blank?
-        # The city is provided by WOS
-        pub[:city] = address['city']
-        # The rest is a parsing game
-        full_address = address['full_address']
-        publisher_state(full_address)
-        publisher_country(full_address)
+        return {} if address.blank?
+        addr = {}
+        addr[:city] = address['city']
+        addr.update publisher_state_country(address['full_address'])
+        addr
       end
 
-      def medline_country
-        return false unless rec.database == 'MEDLINE'
-        country = rec.doc.xpath('/REC/static_data/item/MedlineJournalInfo/Country')
-        pub[:country] = country.text if country.present?
-        country.present?
+      # @param full_address [Hash]
+      def publisher_state_country(full_address)
+        return {} if full_address.blank?
+        addr = {}
+        addr[:country] = medline_country if medline_country.present?
+        usa_address = StreetAddress::US.parse(full_address)
+        if usa_address
+          addr[:stateprovince] = usa_address.state
+          addr[:country] ||= 'USA'
+        end
+        addr[:stateprovince] ||= parse_state(full_address)
+        addr[:country] ||= parse_country(full_address)
+        addr
       end
 
       # Extract a state from "{state} {zip} [{country}]"
-      def publisher_country(full_address)
-        return if medline_country
-        return if usa_address(full_address)
+      def parse_country(full_address)
         # This could be a US address that did not parse or it is an international address.
         # A best guess at the country comes from the last CSV element:
         country = full_address.split(',').last.to_s.strip
         if country.end_with?('USA')
-          pub[:country] = 'USA'
-        elsif country.present?
-          pub[:country] = country #unless country =~ /[0-9]*/
+          'USA'
+        elsif country.present? && country !~ /[0-9]*/
+          country
         end
       end
 
       # Extract a state from "{state} {zip} [{country}]"
-      def publisher_state(full_address)
-        return if usa_address(full_address)
+      def parse_state(full_address)
         # Some US addresses escape the StreetAddress parser.
         # Most often, the state acronym is in the last CSV element.
         state = full_address.split(',').last.to_s.strip
         matches = state.match(/([A-Z]{2})\s+([0-9-]*)/)
-        pub[:stateprovince] = matches[1] if matches.present?
-      end
-
-      # Extract the state and country from a US address
-      def usa_address(full_address)
-        @usa_address ||= StreetAddress::US.parse(full_address)
-        return false if @usa_address.blank?
-        # This is a US address
-        pub[:stateprovince] = @usa_address.state
-        pub[:country] = 'USA'
-        true
+        matches[1] if matches.present?
       end
 
   end

--- a/lib/web_of_science/mapper.rb
+++ b/lib/web_of_science/mapper.rb
@@ -3,24 +3,31 @@ module WebOfScience
   # Map WOS record data into the SUL Publication.pub_hash data
   class Mapper
 
+    delegate :logger, to: :WebOfScience
+
     # @param rec [WebOfScience::Record]
     def initialize(rec)
       raise(ArgumentError, 'rec must be a WebOfScience::Record') unless rec.is_a? WebOfScience::Record
-      @rec = rec
+      extract(rec)
     end
 
+    # Transform mapper content into pub_hash
     # @return [Hash]
     def pub_hash
-      mapper
+      # subclasses can map data, otherwise this method should never get called
+      raise(NotImplementedError, 'Move along, this is not the mapper your looking for.')
     end
 
     private
 
-      attr_reader :rec
+      attr_reader :uid
+      attr_reader :database
 
-      def mapper
-        # subclasses can map data, otherwise this method should never get called
-        raise(NotImplementedError, 'Move along, this is not the mapper your looking for.')
+      # Extract content from record, try not to hang onto the entire record
+      # @param rec [WebOfScience::Record]
+      def extract(rec)
+        @uid = rec.uid
+        @database = rec.database
       end
 
   end

--- a/lib/web_of_science/record.rb
+++ b/lib/web_of_science/record.rb
@@ -28,12 +28,12 @@ module WebOfScience
 
     # @return [Array<Hash<String => String>>]
     def authors
-      @authors ||= names.select { |name| name['role'] == 'author' }
+      names.select { |name| name['role'] == 'author' }
     end
 
     # @return [Array<Hash<String => String>>]
     def editors
-      @editors ||= names.select { |name| name['role'] == 'book_editor' }
+      names.select { |name| name['role'] == 'book_editor' }
     end
 
     # @return [Array<String>]

--- a/lib/web_of_science/record.rb
+++ b/lib/web_of_science/record.rb
@@ -38,7 +38,7 @@ module WebOfScience
 
     # @return [Array<String>]
     def doctypes
-      @doctypes ||= doc.search('static_data/summary/doctypes/doctype').map(&:text)
+      doc.search('static_data/summary/doctypes/doctype').map(&:text)
     end
 
     # @return [Hash<String => String>]

--- a/lib/web_of_science/record.rb
+++ b/lib/web_of_science/record.rb
@@ -90,7 +90,7 @@ module WebOfScience
     # Extract the REC summary fields
     # @return [Hash<String => Object>]
     def summary
-      @summary ||= {
+      {
         'abstracts' => abstracts,
         'doctypes' => doctypes,
         'names' => names,

--- a/lib/web_of_science/record.rb
+++ b/lib/web_of_science/record.rb
@@ -96,18 +96,18 @@ module WebOfScience
       }
     end
 
-    # An OpenStruct for the summary fields
-    # @return [OpenStruct]
-    def summary_struct
-      to_o(summary)
-    end
-
     # @return [Hash<String => String>]
     def titles
       @titles ||= begin
         titles = doc.search('static_data/summary/titles/title')
         titles.map { |title| [title['type'], title.text] }.to_h
       end
+    end
+
+    # Map WOS record data into the SUL PubHash data
+    # @return [Hash]
+    def pub_hash
+      @pub_hash ||= WebOfScience::MapPubHash.new(self).pub_hash
     end
 
     # Extract the REC fields
@@ -118,16 +118,11 @@ module WebOfScience
       }
     end
 
-    # Map WOS record data into the SUL PubHash data
-    # @return [Hash]
-    def pub_hash
-      @pub_hash ||= WebOfScience::MapPubHash.new(self).pub_hash
-    end
-
     # An OpenStruct for the REC fields
     # @return [OpenStruct]
     def to_struct
-      to_o(to_h)
+      # Convert Hash to OpenStruct with recursive application to nested hashes
+      JSON.parse(to_h.to_json, object_class: OpenStruct)
     end
 
     # @return [String] XML
@@ -135,11 +130,5 @@ module WebOfScience
       doc.to_xml(save_with: WebOfScience::XmlParser::XML_OPTIONS).strip
     end
 
-    private
-
-      # Convert Hash to OpenStruct with recursive application to nested hashes
-      def to_o(hash)
-        JSON.parse(hash.to_json, object_class: OpenStruct)
-      end
   end
 end

--- a/lib/web_of_science/record.rb
+++ b/lib/web_of_science/record.rb
@@ -6,8 +6,6 @@ module WebOfScience
   class Record
     extend Forwardable
 
-    delegate %i(abstracts) => :abstract_mapper
-
     delegate %i(database doi eissn issn pmid uid wos_item_id) => :identifiers
     delegate logger: :WebOfScience
 
@@ -21,9 +19,9 @@ module WebOfScience
       @doc = WebOfScience::XmlParser.parse(record, encoded_record)
     end
 
-    # @return [WebOfScience::MapAbstract]
-    def abstract_mapper
-      @abstract_mapper ||= WebOfScience::MapAbstract.new(self)
+    # @return [Array<String>]
+    def abstracts
+      WebOfScience::MapAbstract.new(self).abstracts
     end
 
     # @return [Array<Hash<String => String>>]

--- a/lib/web_of_science/record.rb
+++ b/lib/web_of_science/record.rb
@@ -11,8 +11,6 @@ module WebOfScience
     delegate %i(database doi eissn issn pmid uid wos_item_id) => :identifiers
     delegate logger: :WebOfScience
 
-    delegate %i(publishers) => :publisher
-
     # @!attribute [r] doc
     #   @return [Nokogiri::XML::Document] WOS record document
     attr_reader :doc
@@ -83,8 +81,8 @@ module WebOfScience
     end
 
     # @return [WebOfScience::MapPublisher]
-    def publisher
-      @publisher ||= WebOfScience::MapPublisher.new(self)
+    def publishers
+      WebOfScience::MapPublisher.new(self).publishers
     end
 
     # Extract the REC summary fields

--- a/lib/web_of_science/record.rb
+++ b/lib/web_of_science/record.rb
@@ -83,19 +83,6 @@ module WebOfScience
       WebOfScience::MapPublisher.new(self).publishers
     end
 
-    # Extract the REC summary fields
-    # @return [Hash<String => Object>]
-    def summary
-      {
-        'abstracts' => abstracts,
-        'doctypes' => doctypes,
-        'names' => names,
-        'pub_info' => pub_info,
-        'publishers' => publishers,
-        'titles' => titles,
-      }
-    end
-
     # @return [Hash<String => String>]
     def titles
       @titles ||= begin
@@ -114,7 +101,12 @@ module WebOfScience
     # @return [Hash<String => Object>]
     def to_h
       {
-        'summary' => summary,
+        'abstracts' => abstracts,
+        'doctypes' => doctypes,
+        'names' => names,
+        'pub_info' => pub_info,
+        'publishers' => publishers,
+        'titles' => titles,
       }
     end
 

--- a/spec/lib/web_of_science/map_mesh_spec.rb
+++ b/spec/lib/web_of_science/map_mesh_spec.rb
@@ -30,9 +30,6 @@ describe WebOfScience::MapMesh do
   end
 
   shared_examples 'no_mesh' do
-    it 'works' do
-      expect(mapper.mesh).to be_empty
-    end
     it 'pub_hash has no MESH headings' do
       expect(pub_hash[:mesh_headings]).to be_nil
     end
@@ -48,9 +45,6 @@ describe WebOfScience::MapMesh do
     it_behaves_like 'medline_works'
     it_behaves_like 'pub_hash'
 
-    it 'works' do
-      expect(mapper.mesh).not_to be_empty
-    end
     it 'pub_hash has MESH headings' do
       expect(pub_hash[:mesh_headings]).to be_an Array
     end

--- a/spec/lib/web_of_science/record_spec.rb
+++ b/spec/lib/web_of_science/record_spec.rb
@@ -189,26 +189,14 @@ describe WebOfScience::Record do
     end
   end
 
-  describe '#summary' do
-    let(:summary) { wos_record_encoded.summary }
+  describe '#pub_hash' do
+    let(:pub_hash) { wos_record_encoded.pub_hash }
 
     it 'works' do
-      expect(summary).to be_an Hash
+      expect(pub_hash).to be_an Hash
     end
-    it 'contains doctypes Array' do
-      expect(summary['doctypes']).to be_an Array
-    end
-    it 'contains names Array' do
-      expect(summary['names']).to be_an Array
-    end
-    it 'contains pub_info Hash' do
-      expect(summary['pub_info']).to be_an Hash
-    end
-    it 'contains publishers Array' do
-      expect(summary['publishers']).to be_an Array
-    end
-    it 'contains titles Hash' do
-      expect(summary['titles']).to be_an Hash
+    it 'has "wos" provenance' do
+      expect(pub_hash[:provenance]).to eq 'wos'
     end
   end
 
@@ -225,49 +213,43 @@ describe WebOfScience::Record do
     it 'works' do
       expect(hash).to be_an Hash
     end
-    it 'contains summary fields' do
-      expect(hash['summary']).to eq wos_record_encoded.summary
+    it 'contains doctypes Array' do
+      expect(hash['doctypes']).to be_an Array
     end
-  end
-
-  describe '#pub_hash' do
-    let(:pub_hash) { wos_record_encoded.pub_hash }
-
-    it 'works' do
-      expect(pub_hash).to be_an Hash
+    it 'contains names Array' do
+      expect(hash['names']).to be_an Array
     end
-    it 'has "wos" provenance' do
-      expect(pub_hash[:provenance]).to eq 'wos'
+    it 'contains pub_info Hash' do
+      expect(hash['pub_info']).to be_an Hash
+    end
+    it 'contains publishers Array' do
+      expect(hash['publishers']).to be_an Array
+    end
+    it 'contains titles Hash' do
+      expect(hash['titles']).to be_an Hash
     end
   end
 
   describe '#to_struct' do
     let(:struct) { wos_record_encoded.to_struct }
-    let(:summary) { struct.summary }
 
     it 'works' do
       expect(struct).to be_an OpenStruct
     end
-    it 'contains summary fields' do
-      expect(summary).to be_an OpenStruct
+    it 'contains doctypes Array' do
+      expect(struct.doctypes).to be_an Array
     end
-
-    describe 'summary_struct' do
-      it 'contains doctypes Array' do
-        expect(summary.doctypes).to be_an Array
-      end
-      it 'contains names Array' do
-        expect(summary.names).to be_an Array
-      end
-      it 'contains pub_info OpenStruct' do
-        expect(summary.pub_info).to be_an OpenStruct
-      end
-      it 'contains publishers Array' do
-        expect(summary.publishers).to be_an Array
-      end
-      it 'contains titles OpenStruct' do
-        expect(summary.titles).to be_an OpenStruct
-      end
+    it 'contains names Array' do
+      expect(struct.names).to be_an Array
+    end
+    it 'contains pub_info OpenStruct' do
+      expect(struct.pub_info).to be_an OpenStruct
+    end
+    it 'contains publishers Array' do
+      expect(struct.publishers).to be_an Array
+    end
+    it 'contains titles OpenStruct' do
+      expect(struct.titles).to be_an OpenStruct
     end
   end
 

--- a/spec/lib/web_of_science/record_spec.rb
+++ b/spec/lib/web_of_science/record_spec.rb
@@ -212,29 +212,6 @@ describe WebOfScience::Record do
     end
   end
 
-  describe '#summary_struct' do
-    let(:summary) { wos_record_encoded.summary_struct }
-
-    it 'works' do
-      expect(summary).to be_an OpenStruct
-    end
-    it 'contains doctypes Array' do
-      expect(summary.doctypes).to be_an Array
-    end
-    it 'contains names Array' do
-      expect(summary.names).to be_an Array
-    end
-    it 'contains pub_info OpenStruct' do
-      expect(summary.pub_info).to be_an OpenStruct
-    end
-    it 'contains publishers Array' do
-      expect(summary.publishers).to be_an Array
-    end
-    it 'contains titles OpenStruct' do
-      expect(summary.titles).to be_an OpenStruct
-    end
-  end
-
   describe '#titles' do
     it 'works' do
       result = wos_record_encoded.titles
@@ -266,12 +243,31 @@ describe WebOfScience::Record do
 
   describe '#to_struct' do
     let(:struct) { wos_record_encoded.to_struct }
+    let(:summary) { struct.summary }
 
     it 'works' do
       expect(struct).to be_an OpenStruct
     end
     it 'contains summary fields' do
-      expect(struct.summary).to be_an OpenStruct
+      expect(summary).to be_an OpenStruct
+    end
+
+    describe 'summary_struct' do
+      it 'contains doctypes Array' do
+        expect(summary.doctypes).to be_an Array
+      end
+      it 'contains names Array' do
+        expect(summary.names).to be_an Array
+      end
+      it 'contains pub_info OpenStruct' do
+        expect(summary.pub_info).to be_an OpenStruct
+      end
+      it 'contains publishers Array' do
+        expect(summary.publishers).to be_an Array
+      end
+      it 'contains titles OpenStruct' do
+        expect(summary.titles).to be_an OpenStruct
+      end
     end
   end
 


### PR DESCRIPTION
Fix #601 

Atomic refactoring to remove memoized data wherever possible (resting on green)
- simplify the public API for the WOS Record class
  - removed the `summary*` methods, access to this data is in the `to_h` & `to_struct` methods
  - spec changes should be related to public API changes only
- simplify mappers
  - as a result of some extract class refactoring, there was some complexity in the mappers
    - the mappers were holding onto the record
  - mappers no longer hold onto a reference to the WOS record
    - mappers extract only the WOS XML elements they need
  - instances of mappers are no longer memoized anywhere
  - the goal is to use less memory and make it easier for ruby GC to clean up
  - most of the mapper refactoring rests on green in existing specs, so minimal changes to specs
