### PR TITLE
Csl::Mapper - extract class Csl::CapMapper

### DIFF
--- a/lib/csl/cap_mapper.rb
+++ b/lib/csl/cap_mapper.rb
@@ -1,0 +1,59 @@
+module Csl
+
+  class CapMapper
+
+    # Convert CAP authors into CSL authors
+    # @param [Array<Hash>] authors array of hash data
+    # @return [Array<Hash>] CSL authors array of hash data
+    def self.authors_to_csl(authors)
+      # All the CAP authors are an author if they have no role or they have an 'author' role
+      authors = authors.map(&:symbolize_keys)
+      authors.select! { |author| author[:role].nil? || author[:role].to_s.downcase.eql?('author') }
+      authors.map { |author| Csl::AuthorName.new(author).to_csl_author }
+    end
+
+    # Convert CAP editors into CSL editors
+    # @param [Array<Hash>] authors array of hash data
+    # @return [Array<Hash>] CSL authors array of hash data
+    def self.editors_to_csl(authors)
+      # A CAP editor has an 'editor' role
+      editors = authors.map(&:symbolize_keys)
+      editors.select! { |editor| editor[:role].to_s.downcase.eql?('editor') }
+      editors.map { |editor| Csl::AuthorName.new(editor).to_csl_author }
+    end
+
+    # Report – A document containing the findings of an individual or group.
+    # Can include a technical paper, publication, issue brief, or working paper.
+    #
+    # The Zotero and Mendeley mappings to a CSL report guided this implementation, see
+    # http://aurimasv.github.io/z2csl/typeMap.xml#map-report
+    # http://support.mendeley.com/customer/portal/articles/364144-csl-type-mapping
+    def self.create_csl_report(pub_hash, authors = [], editors = [])
+      csl_report = {}
+      csl_report['id'] = 'sulpub'
+      csl_report['type'] = 'report'
+      csl_report['author'] = authors if authors.present?
+      csl_report['editor'] = editors if editors.present?
+      csl_report['title'] = pub_hash[:title] if pub_hash[:title].present?
+      csl_report['abstract'] = pub_hash[:abstract] if pub_hash[:abstract].present?
+      csl_report['publisher'] = pub_hash[:publisher] if pub_hash[:publisher].present?
+      csl_report['publisher-place'] = pub_hash[:publicationSource] if pub_hash[:publicationSource].present?
+      # Date Accessed -> accessed
+      if pub_hash[:year].present?
+        csl_report['issued'] = {
+          'date-parts' => [[ pub_hash[:year] ]]
+        }
+      end
+      url = pub_hash[:publicationUrl]
+      csl_report['URL'] = url if url.present?
+      series = pub_hash[:series]
+      if series.present?
+        csl_report['collection-title'] = series[:title] if series[:title].present?
+        csl_report['volume'] = series[:volume] if series[:volume].present?
+        csl_report['number'] = series[:number] if series[:number].present?
+      end
+      csl_report['page'] = pub_hash[:pages] if pub_hash[:pages].present?
+      csl_report
+    end
+  end
+end

--- a/lib/csl/cap_mapper.rb
+++ b/lib/csl/cap_mapper.rb
@@ -2,58 +2,90 @@ module Csl
 
   class CapMapper
 
-    # Convert CAP authors into CSL authors
-    # @param [Array<Hash>] authors array of hash data
-    # @return [Array<Hash>] CSL authors array of hash data
-    def self.authors_to_csl(authors)
-      # All the CAP authors are an author if they have no role or they have an 'author' role
-      authors = authors.map(&:symbolize_keys)
-      authors.select! { |author| author[:role].nil? || author[:role].to_s.downcase.eql?('author') }
-      authors.map { |author| Csl::AuthorName.new(author).to_csl_author }
-    end
+    class << self
 
-    # Convert CAP editors into CSL editors
-    # @param [Array<Hash>] authors array of hash data
-    # @return [Array<Hash>] CSL authors array of hash data
-    def self.editors_to_csl(authors)
-      # A CAP editor has an 'editor' role
-      editors = authors.map(&:symbolize_keys)
-      editors.select! { |editor| editor[:role].to_s.downcase.eql?('editor') }
-      editors.map { |editor| Csl::AuthorName.new(editor).to_csl_author }
-    end
+      # Convert CAP authors into CSL authors
+      # @param [Array<Hash>] authors array of hash data
+      # @return [Array<Hash>] CSL authors array of hash data
+      def authors_to_csl(authors)
+        # All the CAP authors are an author if they have no role or they have an 'author' role
+        authors = authors.map(&:symbolize_keys)
+        authors.select! { |author| author[:role].nil? || author[:role].to_s.downcase.eql?('author') }
+        authors.map { |author| Csl::AuthorName.new(author).to_csl_author }
+      end
 
-    # Report – A document containing the findings of an individual or group.
-    # Can include a technical paper, publication, issue brief, or working paper.
-    #
-    # The Zotero and Mendeley mappings to a CSL report guided this implementation, see
-    # http://aurimasv.github.io/z2csl/typeMap.xml#map-report
-    # http://support.mendeley.com/customer/portal/articles/364144-csl-type-mapping
-    def self.create_csl_report(pub_hash, authors = [], editors = [])
-      csl_report = {}
-      csl_report['id'] = 'sulpub'
-      csl_report['type'] = 'report'
-      csl_report['author'] = authors if authors.present?
-      csl_report['editor'] = editors if editors.present?
-      csl_report['title'] = pub_hash[:title] if pub_hash[:title].present?
-      csl_report['abstract'] = pub_hash[:abstract] if pub_hash[:abstract].present?
-      csl_report['publisher'] = pub_hash[:publisher] if pub_hash[:publisher].present?
-      csl_report['publisher-place'] = pub_hash[:publicationSource] if pub_hash[:publicationSource].present?
-      # Date Accessed -> accessed
-      if pub_hash[:year].present?
-        csl_report['issued'] = {
-          'date-parts' => [[ pub_hash[:year] ]]
-        }
+      # Convert CAP editors into CSL editors
+      # @param [Array<Hash>] authors array of hash data
+      # @return [Array<Hash>] CSL authors array of hash data
+      def editors_to_csl(authors)
+        # A CAP editor has an 'editor' role
+        editors = authors.map(&:symbolize_keys)
+        editors.select! { |editor| editor[:role].to_s.downcase.eql?('editor') }
+        editors.map { |editor| Csl::AuthorName.new(editor).to_csl_author }
       end
-      url = pub_hash[:publicationUrl]
-      csl_report['URL'] = url if url.present?
-      series = pub_hash[:series]
-      if series.present?
-        csl_report['collection-title'] = series[:title] if series[:title].present?
-        csl_report['volume'] = series[:volume] if series[:volume].present?
-        csl_report['number'] = series[:number] if series[:number].present?
+
+      # Report – A document containing the findings of an individual or group.
+      # Can include a technical paper, publication, issue brief, or working paper.
+      #
+      # The Zotero and Mendeley mappings to a CSL report guided this implementation, see
+      # http://aurimasv.github.io/z2csl/typeMap.xml#map-report
+      # http://support.mendeley.com/customer/portal/articles/364144-csl-type-mapping
+      #
+      # @param [Hash] pub_hash from Publication.pub_hash data
+      # @param [Array<Hash>] authors
+      # @param [Array<Hash>] editors
+      # @return [Hash] CSL report information
+      def create_csl_report(pub_hash, authors = [], editors = [])
+        csl_report = {}
+        csl_report['id'] = 'sulpub'
+        csl_report['type'] = 'report'
+        csl_report.update(extract_agents(pub_hash, authors, editors))
+        csl_report.update(extract_pub_info(pub_hash))
+        csl_report.update(extract_series(pub_hash))
+        csl_report
       end
-      csl_report['page'] = pub_hash[:pages] if pub_hash[:pages].present?
-      csl_report
+
+      private
+
+        # @return [Hash] CSL publication title, abstract, date, pages, etc.
+        def extract_pub_info(pub_hash)
+          map = {}
+          map['title'] = pub_hash[:title] if pub_hash[:title].present?
+          map['abstract'] = pub_hash[:abstract] if pub_hash[:abstract].present?
+          map['issued'] = { 'date-parts' => [[ pub_hash[:year] ]] } if pub_hash[:year].present?
+          map['URL'] = pub_hash[:publicationUrl] if pub_hash[:publicationUrl].present?
+          map['page'] = pub_hash[:pages] if pub_hash[:pages].present?
+          map
+        end
+
+        # @return [Hash] CSL author, editor, and publisher data
+        def extract_agents(pub_hash, authors, editors)
+          map = {}
+          map['author'] = authors if authors.present?
+          map['editor'] = editors if editors.present?
+          map.update extract_publisher(pub_hash)
+          map
+        end
+
+        # @return [Hash] CSL publisher data
+        def extract_publisher(pub_hash)
+          map = {}
+          map['publisher'] = pub_hash[:publisher] if pub_hash[:publisher].present?
+          map['publisher-place'] = pub_hash[:publicationSource] if pub_hash[:publicationSource].present?
+          map
+        end
+
+        # @return [Hash] CSL series data
+        def extract_series(pub_hash)
+          map = {}
+          return map if pub_hash[:series].blank?
+          series = pub_hash[:series]
+          map['collection-title'] = series[:title] if series[:title].present?
+          map['volume'] = series[:volume] if series[:volume].present?
+          map['number'] = series[:number] if series[:number].present?
+          map
+        end
+
     end
   end
 end

--- a/lib/csl/mapper.rb
+++ b/lib/csl/mapper.rb
@@ -26,8 +26,8 @@ module Csl
           @citeproc_editors ||= [] # there are no editors
         when 'cap'
           # This is a CAP manual submission
-          @citeproc_authors ||= cap_authors_to_csl(authors)
-          @citeproc_editors ||= cap_editors_to_csl(authors)
+          @citeproc_authors ||= Csl::CapMapper.authors_to_csl(authors)
+          @citeproc_editors ||= Csl::CapMapper.editors_to_csl(authors)
         when 'pubmed'
           # This is a PubMed publication and the author is created in
           # PubmedSourceRecord.convert_pubmed_publication_doc_to_hash
@@ -47,7 +47,7 @@ module Csl
           case pub_hash[:type].to_s.downcase
           when 'workingpaper', 'technicalreport'
             # Map a CAP 'workingPaper' or 'technicalReport' to a CSL 'report'
-            return create_csl_report
+            return Csl::CapMapper.create_csl_report(pub_hash, citeproc_authors, citeproc_editors)
           end
           ##
           # Other doc-types include:
@@ -140,66 +140,12 @@ module Csl
 
     private
 
-      # Report – A document containing the findings of an individual or group.
-      # Can include a technical paper, publication, issue brief, or working paper.
-      #
-      # The Zotero and Mendeley mappings to a CSL report guided this implementation, see
-      # http://aurimasv.github.io/z2csl/typeMap.xml#map-report
-      # http://support.mendeley.com/customer/portal/articles/364144-csl-type-mapping
-      def create_csl_report
-        csl_report = {}
-        csl_report['id'] = 'sulpub'
-        csl_report['type'] = 'report'
-        csl_report['author'] = citeproc_authors if citeproc_authors.present?
-        csl_report['editor'] = citeproc_editors if citeproc_editors.present?
-        csl_report['title'] = pub_hash[:title] if pub_hash[:title].present?
-        csl_report['abstract'] = pub_hash[:abstract] if pub_hash[:abstract].present?
-        csl_report['publisher'] = pub_hash[:publisher] if pub_hash[:publisher].present?
-        csl_report['publisher-place'] = pub_hash[:publicationSource] if pub_hash[:publicationSource].present?
-        # Date Accessed -> accessed
-        if pub_hash[:year].present?
-          csl_report['issued'] = {
-            'date-parts' => [[ pub_hash[:year] ]]
-          }
-        end
-        url = pub_hash[:publicationUrl]
-        csl_report['URL'] = url if url.present?
-        series = pub_hash[:series]
-        if series.present?
-          csl_report['collection-title'] = series[:title] if series[:title].present?
-          csl_report['volume'] = series[:volume] if series[:volume].present?
-          csl_report['number'] = series[:number] if series[:number].present?
-        end
-        csl_report['page'] = pub_hash[:pages] if pub_hash[:pages].present?
-        csl_report
-      end
-
       def citeproc_authors
         @citeproc_authors ||= parse_authors[:authors]
       end
 
       def citeproc_editors
         @citeproc_editors ||= parse_authors[:editors]
-      end
-
-      # Convert CAP authors into CSL authors
-      # @param [Array<Hash>] cap_authors array of hash data
-      # @return [Array<Hash>] CSL authors array of hash data
-      def cap_authors_to_csl(cap_authors)
-        # All the CAP authors are an author if they have no role or they have an 'author' role
-        authors = cap_authors.map(&:symbolize_keys)
-        authors.select! { |author| author[:role].nil? || author[:role].to_s.downcase.eql?('author') }
-        authors.map { |author| Csl::AuthorName.new(author).to_csl_author }
-      end
-
-      # Convert CAP editors into CSL editors
-      # @param [Array<Hash>] cap_authors array of hash data
-      # @return [Array<Hash>] CSL authors array of hash data
-      def cap_editors_to_csl(cap_authors)
-        # A CAP editor has an 'editor' role
-        editors = cap_authors.map(&:symbolize_keys)
-        editors.select! { |editor| editor[:role].to_s.downcase.eql?('editor') }
-        editors.map { |editor| Csl::AuthorName.new(editor).to_csl_author }
       end
 
       def parse_authors


### PR DESCRIPTION
Extracted from #512 

This is a straight extract-class refactor to clarify responsibilities for the Csl::Mapper class.
- this PR also applies extract-method refactor to the create_csl_report to fix cognitive complexity