### PR TITLE
Csl::Mapper - extract class Csl::PubmedMapper

### DIFF
--- a/lib/csl/mapper.rb
+++ b/lib/csl/mapper.rb
@@ -31,7 +31,7 @@ module Csl
         when 'pubmed'
           # This is a PubMed publication and the author is created in
           # PubmedSourceRecord.convert_pubmed_publication_doc_to_hash
-          @citeproc_authors ||= pubmed_authors_to_csl(authors)
+          @citeproc_authors ||= Csl::PubmedMapper.authors_to_csl(authors)
           @citeproc_editors ||= [] # there are no editors
         when 'sciencewire'
           # This is a ScienceWire publication and the author is created in
@@ -200,17 +200,6 @@ module Csl
         editors = cap_authors.map(&:symbolize_keys)
         editors.select! { |editor| editor[:role].to_s.downcase.eql?('editor') }
         editors.map { |editor| Csl::AuthorName.new(editor).to_csl_author }
-      end
-
-      # Convert PubMed authors into CSL authors, see also
-      # PubmedSourceRecord.convert_pubmed_publication_doc_to_hash
-      # @param [Array<Hash>] pubmed_authors array of hash data
-      # @return [Array<Hash>] CSL authors array of hash data
-      def pubmed_authors_to_csl(pubmed_authors)
-        pubmed_authors.map do |author|
-          author = author.symbolize_keys
-          Csl::AuthorName.new(author).to_csl_author
-        end.compact
       end
 
       def parse_authors

--- a/lib/csl/pubmed_mapper.rb
+++ b/lib/csl/pubmed_mapper.rb
@@ -1,0 +1,18 @@
+module Csl
+
+  # Convert PubMed content into a CSL format
+  class PubmedMapper
+
+    # Convert PubMed authors into CSL authors, see also
+    # PubmedSourceRecord.convert_pubmed_publication_doc_to_hash
+    # @param [Array<Hash>] authors array of hash data
+    # @return [Array<Hash>] CSL authors array of hash data
+    def self.authors_to_csl(authors)
+      authors.map do |author|
+        author = author.symbolize_keys
+        Csl::AuthorName.new(author).to_csl_author
+      end.compact
+    end
+
+  end
+end


### PR DESCRIPTION
Extracted from #512 

This is a straight extract-class refactor to clarify responsibilities for the Csl::Mapper class.