### PR TITLE
Csl::Mapper - extract class Csl::SciencewireMapper

### DIFF
--- a/lib/csl/mapper.rb
+++ b/lib/csl/mapper.rb
@@ -36,7 +36,7 @@ module Csl
         when 'sciencewire'
           # This is a ScienceWire publication and the author is created in
           # SciencewireSourceRecord.convert_sw_publication_doc_to_hash
-          @citeproc_authors ||= sw_authors_to_csl(authors)
+          @citeproc_authors ||= Csl::SciencewireMapper.authors_to_csl(authors)
           @citeproc_editors ||= [] # there are no editors
         else
           citeproc_authors # calls parse_authors
@@ -222,23 +222,6 @@ module Csl
         pubmed_authors.map do |author|
           author = author.symbolize_keys
           Csl::AuthorName.new(author).to_csl_author
-        end.compact
-      end
-
-      # Convert ScienceWire authors into CSL authors, see also
-      # SciencewireSourceRecord.convert_sw_publication_doc_to_hash
-      # @param [Array<Hash>] sw_authors array of hash data
-      # @return [Array<Hash>] CSL authors array of hash data
-      def sw_authors_to_csl(sw_authors)
-        # ScienceWire AuthorList is split('|') into an array of authors
-        sw_authors.map do |author|
-          # Each ScienceWire author is a CSV value: 'Lastname,Firstname,Middlename'
-          last, first, middle = author[:name].split(',')
-          Csl::AuthorName.new(
-            lastname: last,
-            firstname: first,
-            middlename: middle
-          ).to_csl_author
         end.compact
       end
 

--- a/lib/csl/sciencewire_mapper.rb
+++ b/lib/csl/sciencewire_mapper.rb
@@ -1,0 +1,24 @@
+module Csl
+
+  # Convert ScienceWire content into a CSL format
+  class SciencewireMapper
+
+    # Convert ScienceWire authors into CSL authors, see also
+    # SciencewireSourceRecord.convert_sw_publication_doc_to_hash
+    # @param [Array<Hash>] authors array of hash data
+    # @return [Array<Hash>] CSL authors array of hash data
+    def self.authors_to_csl(authors)
+      # ScienceWire AuthorList is split('|') into an array of authors
+      authors.map do |author|
+        # Each ScienceWire author is a CSV value: 'Lastname,Firstname,Middlename'
+        last, first, middle = author[:name].split(',')
+        Csl::AuthorName.new(
+          lastname: last,
+          firstname: first,
+          middlename: middle
+        ).to_csl_author
+      end.compact
+    end
+
+  end
+end


### PR DESCRIPTION
Extracted from #512

This is a straight extract-class refactor to clarify responsibilities for the Csl::Mapper class.