### PR TITLE
VCR - add filter for Settings.WOS.AUTH_CODE

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -146,6 +146,11 @@ VCR.configure do |c|
       id_match.captures.first if id_match
     end
   end
+
+  # WOS API filters
+  c.filter_sensitive_data('Settings.WOS.AUTH_CODE') do |interaction|
+    Settings.WOS.AUTH_CODE if interaction.request.uri.include? 'WOKMWSAuthenticate'
+  end
 end
 
 def a_post(path)


### PR DESCRIPTION
Some new API code could retrieve WOS records and create new VCR recordings (when a savon mock is not used).  This PR will filter our authentication code from any VCR recordings that match the WOS-API authentication URI.