### PR TITLE
WOS queries singleton for harvester

### DIFF
--- a/spec/api/sul_bib/authorship_api_spec.rb
+++ b/spec/api/sul_bib/authorship_api_spec.rb
@@ -166,7 +166,7 @@ describe SulBib::API, :vcr do
         allow(processor).to receive(:links_client).and_return(links_client)
         allow(WebOfScience::ProcessRecords).to receive(:new).and_return(processor)
         allow(wos_queries).to receive(:retrieve_by_id).and_return(records)
-        allow(WebOfScience.harvester).to receive(:wos_queries).and_return(wos_queries)
+        allow(WebOfScience).to receive(:queries).and_return(wos_queries)
         http_request
         expect(response.body).to eq(new_pub.pub_hash.to_json)
       end


### PR DESCRIPTION
This is a follow-up to #596 

- the delegated methods can be private in the harvester
- this also modifies a query mock for the authorship-api to bring it into line with this change
  - this mock might have been broken by #596 and surfaces in #583 as new VCR recordings
