### PR TITLE
WebOfScience::ProcessRecords - convert records to a mutable array

### DIFF
--- a/lib/web_of_science/process_records.rb
+++ b/lib/web_of_science/process_records.rb
@@ -10,6 +10,7 @@ module WebOfScience
     def initialize(author, records)
       raise(ArgumentError, 'author must be an Author') unless author.is_a? Author
       raise(ArgumentError, 'records must be an WebOfScience::Records') unless records.is_a? WebOfScience::Records
+      raise 'Nothing to do when Settings.WOS.ACCEPTED_DBS is empty' if Settings.WOS.ACCEPTED_DBS.empty?
       @author = author
       @records = records.to_a
     end

--- a/spec/lib/web_of_science/process_records_spec.rb
+++ b/spec/lib/web_of_science/process_records_spec.rb
@@ -87,6 +87,12 @@ describe WebOfScience::ProcessRecords, :vcr do
     it 'raises ArgumentError for records' do
       expect { described_class.new(author, []) }.to raise_error(ArgumentError)
     end
+    it 'raises RuntimeError when Settings.WOS.ACCEPTED_DBS.empty?' do
+      wos = Settings.WOS
+      allow(wos).to receive(:ACCEPTED_DBS).and_return([])
+      allow(Settings).to receive(:WOS).and_return(wos)
+      expect { described_class.new(author, records) }.to raise_error(RuntimeError)
+    end
 
     context 'save_wos_records fails' do
       before do

--- a/spec/lib/web_of_science/process_records_spec.rb
+++ b/spec/lib/web_of_science/process_records_spec.rb
@@ -241,20 +241,19 @@ describe WebOfScience::ProcessRecords, :vcr do
   context 'with records from excluded databases' do
     subject(:processor) { described_class.new(author, records) }
 
-    let(:other_record_xml) do
+    let(:record_xml) do
       xml = File.read('spec/fixtures/wos_client/wos_record_000288663100014.xml')
       xml.gsub('WOS', 'EXCLUDED')
     end
-    let(:other_records_xml) { "<records>#{other_record_xml}</records>" }
-    let(:other_records) { WebOfScience::Records.new(records: other_records_xml) }
-
-    let(:records) { other_records }
+    let(:records_xml) { "<records>#{record_xml}</records>" }
+    let(:records) { WebOfScience::Records.new(records: records_xml) }
 
     it 'does not create new WebOfScienceSourceRecords' do
       expect { processor.execute }.not_to change { WebOfScienceSourceRecord.count }
     end
     it 'filters out excluded records' do
-      expect(processor.send(:filter_databases)).to be_empty
+      expect(processor).not_to receive(:create_publications)
+      expect(processor.execute).to be_empty
     end
   end
 end

--- a/spec/lib/web_of_science/process_records_spec.rb
+++ b/spec/lib/web_of_science/process_records_spec.rb
@@ -32,7 +32,7 @@ describe WebOfScience::ProcessRecords, :vcr do
   before do
     null_logger = Logger.new('/dev/null')
     allow(WebOfScience).to receive(:logger).and_return(null_logger)
-    allow(processor).to receive(:links_client).and_return(links_client)
+    allow(WebOfScience).to receive(:links_client).and_return(links_client)
   end
 
   shared_examples '#execute' do
@@ -214,7 +214,7 @@ describe WebOfScience::ProcessRecords, :vcr do
         expect { processor.execute }.to change { Publication.count }
       end
       it 'logs errors' do
-        expect(NotificationManager).to receive(:error)
+        expect(NotificationManager).to receive(:error).at_least(:once)
         processor.execute
       end
     end
@@ -224,8 +224,8 @@ describe WebOfScience::ProcessRecords, :vcr do
       # any failure to add links data is not catastrophic - just log it
       before do
         identifiers = WebOfScience::Identifiers.new(records.first)
-        allow(identifiers).to receive(:update).and_raise(RuntimeError)
-        allow(WebOfScience::Identifiers).to receive(:new).and_return(identifiers)
+        expect(identifiers).to receive(:update).and_raise(RuntimeError)
+        expect(WebOfScience::Identifiers).to receive(:new).and_return(identifiers).at_least(:once)
       end
 
       it 'continues to create new Publications' do


### PR DESCRIPTION
Extracted from #583 to focus on this class in this PR.

- aims to reduce memory consumption by using a mutable array of records
- progressive filters now select or reject records in-place
- initialize no longer holds onto the original set of records
  - they are immediately filtered for accepted-dbs

### Tech-Debt
Fix #600 