### PR TITLE
WebOfScience::Harvester - extract class WebOfScience::QueryAuthor

### DIFF
--- a/lib/web_of_science/query_author.rb
+++ b/lib/web_of_science/query_author.rb
@@ -1,0 +1,43 @@
+module WebOfScience
+
+  # Use author name-institution logic to find WOS publications for an Author
+  class QueryAuthor
+
+    def initialize(author)
+      raise(ArgumentError, 'author must be an Author') unless author.is_a? Author
+      @names = Agent::AuthorName.new(
+        author.last_name,
+        author.first_name,
+        Settings.HARVESTER.USE_MIDDLE_NAME ? author.middle_name : ''
+      ).text_search_query
+      @institution = Agent::AuthorInstitution.new(author.institution).normalize_name
+    end
+
+    # Find all WOS-UIDs for an author
+    # @return [Array<String>] WosUIDs
+    def uids
+      # TODO: iterate on author identities also, or leave that to the consumer of this class?
+      records = queries.search(author_query)
+      records.uids
+    end
+
+    private
+
+      delegate :queries, to: :WebOfScience
+
+      attr_reader :names
+      attr_reader :institution
+
+      # @return [Hash]
+      def author_query
+        params = queries.params_for_fields(empty_fields)
+        params[:queryParameters][:userQuery] = "AU=(#{names}) AND AD=(#{institution})"
+        params
+      end
+
+      def empty_fields
+        Settings.WOS.ACCEPTED_DBS.map { |db| { collectionName: db, fieldName: [''] } }
+      end
+
+  end
+end


### PR DESCRIPTION
Clarify responsibility for WOS-harvester
- consolidate author name-institution query in WebOfScience::QueryAuthor
- only needs to fetch and return WOS-UIDs for an author

### TODO
- work in a later PR can address how to handle author alternate identities, that's not the scope of this PR
- this PR just defines the responsibility for any WOS author queries lies with this class
