### PR TITLE
Fix rails output for 404

### DIFF
--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -36,7 +36,7 @@ class PublicationsController < ApplicationController
         logger.debug("Limited to only CAP Profile ID #{capProfileId}")
         author = Author.where(cap_profile_id: capProfileId).first
         if author.nil?
-          render status: 404, text: 'No such author'
+          render status: 404, body: "No such author with capProfileId #{capProfileId}"
           return
         else
           description = 'All known publications for CAP profile id ' + capProfileId

--- a/spec/controllers/publications_controller_spec.rb
+++ b/spec/controllers/publications_controller_spec.rb
@@ -11,7 +11,7 @@ describe PublicationsController do
         expect(controller).to receive(:check_authorization).and_return(true)
         get :index, capProfileId: 'nada'
         expect(response.status).to eq 404
-        expect(response.body).to eq 'No such author'
+        expect(response.body).to include 'No such author'
       end
     end
   end


### PR DESCRIPTION
Rails `render` has `body` param, not `text`

See: http://guides.rubyonrails.org/layouts_and_rendering.html#using-render