### PR TITLE
Test targeting & param non-munging

### DIFF
--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -86,8 +86,7 @@ class Publication < ActiveRecord::Base
 
   # @return [self]
   def update_manual_pub_from_pub_hash(incoming_pub_hash, original_source_string, provenance = Settings.cap_provenance)
-    incoming_pub_hash[:provenance] = provenance
-    self.pub_hash = incoming_pub_hash.dup
+    self.pub_hash = incoming_pub_hash.merge(provenance: provenance)
     match = UserSubmittedSourceRecord.find_by_source_data(original_source_string)
     match.publication = self if match # we may still throw this out w/o saving
     r = user_submitted_source_records.first || match || user_submitted_source_records.build

--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -323,7 +323,7 @@ describe Publication do
 
   describe '.build_new_manual_publication' do
     let(:save_new_publication) do
-      pub = Publication.build_new_manual_publication(pub_hash, 'some string', 'some where')
+      pub = Publication.build_new_manual_publication(pub_hash, 'some string')
       pub.save!
       pub
     end
@@ -336,31 +336,28 @@ describe Publication do
 
     it 'should refuse to add a publication with the same source record' do
       save_new_publication
-      expect do
-        Publication.build_new_manual_publication(pub_hash, 'some string', 'some where')
-      end.to raise_error(ActiveRecord::RecordNotUnique)
+      expect { Publication.build_new_manual_publication(pub_hash, 'some string') }.to raise_error(ActiveRecord::RecordNotUnique)
     end
 
     it "should create a publication if a publication for that source record doesn't exist" do
-      UserSubmittedSourceRecord.create source_data: 'some string'
+      UserSubmittedSourceRecord.create!(source_data: 'some string')
       expect { save_new_publication }.not_to raise_exception
     end
   end
 
-  describe 'update_manual_pub_from_pub_Hash' do
+  describe 'update_manual_pub_from_pub_hash' do
     it 'should update the user submitted source record with the new content' do
-      pub = Publication.build_new_manual_publication({ a: :b }, 'some string', 'some where')
-      pub.update_manual_pub_from_pub_hash({ b: :c }, 'some other string', 'some where')
+      pub = Publication.build_new_manual_publication({ a: :b }, 'some string')
+      pub.update_manual_pub_from_pub_hash({ b: :c }, 'some other string')
       pub.save!
       expect(pub.user_submitted_source_records.first[:source_data]).to eq('some other string')
       expect(pub.pub_hash).to include(b: :c)
     end
 
-    it 'should raise an exception if you try to update the record to match an existing source record' do
-      pub = Publication.build_new_manual_publication({ a: :b }, 'some string', 'some where')
-      pub.save
-      pub = Publication.build_new_manual_publication({ b: :c }, 'some other string', 'some where')
-      pub.update_manual_pub_from_pub_hash({ b: :c }, 'some string', 'some where')
+    it 'should raise an exception if you try to update a record to match an existing source record' do
+      Publication.build_new_manual_publication({ a: :b }, 'some string').save!
+      pub = Publication.build_new_manual_publication({ b: :c }, 'some other string')
+      pub.update_manual_pub_from_pub_hash({ b: :c }, 'some string')
       expect { pub.save! }.to raise_error(ActiveRecord::RecordNotUnique)
     end
   end
@@ -369,7 +366,7 @@ describe Publication do
     it 'returns one Publication that has this doi' do
       publication.pub_hash = { identifier: [{ type: 'doi', id: '10.1016/j.mcn.2012.03.008', url: 'https://dx.doi.org/10.1016/j.mcn.2012.03.008' }] }
       publication.send(:sync_identifiers_in_pub_hash)
-      publication.save
+      publication.save!
       res = Publication.find_by_doi('10.1016/j.mcn.2012.03.008')
       expect(res.id).to eq(publication.id)
     end

--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -346,8 +346,9 @@ describe Publication do
   end
 
   describe 'update_manual_pub_from_pub_hash' do
+    let(:pub) { Publication.build_new_manual_publication({ a: :b }, 'some string') }
+
     it 'should update the user submitted source record with the new content' do
-      pub = Publication.build_new_manual_publication({ a: :b }, 'some string')
       pub.update_manual_pub_from_pub_hash({ b: :c }, 'some other string')
       pub.save!
       expect(pub.user_submitted_source_records.first[:source_data]).to eq('some other string')
@@ -355,10 +356,15 @@ describe Publication do
     end
 
     it 'should raise an exception if you try to update a record to match an existing source record' do
-      Publication.build_new_manual_publication({ a: :b }, 'some string').save!
-      pub = Publication.build_new_manual_publication({ b: :c }, 'some other string')
-      pub.update_manual_pub_from_pub_hash({ b: :c }, 'some string')
-      expect { pub.save! }.to raise_error(ActiveRecord::RecordNotUnique)
+      pub.save!
+      other = Publication.build_new_manual_publication({ b: :c }, 'some other string')
+      other.update_manual_pub_from_pub_hash({ b: :c }, 'some string')
+      expect { other.save! }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+
+    it 'does not alter the hash provided' do
+      h = { pub: 'hash' }
+      expect { pub.update_manual_pub_from_pub_hash(h, 'whatev') }.not_to change { h }
     end
   end
 


### PR DESCRIPTION
Split from #631 

This removed 3rd parameter is not part of the tests and subsequent changes will remove it from method sig.  This clears the way for that change to be minimal.  

Avoid munging Hash param in `update_manual_pub_from_pub_hash`, with test.