### PR TITLE
Avoid overwriting WOS records when targeted for "manual" update

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -218,6 +218,7 @@ RSpec/NamedSubject:
 RSpec/NestedGroups:
   Exclude:
     - 'spec/api/sul_bib/authorship_api_spec.rb'
+    - 'spec/api/sul_bib/publications_api_spec.rb'
     - 'spec/api/sul_bib/sourcelookup_spec.rb'
     - 'spec/lib/cap/authors_poller_spec.rb'
     - 'spec/lib/csl/citation_spec.rb'

--- a/app/api/sul_bib/publications_api.rb
+++ b/app/api/sul_bib/publications_api.rb
@@ -78,10 +78,9 @@ module SulBib
       # and a `428 Precondition Required` if the if-match header isn't supplied
       new_pub = params[:pub_hash].to_hash.deep_symbolize_keys # Avoid Hashie::Mash!
       old_pub = publication_find(params[:id])
-      case
-      when !old_pub.sciencewire_id.blank? || !old_pub.pmid.blank?
+      if old_pub.sciencewire_id.present? || old_pub.pmid.present? || old_pub.wos_uid.present?
         error!({ 'error' => 'This record may not be modified.  If you had originally entered details for the record, it has been superceded by a central record.', 'detail' => 'missing widget' }, 403)
-      when !validate_or_create_authors(new_pub[:authorship])
+      elsif !validate_or_create_authors(new_pub[:authorship])
         error!('You have not supplied a valid authorship record.', 406)
       end
 


### PR DESCRIPTION
This adds tests for the other record types also, which were lacking.

Reworked a `case` statement that had no thing being cased!

@darrenleeweber effectively approved this commit (back when it had a different pre-rebase hash) in https://github.com/sul-dlss/sul_pub/pull/631/commits/f1ea3a52f4a456b0047527b15ce79083db9b26e5#r162755918