### PR TITLE
Avoid collision between variable name and `retrieve_options` method

### DIFF
--- a/lib/web_of_science/queries.rb
+++ b/lib/web_of_science/queries.rb
@@ -36,9 +36,9 @@ module WebOfScience
     # @return [WebOfScience::Records]
     def cited_references(uid)
       return empty_records if uid.blank?
-      retrieve_options = [ { key: 'Hot', value: 'On' } ]
+      options = [ { key: 'Hot', value: 'On' } ]
       message = base_uid_params.merge(uid: uid,
-                                      retrieveParameters: retrieve_parameters(options: retrieve_options))
+                                      retrieveParameters: retrieve_parameters(options: options))
       retrieve_records(:cited_references, message)
     end
 


### PR DESCRIPTION
diff-coverage of 0% is useless to fail on, imo.