### PR TITLE
Remove unused 3rd argument from 2 manual-related methods in Publication

### DIFF
--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -75,18 +75,18 @@ class Publication < ActiveRecord::Base
   end
 
   # @return [Publication] new object, unsaved
-  def self.build_new_manual_publication(pub_hash, original_source_string, provenance = Settings.cap_provenance)
+  def self.build_new_manual_publication(pub_hash, original_source_string)
     existingRecord = UserSubmittedSourceRecord.find_or_initialize_by_source_data(original_source_string)
     if existingRecord && existingRecord.publication
       raise ActiveRecord::RecordNotUnique.new('Publication for user submitted source record already exists', nil)
     end
     Publication.new(active: true, pub_hash: pub_hash)
-               .update_manual_pub_from_pub_hash(pub_hash, original_source_string, provenance)
+               .update_manual_pub_from_pub_hash(pub_hash, original_source_string)
   end
 
   # @return [self]
-  def update_manual_pub_from_pub_hash(incoming_pub_hash, original_source_string, provenance = Settings.cap_provenance)
-    self.pub_hash = incoming_pub_hash.merge(provenance: provenance)
+  def update_manual_pub_from_pub_hash(incoming_pub_hash, original_source_string)
+    self.pub_hash = incoming_pub_hash.merge(provenance: Settings.cap_provenance)
     match = UserSubmittedSourceRecord.find_by_source_data(original_source_string)
     match.publication = self if match # we may still throw this out w/o saving
     r = user_submitted_source_records.first || match || user_submitted_source_records.build


### PR DESCRIPTION
We can tell the argument is never invoked because of:
```bash
$ git grep -e update_manual_pub_from_pub_hash -e build_new_manual_publication app/ lib/ |grep -v "^app/models/publication.rb"
app/api/sul_bib/publications_api.rb:        pub = Publication.build_new_manual_publication(pub_hash, original_source)
app/api/sul_bib/publications_api.rb:      old_pub.update_manual_pub_from_pub_hash(new_pub, original_source)
```
Previous discussion here:
https://github.com/sul-dlss/sul_pub/pull/631/commits/562cf2d99fb60c97d79c27e6877beae4d9d6c5ed

(Though that will probably disappear after rebase.)