### PR TITLE
Resolve FactoryBot.lint problem with pub_hash factory

### DIFF
--- a/spec/factories/pub_hash.rb
+++ b/spec/factories/pub_hash.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
-  factory :pub_hash do
+  factory :pub_hash, class: Hash do
+    skip_create
     initialize_with do
       new(provenance: 'sciencewire',
           pmid: '15572175',


### PR DESCRIPTION
- factory needs to explicitly identify `class: Hash`
- since there is no persistence, `skip_create`

Fixes #664