### PR TITLE
Rely on before_save callbacks instead of explicit calls

### DIFF
--- a/lib/cap/authors_poller.rb
+++ b/lib/cap/authors_poller.rb
@@ -173,16 +173,10 @@ module Cap
 
     def contribution_save(contribution)
       contribution.save
-      contribution_sync_to_pubhash(contribution)
+      contribution.publication.pubhash_needs_update!
+      contribution.publication.save
       logger.info "Updated #{contribution_id(contribution)}"
       @contribs_changed += 1
-    end
-
-    def contribution_sync_to_pubhash(contribution)
-      pub = contribution.publication
-      pub.set_last_updated_value_in_hash
-      pub.add_all_db_contributions_to_my_pub_hash
-      pub.save
     end
 
     private

--- a/script/delete_missing_auths.rb
+++ b/script/delete_missing_auths.rb
@@ -18,8 +18,7 @@ class DeleteMissingAuths
         pub.destroy
       else
         @logger.info "   Resynching pub #{pub_id}"
-        pub.set_last_updated_value_in_hash
-        pub.add_all_db_contributions_to_my_pub_hash
+        pub.pubhash_needs_update!
         pub.save
       end
     end


### PR DESCRIPTION
Publication's `before_save` already does:
```
sync_publication_hash_and_db if pubhash_needs_update?
```
which in turn calls `rebuild_authorship` that does exactly the same two things desired by these callers:
```
add_all_db_contributions_to_my_pub_hash
set_last_updated_value_in_hash
```