### PR TITLE
Harvester::Base - decrease the author batch size

### DIFF
--- a/lib/harvester/base.rb
+++ b/lib/harvester/base.rb
@@ -18,7 +18,7 @@ module Harvester
     private
 
       def batch_size
-        100
+        50
       end
   end
 end


### PR DESCRIPTION
Extracted from #644 - trivial change to decrease memory load on harvests - the WOS harvest is so slow that queues of larger batch sizes are just extra load on memory.

- diff-coverage seems absurd on this PR
