### PR TITLE
WebOfScience::ProcessRecord

### DIFF
--- a/lib/web_of_science/process_record.rb
+++ b/lib/web_of_science/process_record.rb
@@ -1,0 +1,110 @@
+module WebOfScience
+
+  # This class complements the WebOfScience::Harvester
+  class ProcessRecord
+    include WebOfScience::Contributions
+
+    # @param [Author] author
+    # @param [WebOfScience::Record] record
+    # @param [Hash] links identifiers for this record
+    def initialize(author, record, links = {})
+      raise(ArgumentError, 'author must be an Author') unless author.is_a? Author
+      @author = author
+      @record = check_record(record, links)
+    end
+
+    # @return [String, nil] WosUID when it results in a new Publication
+    def execute
+      process_record
+    rescue StandardError => err
+      message = "Author: #{author.id}, ProcessRecord failed #{record.uid}"
+      NotificationManager.error(err, message, self)
+      nil
+    end
+
+    private
+
+      attr_reader :author
+      attr_reader :record
+
+      # @param [WebOfScience::Record] record
+      # @param [Hash] links identifiers
+      # @return [WebOfScience::Record]
+      def check_record(record, links)
+        raise(ArgumentError, 'record must be an WebOfScience::Record') unless record.is_a? WebOfScience::Record
+        check_settings(record)
+        record.identifiers.update(links) if links.present?
+        record
+      end
+
+      # @param [WebOfScience::Record] record
+      # @return [void]
+      def check_settings(record)
+        raise 'Settings.WOS.ACCEPTED_DBS is empty' if Settings.WOS.ACCEPTED_DBS.empty?
+        raise "Settings.WOS.ACCEPTED_DBS rejected #{record.uid}" unless Settings.WOS.ACCEPTED_DBS.include?(record.database)
+      end
+
+      # Process a record retrieved by any means; this is a progressive filtering of the record to identify
+      # whether it should create a new Publication.pub_hash, PublicationIdentifier(s) and Contribution(s).
+      # @return [String, nil] WosUID that create a new Publication
+      def process_record
+        save_record # as WebOfScienceSourceRecord
+        return if found_contribution?
+        contrib_persisted = create_publication
+        pubmed_addition
+        record.uid if contrib_persisted
+      end
+
+      # Save a new WebOfScienceSourceRecord
+      # Note: add nothing to PublicationIdentifiers here, or found_contribution? could skip processing this record
+      def save_record
+        return unless WebOfScienceSourceRecord.find_by(uid: record.uid).nil?
+        attr = { source_data: record.to_xml }
+        attr[:doi] = record.doi if record.doi.present?
+        attr[:pmid] = record.pmid if record.pmid.present?
+        WebOfScienceSourceRecord.new(attr).save!
+      end
+
+      # Does record have a contribution for this author? (based on matching PublicationIdentifiers)
+      # Note: must use unique identifiers, don't use ISSN or similar series level identifiers
+      def found_contribution?
+        contribution_by_identifier?(author, 'WosUID', record.uid) ||
+          contribution_by_identifier?(author, 'WosItemID', record.wos_item_id) ||
+          contribution_by_identifier?(author, 'doi', record.doi) ||
+          contribution_by_identifier?(author, 'pmid', record.pmid)
+      end
+
+      # @return [Boolean] WebOfScience::Record created a new Publication?
+      def create_publication
+        pub = Publication.new(
+          active: true,
+          pub_hash: record.pub_hash,
+          wos_uid: record.uid
+        )
+        pub.save!
+        contrib = find_or_create_contribution(author, pub)
+        contrib.persisted?
+      rescue StandardError => err
+        message = "Author: #{author.id}, #{record.uid}; Publication or Contribution failed"
+        NotificationManager.error(err, message, self)
+        false
+      end
+
+      # For WOS-record that has a PMID, fetch data from PubMed and enhance the pub.pub_hash with PubMed data
+      # @return [void]
+      def pubmed_addition
+        return if record.pmid.blank?
+        pub = Publication.find_by(wos_uid: record.uid)
+        pub.pmid = record.pmid
+        pub.save
+        return if record.database == 'MEDLINE'
+        pubmed_record = PubmedSourceRecord.for_pmid(record.pmid)
+        pub.pub_hash.reverse_update(pubmed_record.source_as_hash)
+        pub.save
+      rescue StandardError => err
+        message = "Author: #{author.id}, #{record.uid}, PubmedSourceRecord failed, PMID: #{record.pmid}"
+        NotificationManager.error(err, message, self)
+      end
+
+  end
+end

--- a/spec/fixtures/pubmed/pubmed_record_21253920.xml
+++ b/spec/fixtures/pubmed/pubmed_record_21253920.xml
@@ -1,0 +1,137 @@
+<PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM">
+        <PMID Version="1">21253920</PMID>
+        <DateCompleted>
+            <Year>2011</Year>
+            <Month>08</Month>
+            <Day>01</Day>
+        </DateCompleted>
+        <DateRevised>
+            <Year>2011</Year>
+            <Month>03</Month>
+            <Day>22</Day>
+        </DateRevised>
+        <Article PubModel="Print-Electronic">
+            <Journal>
+                <ISSN IssnType="Electronic">1496-8975</ISSN>
+                <JournalIssue CitedMedium="Internet">
+                    <Volume>58</Volume>
+                    <Issue>4</Issue>
+                    <PubDate>
+                        <Year>2011</Year>
+                        <Month>Apr</Month>
+                    </PubDate>
+                </JournalIssue>
+                <Title>Canadian journal of anaesthesia = Journal canadien d'anesthesie</Title>
+                <ISOAbbreviation>Can J Anaesth</ISOAbbreviation>
+            </Journal>
+            <ArticleTitle>Kinked Perifix® FX Springwound epidural catheters.</ArticleTitle>
+            <Pagination>
+                <MedlinePgn>413-4</MedlinePgn>
+            </Pagination>
+            <ELocationID EIdType="doi" ValidYN="Y">10.1007/s12630-011-9462-1</ELocationID>
+            <AuthorList CompleteYN="Y">
+                <Author ValidYN="Y">
+                    <LastName>Hilton</LastName>
+                    <ForeName>Gillian</ForeName>
+                    <Initials>G</Initials>
+                </Author>
+                <Author ValidYN="Y">
+                    <LastName>Jette</LastName>
+                    <ForeName>Christine G</ForeName>
+                    <Initials>CG</Initials>
+                </Author>
+                <Author ValidYN="Y">
+                    <LastName>Ouyang</LastName>
+                    <ForeName>Yi-Bing</ForeName>
+                    <Initials>YB</Initials>
+                </Author>
+                <Author ValidYN="Y">
+                    <LastName>Riley</LastName>
+                    <ForeName>Edward T</ForeName>
+                    <Initials>ET</Initials>
+                </Author>
+            </AuthorList>
+            <Language>eng</Language>
+            <PublicationTypeList>
+                <PublicationType UI="D016422">Letter</PublicationType>
+                <PublicationType UI="D013485">Research Support, Non-U.S. Gov't</PublicationType>
+            </PublicationTypeList>
+            <ArticleDate DateType="Electronic">
+                <Year>2011</Year>
+                <Month>01</Month>
+                <Day>21</Day>
+            </ArticleDate>
+        </Article>
+        <MedlineJournalInfo>
+            <Country>United States</Country>
+            <MedlineTA>Can J Anaesth</MedlineTA>
+            <NlmUniqueID>8701709</NlmUniqueID>
+            <ISSNLinking>0832-610X</ISSNLinking>
+        </MedlineJournalInfo>
+        <CitationSubset>IM</CitationSubset>
+        <MeshHeadingList>
+            <MeshHeading>
+                <DescriptorName UI="D000767" MajorTopicYN="N">Anesthesia, Epidural</DescriptorName>
+                <QualifierName UI="Q000295" MajorTopicYN="Y">instrumentation</QualifierName>
+            </MeshHeading>
+            <MeshHeading>
+                <DescriptorName UI="D000773" MajorTopicYN="N">Anesthesia, Obstetrical</DescriptorName>
+                <QualifierName UI="Q000295" MajorTopicYN="Y">instrumentation</QualifierName>
+            </MeshHeading>
+            <MeshHeading>
+                <DescriptorName UI="D002404" MajorTopicYN="N">Catheterization</DescriptorName>
+                <QualifierName UI="Q000295" MajorTopicYN="Y">instrumentation</QualifierName>
+            </MeshHeading>
+            <MeshHeading>
+                <DescriptorName UI="D005260" MajorTopicYN="N">Female</DescriptorName>
+            </MeshHeading>
+            <MeshHeading>
+                <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+            </MeshHeading>
+            <MeshHeading>
+                <DescriptorName UI="D011247" MajorTopicYN="N">Pregnancy</DescriptorName>
+            </MeshHeading>
+        </MeshHeadingList>
+    </MedlineCitation>
+    <PubmedData>
+        <History>
+            <PubMedPubDate PubStatus="received">
+                <Year>2010</Year>
+                <Month>12</Month>
+                <Day>09</Day>
+            </PubMedPubDate>
+            <PubMedPubDate PubStatus="accepted">
+                <Year>2011</Year>
+                <Month>01</Month>
+                <Day>10</Day>
+            </PubMedPubDate>
+            <PubMedPubDate PubStatus="entrez">
+                <Year>2011</Year>
+                <Month>1</Month>
+                <Day>22</Day>
+                <Hour>6</Hour>
+                <Minute>0</Minute>
+            </PubMedPubDate>
+            <PubMedPubDate PubStatus="pubmed">
+                <Year>2011</Year>
+                <Month>1</Month>
+                <Day>22</Day>
+                <Hour>6</Hour>
+                <Minute>0</Minute>
+            </PubMedPubDate>
+            <PubMedPubDate PubStatus="medline">
+                <Year>2011</Year>
+                <Month>8</Month>
+                <Day>2</Day>
+                <Hour>6</Hour>
+                <Minute>0</Minute>
+            </PubMedPubDate>
+        </History>
+        <PublicationStatus>ppublish</PublicationStatus>
+        <ArticleIdList>
+            <ArticleId IdType="pubmed">21253920</ArticleId>
+            <ArticleId IdType="doi">10.1007/s12630-011-9462-1</ArticleId>
+        </ArticleIdList>
+    </PubmedData>
+</PubmedArticle>

--- a/spec/lib/web_of_science/process_record_spec.rb
+++ b/spec/lib/web_of_science/process_record_spec.rb
@@ -1,0 +1,206 @@
+describe WebOfScience::ProcessRecord, :vcr do
+  let(:author) do
+    # public data from
+    # - https://stanfordwho.stanford.edu
+    # - https://med.stanford.edu/profiles/russ-altman
+    author = FactoryBot.create(:author,
+                                 preferred_first_name: 'Russ',
+                                 preferred_last_name: 'Altman',
+                                 preferred_middle_name: 'Biagio',
+                                 email: 'Russ.Altman@stanford.edu',
+                                 cap_import_enabled: true)
+    # create some `author.alternative_identities`
+    FactoryBot.create(:author_identity,
+                       author: author,
+                       first_name: 'R',
+                       middle_name: 'B',
+                       last_name: 'Altman',
+                       email: nil,
+                       institution: 'Stanford University')
+    FactoryBot.create(:author_identity,
+                       author: author,
+                       first_name: 'Russ',
+                       middle_name: nil,
+                       last_name: 'Altman',
+                       email: nil,
+                       institution: nil)
+    author
+  end
+
+  before do
+    null_logger = Logger.new('/dev/null')
+    allow(WebOfScience).to receive(:logger).and_return(null_logger)
+  end
+
+  shared_examples '#execute' do
+    # ---
+    # Happy paths
+
+    it 'returns a String' do
+      expect(processor.execute).to be_a String
+    end
+    it 'returns a WosUID on success' do
+      uid = processor.execute
+      expect(uid).to eq(record.uid)
+    end
+    it 'creates new WebOfScienceSourceRecords' do
+      expect { processor.execute }.to change { WebOfScienceSourceRecord.count }
+    end
+
+    it 'creates new Publications' do
+      expect { processor.execute }.to change { Publication.count }
+    end
+    it 'creates Publications with WOS attributes' do
+      processor.execute
+      pub = Publication.find_by(wos_uid: record.uid)
+      expect(pub).not_to be_nil
+      expect(pub.pub_hash[:provenance]).to eq Settings.wos_source
+    end
+
+    it 'creates new PublicationIdentifiers' do
+      expect { processor.execute }.to change { PublicationIdentifier.count }
+    end
+
+    it 'creates new Contributions' do
+      expect { processor.execute }.to change { Contribution.count }
+    end
+    it 'creates new contribution in the pub_hash[:authorship]' do
+      processor.execute
+      pub = Publication.find_by(wos_uid: record.uid)
+      expect(pub.pub_hash).to include(:authorship)
+    end
+
+    # ---
+    # Unhappy paths
+
+    it 'raises ArgumentError for author' do
+      expect { described_class.new('author', record) }.to raise_error(ArgumentError)
+    end
+    it 'raises ArgumentError for record' do
+      expect { described_class.new(author, 'xml-stuff') }.to raise_error(ArgumentError)
+    end
+    it 'raises RuntimeError when Settings.WOS.ACCEPTED_DBS.empty?' do
+      wos = Settings.WOS
+      allow(wos).to receive(:ACCEPTED_DBS).and_return([])
+      allow(Settings).to receive(:WOS).and_return(wos)
+      expect { described_class.new(author, record) }.to raise_error(RuntimeError)
+    end
+
+    context 'save_record fails' do
+      before do
+        allow(processor).to receive(:save_record).and_raise(RuntimeError)
+      end
+
+      it 'does not create new WebOfScienceSourceRecords' do
+        expect { processor.execute }.not_to change { WebOfScienceSourceRecord.count }
+      end
+      it 'logs errors' do
+        expect(NotificationManager).to receive(:error)
+        processor.execute
+      end
+      it 'returns nil' do
+        expect(processor.execute).to be_nil
+      end
+    end
+
+    context 'create_publication fails' do
+      before do
+        allow(Publication).to receive(:new).and_raise(ActiveRecord::RecordInvalid)
+      end
+
+      it 'does not create new Publications' do
+        expect { processor.execute }.not_to change { Publication.count }
+      end
+      it 'does not create new Contributions' do
+        expect { processor.execute }.not_to change { Contribution.count }
+      end
+      it 'logs errors' do
+        expect(NotificationManager).to receive(:error).at_least(:once)
+        processor.execute
+      end
+      it 'returns nil' do
+        expect(processor.execute).to be_nil
+      end
+    end
+  end
+
+  # ---
+  # MESH headings - integration specs
+  # Note: not all PubMed/MEDLINE records contain MESH headings, so the
+  # spec example record was chosen to contain or fetch MESH headings
+
+  shared_examples 'pubs_with_pmid_have_mesh_headings' do
+    # The specs calling this must use a record with a PMID
+    # - any MEDLINE record has a PMID
+    # - for WOS records, they may not have PMID, but they could get one from the links service in the processing
+    it 'persists PMID and publication.pub_hash has MESH headings' do
+      processor.execute
+      pub = Publication.find_by(wos_uid: record.uid)
+      expect(pub.pmid).to be_an Integer
+      expect(pub.pub_hash).to include(:mesh_headings)
+    end
+  end
+
+  context 'with MEDLINE record' do
+    subject(:processor) { described_class.new(author, record, links) }
+
+    # Note: "MEDLINE:26776186" has a PMID and MESH headings
+    let(:record_uid) { 'MEDLINE:26776186' }
+    let(:record_xml) { File.read('spec/fixtures/wos_client/medline_record_26776186.xml') }
+    let(:record) { WebOfScience::Record.new(record: record_xml) }
+    let(:links) { {} } # medline records are not submitted to the links-API
+
+    it_behaves_like '#execute'
+    it_behaves_like 'pubs_with_pmid_have_mesh_headings'
+  end
+
+  context 'with WOS record' do
+    subject(:processor) { described_class.new(author, record, links) }
+
+    # Note: "WOS:000288663100014" has a PMID and it gets MESH headings from PubMed
+    let(:pmid) { '21253920' }
+    let(:pubmed_xml) { File.read("spec/fixtures/pubmed/pubmed_record_#{pmid}.xml") }
+    let(:record_uid) { 'WOS:000288663100014' }
+    let(:record_xml) { File.read('spec/fixtures/wos_client/wos_record_000288663100014.xml') }
+    let(:record) { WebOfScience::Record.new(record: record_xml) }
+    let(:links) { { 'pmid' => pmid, 'doi' => '10.1007/s12630-011-9462-1' } }
+
+    before do
+      pub_doc = Nokogiri::XML(pubmed_xml)
+      PubmedSourceRecord.create_pubmed_source_record(pmid, pub_doc)
+    end
+
+    it_behaves_like '#execute'
+    it_behaves_like 'pubs_with_pmid_have_mesh_headings'
+
+    context 'PubMed integration fails' do
+      # only WOS records can be supplemented by PubMed data
+      # any failure is not catastrophic - just log it
+      before do
+        allow(PubmedSourceRecord).to receive(:for_pmid).and_raise(RuntimeError)
+      end
+
+      it 'continues to create new Publications' do
+        expect { processor.execute }.to change { Publication.count }
+      end
+      it 'logs errors' do
+        expect(NotificationManager).to receive(:error)
+        processor.execute
+      end
+    end
+  end
+
+  context 'with record from excluded databases' do
+    subject(:processor) { described_class.new(author, record) }
+
+    let(:record_xml) do
+      xml = File.read('spec/fixtures/wos_client/wos_record_000288663100014.xml')
+      xml.gsub('WOS', 'EXCLUDED')
+    end
+    let(:record) { WebOfScience::Record.new(record: record_xml) }
+
+    it 'raises RuntimeError' do
+      expect { processor.execute }.to raise_error(RuntimeError)
+    end
+  end
+end


### PR DESCRIPTION
Connected to #639, #673 

This class could be used by anything that needs to process only one WOS-record, e.g. an API request for one record or a background jobs process for async processing.

This opens up some follow-on possibilities.  This class could be used inside the WOS-process-records class (but, if so, it might forgo some enumerator optimizations there; not sure).  This class could be attached directly to the WOS-record class as in `WebOfScience::Record#process` or something.
