### PR TITLE
DoiSearch against WOS

### DIFF
--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -53,11 +53,11 @@ class PublicationsController < ApplicationController
     if params[:doi]
       msg << "doi #{params[:doi]}"
       logger.info(msg)
-      all_matching_records += DoiSearch.search(params[:doi])
+      all_matching_records += DoiSearch.search(params[:doi].strip)
     elsif params[:pmid]
       msg << "pmid #{params[:pmid]}"
       logger.info(msg)
-      all_matching_records += PubmedHarvester.search_all_sources_by_pmid(params[:pmid])
+      all_matching_records += PubmedHarvester.search_all_sources_by_pmid(params[:pmid].strip)
     else
       raise ActionController::ParameterMissing, :title unless params[:title].presence
       msg << "title '#{params[:title]}'"

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -204,9 +204,6 @@ class Publication < ActiveRecord::Base
   ##
   #  Pubhash accessors
   ##
-  def title
-    pub_hash[:title]
-  end
 
   def issn
     pub_hash[:issn]
@@ -220,6 +217,12 @@ class Publication < ActiveRecord::Base
     pub_hash[:type]
   end
 
+  # @note obscures ActiveRecord field/attribute getter for title
+  def title
+    pub_hash[:title]
+  end
+
+  # @note obscures ActiveRecord field/attribute getter for year
   def year
     pub_hash[:year]
   end

--- a/fixtures/vcr_cassettes/DoiSearch/_search/ScienceWire_enabled_WOS_disabled/behaves_like_sciencewire_one_hit/returns_Array_of_one_document_Hash_.yml
+++ b/fixtures/vcr_cassettes/DoiSearch/_search/ScienceWire_enabled_WOS_disabled/behaves_like_sciencewire_one_hit/returns_Array_of_one_document_Hash_.yml
@@ -28,13 +28,13 @@ http_interactions:
             </ScienceWireQueryXMLParameter>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Accept:
       - "*/*"
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Tue, 14 Nov 2017 01:21:28 GMT
+      - Fri, 26 Jan 2018 03:47:21 GMT
       Licenseid:
       - Settings.SCIENCEWIRE.LICENSE_ID
       Host:
@@ -63,7 +63,7 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       Date:
-      - Tue, 14 Nov 2017 01:37:39 GMT
+      - Fri, 26 Jan 2018 03:47:20 GMT
       Content-Length:
       - '278'
     body:
@@ -72,7 +72,7 @@ http_interactions:
         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\r\n  <queryID>142612</queryID>\r\n
         \ <queryResultRows>1</queryResultRows>\r\n  <totalRows>1</totalRows>\r\n</ScienceWireQueryIDResponse>"
     http_version: 
-  recorded_at: Tue, 14 Nov 2017 01:21:29 GMT
+  recorded_at: Fri, 26 Jan 2018 03:47:21 GMT
 - request:
     method: get
     uri: https://sciencewirerest.discoverylogic.com/PublicationCatalog/PublicationQuery/142612?format=xml&page=0&pageSize=1&v=version/4
@@ -81,13 +81,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Accept:
       - "*/*"
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Tue, 14 Nov 2017 01:21:29 GMT
+      - Fri, 26 Jan 2018 03:47:21 GMT
       Licenseid:
       - Settings.SCIENCEWIRE.LICENSE_ID
       Host:
@@ -116,7 +116,7 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       Date:
-      - Tue, 14 Nov 2017 01:37:39 GMT
+      - Fri, 26 Jan 2018 03:47:22 GMT
       Content-Length:
       - '4108'
     body:
@@ -171,5 +171,5 @@ http_interactions:
         \   <CopyrightStateProvince>CA</CopyrightStateProvince>\r\n    <CopyrightCountry>UNITED
         STATES</CopyrightCountry>\r\n  </PublicationItem>\r\n</ArrayOfPublicationItem>"
     http_version: 
-  recorded_at: Tue, 14 Nov 2017 01:21:29 GMT
-recorded_with: VCR 3.0.1
+  recorded_at: Fri, 26 Jan 2018 03:47:22 GMT
+recorded_with: VCR 4.0.0

--- a/fixtures/vcr_cassettes/DoiSearch/_search/ScienceWire_enabled_WOS_disabled/queries_sciencewire_if_the_local_pub_match_is_not_DOI-reliable.yml
+++ b/fixtures/vcr_cassettes/DoiSearch/_search/ScienceWire_enabled_WOS_disabled/queries_sciencewire_if_the_local_pub_match_is_not_DOI-reliable.yml
@@ -1,0 +1,175 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://sciencewirerest.discoverylogic.com/PublicationCatalog/PublicationQuery?format=xml
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0"?>
+            <ScienceWireQueryXMLParameter xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+            <xmlQuery>      <![CDATA[
+              <query xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                  <Criterion>
+                      <Criteria>
+                          <Criterion>
+                              <Filter>
+                                  <Column>DOI</Column>
+                                  <Operator>Equals</Operator>
+                                  <Value>10.1016/j.mcn.2012.03.007</Value>
+                              </Filter>
+                          </Criterion>
+                      </Criteria>
+                  </Criterion>
+                  <MaximumRows>200</MaximumRows>
+              </query>
+              ]]>
+        </xmlQuery>
+            </ScienceWireQueryXMLParameter>
+    headers:
+      User-Agent:
+      - Faraday v0.14.0
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 26 Jan 2018 03:47:20 GMT
+      Licenseid:
+      - Settings.SCIENCEWIRE.LICENSE_ID
+      Host:
+      - Settings.SCIENCEWIRE.HOST
+      Connection:
+      - Keep-Alive
+      Expect:
+      - 100-continue
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/xml; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Aspnetmvc-Version:
+      - '2.0'
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Fri, 26 Jan 2018 03:47:20 GMT
+      Content-Length:
+      - '278'
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\"?>\r\n<ScienceWireQueryIDResponse xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
+        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\r\n  <queryID>142612</queryID>\r\n
+        \ <queryResultRows>1</queryResultRows>\r\n  <totalRows>1</totalRows>\r\n</ScienceWireQueryIDResponse>"
+    http_version: 
+  recorded_at: Fri, 26 Jan 2018 03:47:20 GMT
+- request:
+    method: get
+    uri: https://sciencewirerest.discoverylogic.com/PublicationCatalog/PublicationQuery/142612?format=xml&page=0&pageSize=1&v=version/4
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.14.0
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 26 Jan 2018 03:47:20 GMT
+      Licenseid:
+      - Settings.SCIENCEWIRE.LICENSE_ID
+      Host:
+      - Settings.SCIENCEWIRE.HOST
+      Connection:
+      - Keep-Alive
+      Expect:
+      - 100-continue
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/xml; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Aspnetmvc-Version:
+      - '2.0'
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Fri, 26 Jan 2018 03:47:20 GMT
+      Content-Length:
+      - '4108'
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\"?>\r\n<ArrayOfPublicationItem xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
+        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\r\n  <PublicationItem>\r\n
+        \   <PublicationItemID>60813767</PublicationItemID>\r\n    <Title>The T3-induced
+        gene KLF9 regulates oligodendrocyte differentiation and myelin regeneration</Title>\r\n
+        \   <Abstract>Hypothyroidism is a well-described cause of hypomyelination.
+        In addition, thyroid hormone (T3) has recently been shown to enhance remyelination
+        in various animal models of CNS demyelination. What are the ways in which
+        T3 promotes the development and regeneration of healthy myelin? To begin to
+        understand the mechanisms by which 13 drives myelination, we have identified
+        genes regulated specifically by T3 in purified oligodendrocyte precursor cells
+        (OPCs). Among the genes identified by genomic expression analyses were four
+        transcription factors, Kruppel-like factor 9 (KLF9), basic helix-loop-helix
+        family member e22 (BHLHe22), Hairless (Hr), and Albumin D box-binding protein
+        (DBP), all of which were induced in OPCs by both brief and long term exposure
+        to T3. To begin to investigate the role of these genes in myelination, we
+        focused on the most rapidly and robustly induced of these, KLF9, and found
+        it is both necessary and sufficient to promote oligodendrocyte differentiation
+        in vitro. Surprisingly, we found that loss of KLF9 in vivo negligibly affects
+        the formation of CNS myelin during development, but does significantly delay
+        remyelination in cuprizone-induced demyelinated lesions. These experiments
+        indicate that KLF9 is likely a novel integral component of the T3-driven signaling
+        cascade that promotes the regeneration of lost myelin. Future analyses of
+        the roles of KLF9 and other identified T3-induced genes in myelination may
+        lead to novel insights into how to enhance the regeneration of myelin in demyelinating
+        diseases such as multiple sclerosis. (c) 2012 Elsevier Inc. All rights reserved.</Abstract>\r\n
+        \   <AuthorList>Dugas,Jason,C|Ibrahim,Adiljan,|Barres,Ben,A</AuthorList>\r\n
+        \   <AuthorCount>3</AuthorCount>\r\n    <KeywordList>IN-VIVO|CONGENITAL HYPOTHYROIDISM|THYROID-HORMONE
+        ACTION|CENTRAL-NERVOUS-SYSTEM|ELEMENT-BINDING PROTEIN-1|MAGNETIC-RESONANCE
+        SPECTROSCOPY|RAT-BRAIN|EXPERIMENTAL HYPOTHYROIDISM|SPINAL-CORD DEMYELINATION|KRUPPEL-LIKE
+        FACTOR-9|OLIGODENDROCYTE|MYELIN|thyroid hormone|cuprizone|Klf9|BTEB1</KeywordList>\r\n
+        \   <DocumentTypeList>Article</DocumentTypeList>\r\n    <DocumentCategory>Journal
+        Document</DocumentCategory>\r\n    <NumberOfReferences>61</NumberOfReferences>\r\n
+        \   <TimesCited>43</TimesCited>\r\n    <TimesNotSelfCited>43</TimesNotSelfCited>\r\n
+        \   <PMID>22472204</PMID>\r\n    <WoSItemID>000305547700005</WoSItemID>\r\n
+        \   <PublicationSourceTitle>MOLECULAR AND CELLULAR NEUROSCIENCE</PublicationSourceTitle>\r\n
+        \   <Volume>50</Volume>\r\n    <Issue>1</Issue>\r\n    <Pagination>45-57</Pagination>\r\n
+        \   <PublicationDate>2012-05-01T00:00:00</PublicationDate>\r\n    <PublicationYear>2012</PublicationYear>\r\n
+        \   <PublicationType>Journal</PublicationType>\r\n    <PublicationSubjectCategoryList>Neurosciences</PublicationSubjectCategoryList>\r\n
+        \   <ISSN>1044-7431</ISSN>\r\n    <DOI>10.1016/j.mcn.2012.03.007</DOI>\r\n
+        \   <ConferenceStartDate xsi:nil=\"true\" />\r\n    <ConferenceEndDate xsi:nil=\"true\"
+        />\r\n    <Rank xsi:nil=\"true\" />\r\n    <OrdinalRank>0</OrdinalRank>\r\n
+        \   <NormalizedRank xsi:nil=\"true\" />\r\n    <NewPublicationItemID xsi:nil=\"true\"
+        />\r\n    <IsObsolete>false</IsObsolete>\r\n    <CopyrightPublisher>ACADEMIC
+        PRESS INC ELSEVIER SCIENCE</CopyrightPublisher>\r\n    <CopyrightCity>SAN
+        DIEGO</CopyrightCity>\r\n    <PublicationImpactFactorList>3.837,2012,ExactPublicationYear|3.734,2013,MostRecentYear</PublicationImpactFactorList>\r\n
+        \   <PublicationCategoryRankingList>74/252;NEUROSCIENCES;2012;SC;ExactPublicationYear|82/252;NEUROSCIENCES;2013;SC;MostRecentYear</PublicationCategoryRankingList>\r\n
+        \   <AuthorCitationCountList>1,0,43|2,0,43|3,0,43</AuthorCitationCountList>\r\n
+        \   <CopyrightStateProvince>CA</CopyrightStateProvince>\r\n    <CopyrightCountry>UNITED
+        STATES</CopyrightCountry>\r\n  </PublicationItem>\r\n</ArrayOfPublicationItem>"
+    http_version: 
+  recorded_at: Fri, 26 Jan 2018 03:47:21 GMT
+recorded_with: VCR 4.0.0

--- a/lib/doi_search.rb
+++ b/lib/doi_search.rb
@@ -1,15 +1,53 @@
 class DoiSearch
+  # The first authoritative result(s) are returned.
+  # If an authoritative local match is found, no remote services are hit.
+  # WoS hits need to be post-processed because the API does partial string
+  # matching for DOI queries, unfortunately.
+  # @param [String] doi
+  # @return [Array<Hash>] matching hashes
   def self.search(doi)
-    results = [Publication.find_by_doi(doi)].compact
-    results += ScienceWireClient.new.get_pub_by_doi(doi) if results.none?(&:authoritative_doi_source?)
-    results.reject! { |pub| non_sw_pub pub } if results.size > 1
+    pub = Publication.find_by_doi(doi)
+    return [pub.pub_hash] if pub && pub.authoritative_doi_source?
+    if Settings.SCIENCEWIRE.enabled
+      sw_hits = ScienceWireClient.new.get_pub_by_doi(doi)
+      return sw_hits unless sw_hits.empty?
+    end
+    results = []
+    if Settings.WOS.enabled
+      results += WebOfScience.queries.search_by_doi(doi).map { |rec| add_citation(rec.pub_hash) }
+      full_match = normalized_dois(results)[normalized_doi(doi)]
+      return [full_match] if full_match
+    end
+    # Everything else is non-authoritative
+    results.unshift(pub.pub_hash) if pub
     results
   end
 
-  # @return [Boolean] true if the pub is not from sciencewire
-  def self.non_sw_pub(pub)
-    return false if pub.is_a? Hash # Hashes are returned from the SW only query
-    !pub.authoritative_doi_source?
+  # @param [Hash] pub_hash modifies passed hash to include citation k/v pairs
+  # @return [Hash] the same modified hash
+  def self.add_citation(pub_hash)
+    cite = Csl::Citation.new(pub_hash)
+    pub_hash[:apa_citation] ||= cite.to_apa_citation
+    pub_hash[:mla_citation] ||= cite.to_mla_citation
+    pub_hash[:chicago_citation] ||= cite.to_chicago_citation
+    pub_hash
   end
-  private_class_method :non_sw_pub
+  private_class_method :add_citation
+
+  # @param [Array<Hash>] pub_hashes WOS pub_hashes
+  # @return [Hash<String => Hash>] normalized DOI strings mapped to pub_hashes
+  # pub_hash[:identifier].select{|h| h[:type] == 'doi'}}}
+  # [{:type=>"doi", :id=>"10.1172/jci.insight.87623", :url=>"https://dx.doi.org/10.1172/jci.insight.87623"}]
+  def self.normalized_dois(pub_hashes)
+    Hash[pub_hashes.map { |h| normalized_doi(h[:doi]) }.zip(pub_hashes)]
+      .select { |k| k } # exclude nil key(s) (normalization fail)
+  end
+  private_class_method :normalized_dois
+
+  # @param [String, nil] doi
+  # @return [String, nil] normalized DOI string
+  def self.normalized_doi(doi)
+    Identifiers::DOI.extract(doi).first
+  end
+  private_class_method :normalized_doi
 end

--- a/spec/lib/doi_search_spec.rb
+++ b/spec/lib/doi_search_spec.rb
@@ -1,36 +1,100 @@
-
 describe DoiSearch do
+  let(:other_doi) { '10.1038/psp.2013.66' }
   let(:doi_value) { '10.1016/j.mcn.2012.03.007' }
-  let(:doi_identifier) do
-    FactoryBot.create(:publication_identifier,
-                       identifier_type: 'doi',
-                       identifier_value: doi_value,
-                       identifier_uri: "http://dx.doi.org/#{doi_value}")
-  end
+  let(:doi_identifier) { create(:doi_pub_id, identifier_value: doi_value) }
+  let(:wos_html) { File.read('spec/fixtures/wos_client/medline_encoded_records.html') }
+  let(:wos_records) { WebOfScience::Records.new(encoded_records: wos_html) }
 
   before(:each) do
     doi_identifier.publication.save
+    allow(Settings.SCIENCEWIRE).to receive(:enabled).and_return(false) # default
+    allow(Settings.WOS).to receive(:enabled).and_return(false) # default
   end
 
   describe '.search' do
-    it 'returns one document ' do
-      VCR.use_cassette('doi_search_spec_one_doc') do
-        result = DoiSearch.search doi_value
+    subject(:result) { described_class.search(doi_value) }
 
-        expect(result.size).to eq 1
-        expect(result.first[:sw_id]).to eq '60813767'
+    shared_examples 'sciencewire one hit' do
+      it 'returns Array of one document (Hash)' do
+        expect(result).to match [a_hash_including(sw_id: '60813767', provenance: 'sciencewire')]
       end
     end
 
-    it 'queries sciencewire if the locally found pub is non-sciencewire' do
-      VCR.use_cassette('doi_search_manual_doi_local') do
-        doi_identifier.publication.pub_hash.update(provenance: 'cap')
-        doi_identifier.publication.save
-        expect(ScienceWireClient).to receive(:new).and_call_original
-        result = DoiSearch.search doi_value
-        expect(result.size).to eq 1
-        expect(result.first[:provenance]).to eq 'sciencewire'
+    context 'ScienceWire and WOS both disabled' do
+      it 'only searches locally, returning Array of one Publication' do
+        expect(ScienceWireClient).not_to receive(:new)
+        expect(WebOfScience).not_to receive(:queries)
+        expect(described_class.search(doi_value)).to eq([doi_identifier.publication.pub_hash])
       end
+    end
+
+    context 'ScienceWire enabled, WOS disabled', :vcr do
+      before { allow(Settings.SCIENCEWIRE).to receive(:enabled).and_return(true) }
+
+      VCR.use_cassette('doi_search_spec_one_doc') do
+        it_behaves_like 'sciencewire one hit'
+        it 'queries sciencewire if the local pub match is not DOI-reliable' do
+          doi_identifier.publication.pub_hash[:provenance] = 'cap'
+          doi_identifier.publication.save!
+          expect(ScienceWireClient).to receive(:new).and_call_original
+          expect(result.size).to eq 1
+          expect(result.first[:provenance]).to eq 'sciencewire'
+        end
+      end
+    end
+
+    context 'ScienceWire disabled, WOS enabled' do
+      before do
+        allow(Settings.WOS).to receive(:enabled).and_return(true)
+        expect(ScienceWireClient).not_to receive(:new)
+      end
+
+      context 'local hit found' do
+        let(:publication) { doi_identifier.publication }
+        before { expect(Publication).to receive(:find_by_doi).with(doi_value).and_return(publication) }
+
+        it 'never queries WOS, if authoritative' do
+          allow(publication).to receive(:wos_pub?).and_return(true)
+          expect(WebOfScience).not_to receive(:queries)
+          described_class.search(doi_value)
+        end
+        it 'queries WOS, if not authoritative' do
+          allow(publication).to receive(:wos_pub?).and_return(false)
+          expect(WebOfScience.queries).to receive(:search_by_doi).with(doi_value).and_return([])
+          described_class.search(doi_value)
+        end
+      end
+
+      it 'without a local hit, queries WOS' do
+        expect(WebOfScience.queries).to receive(:search_by_doi).with(other_doi).and_return([])
+        expect(described_class.search(other_doi)).to eq []
+      end
+    end
+  end
+
+  # private methods
+
+  describe '.normalized_doi' do
+    it 'does not alter conventional DOIs' do
+      expect(described_class.send(:normalized_doi, doi_value)).to eq doi_value
+    end
+    it 'returns nil for invalid DOIs' do
+      expect(described_class.send(:normalized_doi, '10.1038/')).to be_nil
+      expect(described_class.send(:normalized_doi, '')).to be_nil
+      expect(described_class.send(:normalized_doi, nil)).to be_nil
+    end
+    it 'returns normalized DOI for full URI' do
+      expect(described_class.send(:normalized_doi, 'http://dx.doi.org/10.1038/ncomms3199')).to eq '10.1038/ncomms3199'
+    end
+  end
+
+  describe '.normalized_dois' do
+    subject(:result) { described_class.send(:normalized_dois, wos_records.map(&:pub_hash)) }
+
+    it 'returns a hash with only authoritative DOI keys mapped to hashes' do
+      expect(wos_records.count).to eq 5 # the fixture has many records
+      expect(result.count).to eq 1
+      expect(result).to match a_hash_including(other_doi => a_hash_including(doi: other_doi))
     end
   end
 end


### PR DESCRIPTION
- honors configs
- for wos, ensures FULL doi string match returned if available

I don't care about "cognitive complexity" for this method at the moment.  The two things I anticipate doing to resolve that are:

1. Eventually ripping out the ScienceWire code, obviously
2. Moving the DOI full match stuff deeper into the stack, e.g. WOS `Queries`

Given the decent test coverage and temporary nature, I'm willing to punt on the CoCliCogCom, for now.