### PR TITLE
Pubmed from WOS

### DIFF
--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -240,7 +240,7 @@ class Publication < ActiveRecord::Base
   end
 
   def authoritative_pmid_source?
-    pubmed_pub? || sciencewire_pub?
+    pubmed_pub? || sciencewire_pub? || wos_pub?
   end
 
   def authoritative_doi_source?

--- a/app/models/pubmed_source_record.rb
+++ b/app/models/pubmed_source_record.rb
@@ -98,9 +98,11 @@ class PubmedSourceRecord < ActiveRecord::Base
     mesh_headings_for_record
   end
 
+  # Convert MEDLINE®PubMed® XML to pub_hash
+  # @param [Nokogiri::XML::Node] publication
+  # @return [Hash<Symbol => Object>] pub_hash
+  # @see https://www.nlm.nih.gov/bsd/licensee/elements_descriptions.html XML Element Descriptions and their Attributes
   def convert_pubmed_publication_doc_to_hash(publication)
-    # MEDLINE®PubMed® XML Element Descriptions and their Attributes, see
-    # https://www.nlm.nih.gov/bsd/licensee/elements_descriptions.html
     record_as_hash = {}
     pmid = publication.xpath('MedlineCitation/PMID').text
 
@@ -146,7 +148,7 @@ class PubmedSourceRecord < ActiveRecord::Base
     journal_hash[:volume] = publication.xpath('MedlineCitation/Article/Journal/JournalIssue/Volume').text unless publication.xpath('MedlineCitation/Article/Journal/JournalIssue/Volume').blank?
     journal_hash[:issue] = publication.xpath('MedlineCitation/Article/Journal/JournalIssue/Issue').text unless publication.xpath('MedlineCitation/Article/Journal/JournalIssue/Issue').blank?
     # journal_hash[:articlenumber] = publication.xpath('ArticleNumber') unless publication.xpath('ArticleNumber').blank?
-    #  journal_hash[:pages] = publication.xpath('Pagination').text unless publication.xpath('Pagination').blank?
+    # journal_hash[:pages] = publication.xpath('Pagination').text unless publication.xpath('Pagination').blank?
     journal_identifiers = []
     issn = publication.xpath('MedlineCitation/Article/Journal/ISSN').text
     record_as_hash[:issn] = issn unless issn.blank?

--- a/fixtures/vcr_cassettes/PubmedHarvester/_fetch_remote_pubmed/WOS_and_ScienceWire_both_disabled/searches_only_pubmed.yml
+++ b/fixtures/vcr_cassettes/PubmedHarvester/_fetch_remote_pubmed/WOS_and_ScienceWire_both_disabled/searches_only_pubmed.yml
@@ -1,0 +1,551 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    body:
+      encoding: UTF-8
+      string: "&id=24930130"
+    headers:
+      User-Agent:
+      - Faraday v0.14.0
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Tue, 30 Jan 2018 22:37:06 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 30 Jan 2018 22:37:07 GMT
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - private
+      Ncbi-Phid:
+      - 990C9355A70F16710000000001350134
+      Ncbi-Sid:
+      - 990C9355A70F3931_0309SID
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Set-Cookie:
+      - ncbi_sid=990C9355A70F3931_0309SID; domain=.nih.gov; path=/; expires=Wed, 30
+        Jan 2019 22:37:07 GMT
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" ?>
+        <!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2018//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_180101.dtd">
+        <PubmedArticleSet>
+        <PubmedArticle>
+            <MedlineCitation Status="MEDLINE" Owner="NLM">
+                <PMID Version="1">24930130</PMID>
+                <DateCompleted>
+                    <Year>2014</Year>
+                    <Month>09</Month>
+                    <Day>29</Day>
+                </DateCompleted>
+                <DateRevised>
+                    <Year>2017</Year>
+                    <Month>02</Month>
+                    <Day>20</Day>
+                </DateRevised>
+                <Article PubModel="Print-Electronic">
+                    <Journal>
+                        <ISSN IssnType="Electronic">1548-7105</ISSN>
+                        <JournalIssue CitedMedium="Internet">
+                            <Volume>11</Volume>
+                            <Issue>8</Issue>
+                            <PubDate>
+                                <Year>2014</Year>
+                                <Month>Aug</Month>
+                            </PubDate>
+                        </JournalIssue>
+                        <Title>Nature methods</Title>
+                        <ISOAbbreviation>Nat. Methods</ISOAbbreviation>
+                    </Journal>
+                    <ArticleTitle>Chemically defined generation of human cardiomyocytes.</ArticleTitle>
+                    <Pagination>
+                        <MedlinePgn>855-60</MedlinePgn>
+                    </Pagination>
+                    <ELocationID EIdType="doi" ValidYN="Y">10.1038/nmeth.2999</ELocationID>
+                    <Abstract>
+                        <AbstractText>Existing methods for human induced pluripotent stem cell (hiPSC) cardiac differentiation are efficient but require complex, undefined medium constituents that hinder further elucidation of the molecular mechanisms of cardiomyogenesis. Using hiPSCs derived under chemically defined conditions on synthetic matrices, we systematically developed an optimized cardiac differentiation strategy, using a chemically defined medium consisting of just three components: the basal medium RPMI 1640, L-ascorbic acid 2-phosphate and rice-derived recombinant human albumin. Along with small molecule-based induction of differentiation, this protocol produced contractile sheets of up to 95% TNNT2(+) cardiomyocytes at a yield of up to 100 cardiomyocytes for every input pluripotent cell and was effective in 11 hiPSC lines tested. This chemically defined platform for cardiac specification of hiPSCs will allow the elucidation of cardiomyocyte macromolecular and metabolic requirements and will provide a minimal system for the study of maturation and subtype specification.</AbstractText>
+                    </Abstract>
+                    <AuthorList CompleteYN="Y">
+                        <Author ValidYN="Y">
+                            <LastName>Burridge</LastName>
+                            <ForeName>Paul W</ForeName>
+                            <Initials>PW</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Matsa</LastName>
+                            <ForeName>Elena</ForeName>
+                            <Initials>E</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Shukla</LastName>
+                            <ForeName>Praveen</ForeName>
+                            <Initials>P</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Lin</LastName>
+                            <ForeName>Ziliang C</ForeName>
+                            <Initials>ZC</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>Department of Applied Physics, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Churko</LastName>
+                            <ForeName>Jared M</ForeName>
+                            <Initials>JM</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Ebert</LastName>
+                            <ForeName>Antje D</ForeName>
+                            <Initials>AD</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Lan</LastName>
+                            <ForeName>Feng</ForeName>
+                            <Initials>F</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Diecke</LastName>
+                            <ForeName>Sebastian</ForeName>
+                            <Initials>S</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Huber</LastName>
+                            <ForeName>Bruno</ForeName>
+                            <Initials>B</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Mordwinkin</LastName>
+                            <ForeName>Nicholas M</ForeName>
+                            <Initials>NM</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Plews</LastName>
+                            <ForeName>Jordan R</ForeName>
+                            <Initials>JR</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Abilez</LastName>
+                            <ForeName>Oscar J</ForeName>
+                            <Initials>OJ</Initials>
+                            <Identifier Source="ORCID">000000029991400X</Identifier>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Cui</LastName>
+                            <ForeName>Bianxiao</ForeName>
+                            <Initials>B</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>Department of Chemistry, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Gold</LastName>
+                            <ForeName>Joseph D</ForeName>
+                            <Initials>JD</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Wu</LastName>
+                            <ForeName>Joseph C</ForeName>
+                            <Initials>JC</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                    </AuthorList>
+                    <Language>eng</Language>
+                    <GrantList CompleteYN="Y">
+                        <Grant>
+                            <GrantID>R01 HL113006</GrantID>
+                            <Acronym>HL</Acronym>
+                            <Agency>NHLBI NIH HHS</Agency>
+                            <Country>United States</Country>
+                        </Grant>
+                        <Grant>
+                            <GrantID>T32 EB009035</GrantID>
+                            <Acronym>EB</Acronym>
+                            <Agency>NIBIB NIH HHS</Agency>
+                            <Country>United States</Country>
+                        </Grant>
+                        <Grant>
+                            <GrantID>U01 HL099776</GrantID>
+                            <Acronym>HL</Acronym>
+                            <Agency>NHLBI NIH HHS</Agency>
+                            <Country>United States</Country>
+                        </Grant>
+                        <Grant>
+                            <GrantID>R24 HL117756</GrantID>
+                            <Acronym>HL</Acronym>
+                            <Agency>NHLBI NIH HHS</Agency>
+                            <Country>United States</Country>
+                        </Grant>
+                        <Grant>
+                            <GrantID>K99 HL121177</GrantID>
+                            <Acronym>HL</Acronym>
+                            <Agency>NHLBI NIH HHS</Agency>
+                            <Country>United States</Country>
+                        </Grant>
+                        <Grant>
+                            <GrantID>R00 HL121177</GrantID>
+                            <Acronym>HL</Acronym>
+                            <Agency>NHLBI NIH HHS</Agency>
+                            <Country>United States</Country>
+                        </Grant>
+                    </GrantList>
+                    <PublicationTypeList>
+                        <PublicationType UI="D016428">Journal Article</PublicationType>
+                        <PublicationType UI="D052061">Research Support, N.I.H., Extramural</PublicationType>
+                        <PublicationType UI="D013485">Research Support, Non-U.S. Gov't</PublicationType>
+                    </PublicationTypeList>
+                    <ArticleDate DateType="Electronic">
+                        <Year>2014</Year>
+                        <Month>06</Month>
+                        <Day>15</Day>
+                    </ArticleDate>
+                </Article>
+                <MedlineJournalInfo>
+                    <Country>United States</Country>
+                    <MedlineTA>Nat Methods</MedlineTA>
+                    <NlmUniqueID>101215604</NlmUniqueID>
+                    <ISSNLinking>1548-7091</ISSNLinking>
+                </MedlineJournalInfo>
+                <ChemicalList>
+                    <Chemical>
+                        <RegistryNumber>0</RegistryNumber>
+                        <NameOfSubstance UI="D003470">Culture Media</NameOfSubstance>
+                    </Chemical>
+                </ChemicalList>
+                <CitationSubset>IM</CitationSubset>
+                <CommentsCorrectionsList>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Nature. 2013 Aug 8;500(7461):222-6</RefSource>
+                        <PMID Version="1">23812591</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Cell Res. 2011 Mar;21(3):518-29</RefSource>
+                        <PMID Version="1">21243013</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Cell Stem Cell. 2012 Jan 6;10(1):16-28</RefSource>
+                        <PMID Version="1">22226352</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Cell Stem Cell. 2011 Feb 4;8(2):228-40</RefSource>
+                        <PMID Version="1">21295278</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Nat Protoc. 2008;3(5):768-76</RefSource>
+                        <PMID Version="1">18451785</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>BMC Dev Biol. 2010;10:60</RefSource>
+                        <PMID Version="1">20525219</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Nat Methods. 2011 May;8(5):409-12</RefSource>
+                        <PMID Version="1">21460823</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Nat Biotechnol. 2007 Sep;25(9):1015-24</RefSource>
+                        <PMID Version="1">17721512</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>PLoS One. 2011;6(8):e23657</RefSource>
+                        <PMID Version="1">21876760</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Cytotechnology. 2010 Jan;62(1):1-16</RefSource>
+                        <PMID Version="1">20373019</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Tissue Eng Part C Methods. 2011 Feb;17(2):193-207</RefSource>
+                        <PMID Version="1">20726687</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Nature. 2008 May 22;453(7194):524-8</RefSource>
+                        <PMID Version="1">18432194</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Cell Stem Cell. 2013 Jan 3;12(1):127-37</RefSource>
+                        <PMID Version="1">23168164</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Science. 1998 Nov 6;282(5391):1145-7</RefSource>
+                        <PMID Version="1">9804556</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>PLoS One. 2011;6(4):e18293</RefSource>
+                        <PMID Version="1">21494607</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Cell Res. 2011 Apr;21(4):579-87</RefSource>
+                        <PMID Version="1">21102549</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>JAMA. 1967 Feb 20;199(8):519-24</RefSource>
+                        <PMID Version="1">4960081</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Cell Rep. 2012 Nov 29;2(5):1448-60</RefSource>
+                        <PMID Version="1">23103164</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Stem Cells. 2007 Apr;25(4):929-38</RefSource>
+                        <PMID Version="1">17185609</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Dev Dyn. 2006 Jul;235(7):1994-2002</RefSource>
+                        <PMID Version="1">16649168</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Cell Stem Cell. 2012 Aug 3;11(2):242-52</RefSource>
+                        <PMID Version="1">22862949</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>J Biol Chem. 1981 Jan 25;256(2):964-8</RefSource>
+                        <PMID Version="1">7451483</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>PLoS One. 2012;7(12):e52405</RefSource>
+                        <PMID Version="1">23300662</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>PLoS One. 2010;5(6):e11134</RefSource>
+                        <PMID Version="1">20559569</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Am J Physiol Cell Physiol. 2010 Dec;299(6):C1234-49</RefSource>
+                        <PMID Version="1">20844252</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Nat Biotechnol. 2010 Jun;28(6):606-10</RefSource>
+                        <PMID Version="1">20512120</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Proc Jpn Acad Ser B Phys Biol Sci. 2009;85(8):348-62</RefSource>
+                        <PMID Version="1">19838014</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Stem Cells Dev. 2012 Apr 10;21(6):977-86</RefSource>
+                        <PMID Version="1">22182484</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Brain Res. 1989 Aug 7;494(1):65-74</RefSource>
+                        <PMID Version="1">2765923</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Stem Cells. 2010 Apr;28(4):713-20</RefSource>
+                        <PMID Version="1">20201064</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Cardiovasc Res. 2003 May 1;58(2):423-34</RefSource>
+                        <PMID Version="1">12757876</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Differentiation. 2008 Apr;76(4):357-70</RefSource>
+                        <PMID Version="1">18021257</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Nat Commun. 2012;3:1236</RefSource>
+                        <PMID Version="1">23212365</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>J Mol Histol. 2004 Jun;35(5):463-70</RefSource>
+                        <PMID Version="1">15571324</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Cell Res. 2012 Jan;22(1):219-36</RefSource>
+                        <PMID Version="1">22143566</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Nature. 2011 May 19;473(7347):326-35</RefSource>
+                        <PMID Version="1">21593865</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Stem Cells. 2008 Sep;26(9):2257-65</RefSource>
+                        <PMID Version="1">18599809</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Annu Rev Cell Dev Biol. 2012;28:523-53</RefSource>
+                        <PMID Version="1">23057746</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Nat Methods. 2011 May;8(5):424-9</RefSource>
+                        <PMID Version="1">21478862</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Proc Natl Acad Sci U S A. 2012 Jul 3;109(27):E1848-57</RefSource>
+                        <PMID Version="1">22645348</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Circulation. 2003 Apr 15;107(14):1912-6</RefSource>
+                        <PMID Version="1">12668514</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Nat Commun. 2014;5:3195</RefSource>
+                        <PMID Version="1">24463987</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Nat Methods. 2011 Dec;8(12):1037-40</RefSource>
+                        <PMID Version="1">22020065</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Can J Physiol Pharmacol. 2006 Aug-Sep;84(8-9):935-41</RefSource>
+                        <PMID Version="1">17111039</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Circ Res. 2012 Oct 12;111(9):1125-36</RefSource>
+                        <PMID Version="1">22912385</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Nat Nanotechnol. 2012 Mar;7(3):185-90</RefSource>
+                        <PMID Version="1">22327876</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Nat Commun. 2014;5:3206</RefSource>
+                        <PMID Version="1">24487777</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Nat Biotechnol. 2010 Jun;28(6):611-5</RefSource>
+                        <PMID Version="1">20512123</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="Cites">
+                        <RefSource>Stem Cells Dev. 2013 Aug 15;22(16):2315-25</RefSource>
+                        <PMID Version="1">23517131</PMID>
+                    </CommentsCorrections>
+                </CommentsCorrectionsList>
+                <MeshHeadingList>
+                    <MeshHeading>
+                        <DescriptorName UI="D002454" MajorTopicYN="N">Cell Differentiation</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D003470" MajorTopicYN="N">Culture Media</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D057026" MajorTopicYN="N">Induced Pluripotent Stem Cells</DescriptorName>
+                        <QualifierName UI="Q000166" MajorTopicYN="N">cytology</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D032383" MajorTopicYN="N">Myocytes, Cardiac</DescriptorName>
+                        <QualifierName UI="Q000166" MajorTopicYN="Y">cytology</QualifierName>
+                    </MeshHeading>
+                </MeshHeadingList>
+                <OtherID Source="NLM">NIHMS599769</OtherID>
+                <OtherID Source="NLM">PMC4169698</OtherID>
+            </MedlineCitation>
+            <PubmedData>
+                <History>
+                    <PubMedPubDate PubStatus="received">
+                        <Year>2013</Year>
+                        <Month>10</Month>
+                        <Day>15</Day>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="accepted">
+                        <Year>2014</Year>
+                        <Month>05</Month>
+                        <Day>06</Day>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="entrez">
+                        <Year>2014</Year>
+                        <Month>6</Month>
+                        <Day>16</Day>
+                        <Hour>6</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="pubmed">
+                        <Year>2014</Year>
+                        <Month>6</Month>
+                        <Day>16</Day>
+                        <Hour>6</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="medline">
+                        <Year>2014</Year>
+                        <Month>9</Month>
+                        <Day>30</Day>
+                        <Hour>6</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                </History>
+                <PublicationStatus>ppublish</PublicationStatus>
+                <ArticleIdList>
+                    <ArticleId IdType="pubmed">24930130</ArticleId>
+                    <ArticleId IdType="pii">nmeth.2999</ArticleId>
+                    <ArticleId IdType="doi">10.1038/nmeth.2999</ArticleId>
+                    <ArticleId IdType="pmc">PMC4169698</ArticleId>
+                    <ArticleId IdType="mid">NIHMS599769</ArticleId>
+                </ArticleIdList>
+            </PubmedData>
+        </PubmedArticle>
+
+        </PubmedArticleSet>
+    http_version: 
+  recorded_at: Tue, 30 Jan 2018 22:37:07 GMT
+recorded_with: VCR 4.0.0

--- a/fixtures/vcr_cassettes/PubmedHarvester/_fetch_remote_pubmed/WOS_disabled_ScienceWire_enabled/searches_only_ScienceWire.yml
+++ b/fixtures/vcr_cassettes/PubmedHarvester/_fetch_remote_pubmed/WOS_disabled_ScienceWire_enabled/searches_only_ScienceWire.yml
@@ -1,0 +1,168 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://sciencewirerest.discoverylogic.com/PublicationCatalog/PublicationQuery?format=xml
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0"?>
+            <ScienceWireQueryXMLParameter xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+            <xmlQuery>&lt;query xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"&gt;
+                      &lt;Criterion ConjunctionOperator="AND"&gt;
+                        &lt;Criteria&gt;
+                          &lt;Criterion&gt;
+                            &lt;Filter&gt;
+                              &lt;Column&gt;PMID&lt;/Column&gt;
+                              &lt;Operator&gt;In&lt;/Operator&gt;
+                              &lt;Values&gt;&lt;Value&gt;24930130&lt;/Value&gt;&lt;/Values&gt;
+                                    &lt;/Filter&gt;
+                                  &lt;/Criterion&gt;
+                                &lt;/Criteria&gt;
+                              &lt;/Criterion&gt;
+                              &lt;Columns&gt;
+                                &lt;SortColumn&gt;
+                                  &lt;Column&gt;Rank&lt;/Column&gt;
+                                  &lt;Direction&gt;Descending&lt;/Direction&gt;
+                                &lt;/SortColumn&gt;
+                              &lt;/Columns&gt;
+                              &lt;MaximumRows&gt;1000&lt;/MaximumRows&gt;
+                            &lt;/query&gt;</xmlQuery>
+            </ScienceWireQueryXMLParameter>
+    headers:
+      User-Agent:
+      - Faraday v0.14.0
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Tue, 30 Jan 2018 22:46:29 GMT
+      Licenseid:
+      - Settings.SCIENCEWIRE.LICENSE_ID
+      Host:
+      - Settings.SCIENCEWIRE.HOST
+      Connection:
+      - Keep-Alive
+      Expect:
+      - 100-continue
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/xml; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Aspnetmvc-Version:
+      - '2.0'
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 30 Jan 2018 22:46:30 GMT
+      Content-Length:
+      - '278'
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\"?>\r\n<ScienceWireQueryIDResponse xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
+        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\r\n  <queryID>168160</queryID>\r\n
+        \ <queryResultRows>1</queryResultRows>\r\n  <totalRows>1</totalRows>\r\n</ScienceWireQueryIDResponse>"
+    http_version: 
+  recorded_at: Tue, 30 Jan 2018 22:46:30 GMT
+- request:
+    method: get
+    uri: https://sciencewirerest.discoverylogic.com/PublicationCatalog/PublicationQuery/168160?format=xml&page=0&pageSize=1&v=version/4
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.14.0
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Tue, 30 Jan 2018 22:46:30 GMT
+      Licenseid:
+      - Settings.SCIENCEWIRE.LICENSE_ID
+      Host:
+      - Settings.SCIENCEWIRE.HOST
+      Connection:
+      - Keep-Alive
+      Expect:
+      - 100-continue
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/xml; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Aspnetmvc-Version:
+      - '2.0'
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 30 Jan 2018 22:46:30 GMT
+      Content-Length:
+      - '3657'
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\"?>\r\n<ArrayOfPublicationItem xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
+        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\r\n  <PublicationItem>\r\n
+        \   <PublicationItemID>67444125</PublicationItemID>\r\n    <Title>Chemically
+        defined generation of human cardiomyocytes</Title>\r\n    <Abstract>Existing
+        methods for human induced pluripotent stem cell (hiPSC) cardiac differentiation
+        are efficient but require complex, undefined medium constituents that hinder
+        further elucidation of the molecular mechanisms of cardiomyogenesis. Using
+        hiPSCs derived under chemically defined conditions on synthetic matrices,
+        we systematically developed an optimized cardiac differentiation strategy,
+        using a chemically defined medium consisting of just three components: the
+        basal medium RPMI 1640, L-ascorbic acid 2-phosphate and rice-derived recombinant
+        human albumin. Along with small molecule based induction of differentiation,
+        this protocol produced contractile sheets of up to 95% TNNT2(+) cardiomyocytes
+        at a yield of up to 100 cardiomyocytes for every input pluripotent cell and
+        was effective in 11 hiPSC lines tested. This chemically defined platform for
+        cardiac specification of hiPSCs will allow the elucidation of cardiomyocyte
+        macromolecular and metabolic requirements and will provide a minimal system
+        for the study of maturation and subtype specification.</Abstract>\r\n    <AuthorList>Burridge,Paul,W|Matsa,Elena,|Shukla,Praveen,|Lin,Ziliang,C|Churko,Jared,M|Ebert,Antje,D|Lan,Feng,|Diecke,Sebastian,|Huber,Bruno,|Mordwinkin,Nicholas,M|Plews,Jordan,R|Abilez,Oscar,J|Cui,Bianxiao,|Gold,Joseph,D|Wu,Joseph,C</AuthorList>\r\n
+        \   <AuthorCount>15</AuthorCount>\r\n    <KeywordList>PROGENITOR CELLS|PLURIPOTENT
+        STEM-CELLS|CARDIOMYOGENESIS|MYOCYTES|SMALL-MOLECULE|CULTURE|EXPRESSION|THYRONINE|CARDIAC
+        DIFFERENTIATION|TERM SELF-RENEWAL</KeywordList>\r\n    <DocumentTypeList>Article</DocumentTypeList>\r\n
+        \   <DocumentCategory>Journal Document</DocumentCategory>\r\n    <NumberOfReferences>40</NumberOfReferences>\r\n
+        \   <TimesCited>161</TimesCited>\r\n    <TimesNotSelfCited>129</TimesNotSelfCited>\r\n
+        \   <PMID>24930130</PMID>\r\n    <WoSItemID>000340075600026</WoSItemID>\r\n
+        \   <PublicationSourceTitle>NATURE METHODS</PublicationSourceTitle>\r\n    <Volume>11</Volume>\r\n
+        \   <Issue>8</Issue>\r\n    <Pagination>855-860</Pagination>\r\n    <PublicationDate>2014-08-01T00:00:00</PublicationDate>\r\n
+        \   <PublicationYear>2014</PublicationYear>\r\n    <PublicationType>Journal</PublicationType>\r\n
+        \   <PublicationSubjectCategoryList>Biochemical Research Methods</PublicationSubjectCategoryList>\r\n
+        \   <ISSN>1548-7091</ISSN>\r\n    <DOI>10.1038/NMETH.2999</DOI>\r\n    <ConferenceStartDate
+        xsi:nil=\"true\" />\r\n    <ConferenceEndDate xsi:nil=\"true\" />\r\n    <Rank
+        xsi:nil=\"true\" />\r\n    <OrdinalRank>0</OrdinalRank>\r\n    <NormalizedRank
+        xsi:nil=\"true\" />\r\n    <NewPublicationItemID xsi:nil=\"true\" />\r\n    <IsObsolete>false</IsObsolete>\r\n
+        \   <CopyrightPublisher>NATURE PUBLISHING GROUP</CopyrightPublisher>\r\n    <CopyrightCity>LONDON</CopyrightCity>\r\n
+        \   <PublicationImpactFactorList>25.953,2013,ClosestToPublicationYear|25.953,2013,MostRecentYear</PublicationImpactFactorList>\r\n
+        \   <PublicationCategoryRankingList>1/78;BIOCHEMICAL RESEARCH METHODS;2013;SC;ClosestToPublicationYear|1/78;BIOCHEMICAL
+        RESEARCH METHODS;2013;SC;MostRecentYear</PublicationCategoryRankingList>\r\n
+        \   <AuthorCitationCountList>1,6,155|2,4,157|3,5,156|4,1,160|5,3,158|6,5,156|7,1,160|8,2,159|9,0,161|10,1,160|11,0,161|12,4,157|13,1,160|14,4,157|15,28,133</AuthorCitationCountList>\r\n
+        \   <CopyrightStateProvince />\r\n    <CopyrightCountry>UNITED KINGDOM</CopyrightCountry>\r\n
+        \ </PublicationItem>\r\n</ArrayOfPublicationItem>"
+    http_version: 
+  recorded_at: Tue, 30 Jan 2018 22:46:30 GMT
+recorded_with: VCR 4.0.0

--- a/fixtures/vcr_cassettes/PubmedHarvester/_fetch_remote_pubmed/WOS_enabled_ScienceWire_disabled/searches_only_WOS.yml
+++ b/fixtures/vcr_cassettes/PubmedHarvester/_fetch_remote_pubmed/WOS_enabled_ScienceWire_disabled/searches_only_WOS.yml
@@ -1,0 +1,1038 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://search.webofknowledge.com/esti/wokmws/ws/WOKMWSAuthenticate?wsdl
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.4.1 (2017-03-22))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 30 Jan 2018 23:30:03 GMT
+      Authorization:
+      - Basic Settings.WOS.AUTH_CODE
+      Soapaction:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Date:
+      - Tue, 30 Jan 2018 23:30:03 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Content-Length:
+      - '8705'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version='1.0' encoding='UTF-8'?><wsdl:definitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="http://auth.cxf.wokmws.thomsonreuters.com" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" name="WOKMWSAuthenticateService" targetNamespace="http://auth.cxf.wokmws.thomsonreuters.com">
+          <wsdl:types>
+        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://auth.cxf.wokmws.thomsonreuters.com" targetNamespace="http://auth.cxf.wokmws.thomsonreuters.com" version="1.0">
+        <xs:element name="AuthenticationException" type="tns:AuthenticationException"/>
+        <xs:element name="ESTIWSException" type="tns:ESTIWSException"/>
+        <xs:element name="InternalServerException" type="tns:InternalServerException"/>
+        <xs:element name="InvalidInputException" type="tns:InvalidInputException"/>
+        <xs:element name="QueryException" type="tns:QueryException"/>
+        <xs:element name="SessionException" type="tns:SessionException"/>
+        <xs:element name="authenticate" type="tns:authenticate"/>
+        <xs:element name="authenticateResponse" type="tns:authenticateResponse"/>
+        <xs:element name="closeSession" type="tns:closeSession"/>
+        <xs:element name="closeSessionResponse" type="tns:closeSessionResponse"/>
+        <xs:complexType name="closeSession">
+            <xs:sequence/>
+          </xs:complexType>
+        <xs:complexType name="closeSessionResponse">
+            <xs:sequence/>
+          </xs:complexType>
+        <xs:complexType name="QueryException">
+            <xs:sequence/>
+          </xs:complexType>
+        <xs:complexType name="ESTIWSException">
+            <xs:sequence/>
+          </xs:complexType>
+        <xs:complexType name="InvalidInputException">
+            <xs:sequence/>
+          </xs:complexType>
+        <xs:complexType name="InternalServerException">
+            <xs:sequence/>
+          </xs:complexType>
+        <xs:complexType name="SessionException">
+            <xs:sequence/>
+          </xs:complexType>
+        <xs:complexType name="AuthenticationException">
+            <xs:sequence/>
+          </xs:complexType>
+        <xs:complexType name="authenticate">
+            <xs:sequence/>
+          </xs:complexType>
+        <xs:complexType name="authenticateResponse">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="return" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:schema>
+          </wsdl:types>
+          <wsdl:message name="closeSession">
+            <wsdl:part element="tns:closeSession" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="QueryException_Exception">
+            <wsdl:part element="tns:QueryException" name="QueryException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="ESTIWSException_Exception">
+            <wsdl:part element="tns:ESTIWSException" name="ESTIWSException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="InvalidInputException_Exception">
+            <wsdl:part element="tns:InvalidInputException" name="InvalidInputException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="InternalServerException_Exception">
+            <wsdl:part element="tns:InternalServerException" name="InternalServerException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="SessionException_Exception">
+            <wsdl:part element="tns:SessionException" name="SessionException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="authenticate">
+            <wsdl:part element="tns:authenticate" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="closeSessionResponse">
+            <wsdl:part element="tns:closeSessionResponse" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="authenticateResponse">
+            <wsdl:part element="tns:authenticateResponse" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="AuthenticationException_Exception">
+            <wsdl:part element="tns:AuthenticationException" name="AuthenticationException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:portType name="WOKMWSAuthenticate">
+            <wsdl:operation name="closeSession">
+              <wsdl:input message="tns:closeSession" name="closeSession">
+            </wsdl:input>
+              <wsdl:output message="tns:closeSessionResponse" name="closeSessionResponse">
+            </wsdl:output>
+              <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="authenticate">
+              <wsdl:input message="tns:authenticate" name="authenticate">
+            </wsdl:input>
+              <wsdl:output message="tns:authenticateResponse" name="authenticateResponse">
+            </wsdl:output>
+              <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+            </wsdl:operation>
+          </wsdl:portType>
+          <wsdl:binding name="WOKMWSAuthenticateServiceSoapBinding" type="tns:WOKMWSAuthenticate">
+            <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+            <wsdl:operation name="closeSession">
+              <soap:operation soapAction="" style="document"/>
+              <wsdl:input name="closeSession">
+                <soap:body use="literal"/>
+              </wsdl:input>
+              <wsdl:output name="closeSessionResponse">
+                <soap:body use="literal"/>
+              </wsdl:output>
+              <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+              </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="authenticate">
+              <soap:operation soapAction="" style="document"/>
+              <wsdl:input name="authenticate">
+                <soap:body use="literal"/>
+              </wsdl:input>
+              <wsdl:output name="authenticateResponse">
+                <soap:body use="literal"/>
+              </wsdl:output>
+              <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+              </wsdl:fault>
+            </wsdl:operation>
+          </wsdl:binding>
+          <wsdl:service name="WOKMWSAuthenticateService">
+            <wsdl:port binding="tns:WOKMWSAuthenticateServiceSoapBinding" name="WOKMWSAuthenticatePort">
+              <soap:address location="http://search.webofknowledge.com/esti/wokmws/ws/WOKMWSAuthenticate"/>
+            </wsdl:port>
+          </wsdl:service>
+        </wsdl:definitions>
+    http_version: 
+  recorded_at: Tue, 30 Jan 2018 23:30:03 GMT
+- request:
+    method: post
+    uri: http://search.webofknowledge.com/esti/wokmws/ws/WOKMWSAuthenticate
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://auth.cxf.wokmws.thomsonreuters.com"
+        xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Body><tns:authenticate></tns:authenticate></soapenv:Body></soapenv:Envelope>
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.4.1 (2017-03-22))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 30 Jan 2018 23:30:03 GMT
+      Authorization:
+      - Basic Settings.WOS.AUTH_CODE
+      Soapaction:
+      - ''
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Content-Length:
+      - '352'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Date:
+      - Tue, 30 Jan 2018 23:30:03 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Set-Cookie:
+      - SID=5A7GtrdfrfFgPd11f55
+      Content-Length:
+      - '252'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><ns2:authenticateResponse
+        xmlns:ns2="http://auth.cxf.wokmws.thomsonreuters.com"><return>5A7GtrdfrfFgPd11f55</return></ns2:authenticateResponse></soap:Body></soap:Envelope>
+    http_version: 
+  recorded_at: Tue, 30 Jan 2018 23:30:03 GMT
+- request:
+    method: get
+    uri: http://search.webofknowledge.com/esti/wokmws/ws/WokSearch?wsdl
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.4.1 (2017-03-22))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 30 Jan 2018 23:30:03 GMT
+      Cookie:
+      - SID="5A7GtrdfrfFgPd11f55"
+      Soapaction:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Date:
+      - Tue, 30 Jan 2018 23:30:03 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version='1.0' encoding='UTF-8'?><wsdl:definitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="http://woksearch.v3.wokmws.thomsonreuters.com" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" name="WokSearchService" targetNamespace="http://woksearch.v3.wokmws.thomsonreuters.com">
+          <wsdl:types>
+        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://woksearch.v3.wokmws.thomsonreuters.com" targetNamespace="http://woksearch.v3.wokmws.thomsonreuters.com" version="1.0">
+        <xs:element name="AuthenticationException" type="tns:AuthenticationException"/>
+        <xs:element name="ESTIWSException" type="tns:ESTIWSException"/>
+        <xs:element name="InternalServerException" type="tns:InternalServerException"/>
+        <xs:element name="InvalidInputException" type="tns:InvalidInputException"/>
+        <xs:element name="QueryException" type="tns:QueryException"/>
+        <xs:element name="SessionException" type="tns:SessionException"/>
+        <xs:element name="citedReferences" type="tns:citedReferences"/>
+        <xs:element name="citedReferencesResponse" type="tns:citedReferencesResponse"/>
+        <xs:element name="citedReferencesRetrieve" type="tns:citedReferencesRetrieve"/>
+        <xs:element name="citedReferencesRetrieveResponse" type="tns:citedReferencesRetrieveResponse"/>
+        <xs:element name="citingArticles" type="tns:citingArticles"/>
+        <xs:element name="citingArticlesResponse" type="tns:citingArticlesResponse"/>
+        <xs:element name="relatedRecords" type="tns:relatedRecords"/>
+        <xs:element name="relatedRecordsResponse" type="tns:relatedRecordsResponse"/>
+        <xs:element name="retrieve" type="tns:retrieve"/>
+        <xs:element name="retrieveById" type="tns:retrieveById"/>
+        <xs:element name="retrieveByIdResponse" type="tns:retrieveByIdResponse"/>
+        <xs:element name="retrieveResponse" type="tns:retrieveResponse"/>
+        <xs:element name="search" type="tns:search"/>
+        <xs:element name="searchResponse" type="tns:searchResponse"/>
+        <xs:complexType name="citedReferences">
+            <xs:sequence>
+              <xs:element name="databaseId" type="xs:string"/>
+              <xs:element name="uid" type="xs:string"/>
+              <xs:element name="queryLanguage" type="xs:string"/>
+              <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="retrieveParameters">
+            <xs:sequence>
+              <xs:element name="firstRecord" type="xs:int"/>
+              <xs:element name="count" type="xs:int"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="sortField" nillable="true" type="tns:sortField"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="viewField" nillable="true" type="tns:viewField"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="option" nillable="true" type="tns:keyValuePair"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="sortField">
+            <xs:sequence>
+              <xs:element name="name" type="xs:string"/>
+              <xs:element name="sort" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="viewField">
+            <xs:sequence>
+              <xs:element name="collectionName" type="xs:string"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="fieldName" nillable="true" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="keyValuePair">
+            <xs:sequence>
+              <xs:element name="key" type="xs:string"/>
+              <xs:element name="value" nillable="true" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="citedReferencesResponse">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="return" type="tns:citedReferencesSearchResults"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="citedReferencesSearchResults">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="queryId" type="xs:string"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="references" nillable="true" type="tns:citedReference"/>
+              <xs:element name="recordsFound" type="xs:int"/>
+              <xs:element name="recordsSearched" type="xs:long"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="citedReference">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="uid" type="xs:string"/>
+              <xs:element minOccurs="0" name="docid" type="xs:string"/>
+              <xs:element minOccurs="0" name="articleId" type="xs:string"/>
+              <xs:element minOccurs="0" name="citedAuthor" type="xs:string"/>
+              <xs:element minOccurs="0" name="timesCited" type="xs:string"/>
+              <xs:element minOccurs="0" name="year" type="xs:string"/>
+              <xs:element minOccurs="0" name="page" type="xs:string"/>
+              <xs:element minOccurs="0" name="volume" type="xs:string"/>
+              <xs:element minOccurs="0" name="citedTitle" type="xs:string"/>
+              <xs:element minOccurs="0" name="citedWork" type="xs:string"/>
+              <xs:element minOccurs="0" name="hot" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="QueryException">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
+              <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="FaultInformation">
+            <xs:sequence>
+              <xs:element name="code" type="xs:string"/>
+              <xs:element minOccurs="0" name="message" type="xs:string"/>
+              <xs:element minOccurs="0" name="reason" type="xs:string"/>
+              <xs:element minOccurs="0" name="causeType" type="xs:string"/>
+              <xs:element minOccurs="0" name="cause" type="xs:string"/>
+              <xs:element minOccurs="0" name="supportingWebServiceException" type="tns:SupportingWebServiceException"/>
+              <xs:element minOccurs="0" name="remedy" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="SupportingWebServiceException">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="remoteNamespace" type="xs:string"/>
+              <xs:element minOccurs="0" name="remoteOperation" type="xs:string"/>
+              <xs:element minOccurs="0" name="remoteCode" type="xs:string"/>
+              <xs:element minOccurs="0" name="remoteReason" type="xs:string"/>
+              <xs:element minOccurs="0" name="handshakeCauseId" type="xs:string"/>
+              <xs:element minOccurs="0" name="handshakeCause" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="RawFaultInformation">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="rawFaultstring" type="xs:string"/>
+              <xs:element minOccurs="0" name="rawMessage" type="xs:string"/>
+              <xs:element minOccurs="0" name="rawReason" type="xs:string"/>
+              <xs:element minOccurs="0" name="rawCause" type="xs:string"/>
+              <xs:element minOccurs="0" name="rawRemedy" type="xs:string"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="messageData" nillable="true" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="InvalidInputException">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
+              <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="ESTIWSException">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
+              <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="InternalServerException">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
+              <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="AuthenticationException">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
+              <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="SessionException">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
+              <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="citedReferencesRetrieve">
+            <xs:sequence>
+              <xs:element name="queryId" type="xs:string"/>
+              <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="citedReferencesRetrieveResponse">
+            <xs:sequence>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="return" type="tns:citedReference"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="relatedRecords">
+            <xs:sequence>
+              <xs:element name="databaseId" type="xs:string"/>
+              <xs:element name="uid" type="xs:string"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="editions" nillable="true" type="tns:editionDesc"/>
+              <xs:element minOccurs="0" name="timeSpan" type="tns:timeSpan"/>
+              <xs:element name="queryLanguage" type="xs:string"/>
+              <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="editionDesc">
+            <xs:sequence>
+              <xs:element name="collection" type="xs:string"/>
+              <xs:element name="edition" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="timeSpan">
+            <xs:sequence>
+              <xs:element name="begin" type="xs:string"/>
+              <xs:element name="end" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="relatedRecordsResponse">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="return" type="tns:fullRecordSearchResults"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="fullRecordSearchResults">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="queryId" type="xs:string"/>
+              <xs:element name="recordsFound" type="xs:int"/>
+              <xs:element name="recordsSearched" type="xs:long"/>
+              <xs:element minOccurs="0" name="parent" type="xs:string"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="optionValue" nillable="true" type="tns:labelValuesPair"/>
+              <xs:element minOccurs="0" name="records" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="labelValuesPair">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="label" type="xs:string"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="value" nillable="true" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="retrieveById">
+            <xs:sequence>
+              <xs:element name="databaseId" type="xs:string"/>
+              <xs:element maxOccurs="unbounded" name="uid" type="xs:string"/>
+              <xs:element name="queryLanguage" type="xs:string"/>
+              <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="retrieveByIdResponse">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="return" type="tns:fullRecordSearchResults"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="retrieve">
+            <xs:sequence>
+              <xs:element name="queryId" type="xs:string"/>
+              <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="retrieveResponse">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="return" type="tns:fullRecordData"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="fullRecordData">
+            <xs:sequence>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="optionValue" nillable="true" type="tns:labelValuesPair"/>
+              <xs:element minOccurs="0" name="records" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="search">
+            <xs:sequence>
+              <xs:element name="queryParameters" type="tns:queryParameters"/>
+              <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="queryParameters">
+            <xs:sequence>
+              <xs:element name="databaseId" type="xs:string"/>
+              <xs:element name="userQuery" type="xs:string"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="editions" nillable="true" type="tns:editionDesc"/>
+              <xs:element minOccurs="0" name="symbolicTimeSpan" type="xs:string"/>
+              <xs:element minOccurs="0" name="timeSpan" type="tns:timeSpan"/>
+              <xs:element name="queryLanguage" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="searchResponse">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="return" type="tns:fullRecordSearchResults"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="citingArticles">
+            <xs:sequence>
+              <xs:element name="databaseId" type="xs:string"/>
+              <xs:element name="uid" type="xs:string"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="editions" nillable="true" type="tns:editionDesc"/>
+              <xs:element minOccurs="0" name="timeSpan" type="tns:timeSpan"/>
+              <xs:element name="queryLanguage" type="xs:string"/>
+              <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="citingArticlesResponse">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="return" type="tns:fullRecordSearchResults"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:schema>
+          </wsdl:types>
+          <wsdl:message name="relatedRecordsResponse">
+            <wsdl:part element="tns:relatedRecordsResponse" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="relatedRecords">
+            <wsdl:part element="tns:relatedRecords" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="retrieveById">
+            <wsdl:part element="tns:retrieveById" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="retrieveResponse">
+            <wsdl:part element="tns:retrieveResponse" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="ESTIWSException_Exception">
+            <wsdl:part element="tns:ESTIWSException" name="ESTIWSException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="InternalServerException_Exception">
+            <wsdl:part element="tns:InternalServerException" name="InternalServerException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="retrieve">
+            <wsdl:part element="tns:retrieve" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="searchResponse">
+            <wsdl:part element="tns:searchResponse" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="citingArticlesResponse">
+            <wsdl:part element="tns:citingArticlesResponse" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="AuthenticationException_Exception">
+            <wsdl:part element="tns:AuthenticationException" name="AuthenticationException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="retrieveByIdResponse">
+            <wsdl:part element="tns:retrieveByIdResponse" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="search">
+            <wsdl:part element="tns:search" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="citingArticles">
+            <wsdl:part element="tns:citingArticles" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="citedReferences">
+            <wsdl:part element="tns:citedReferences" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="citedReferencesRetrieve">
+            <wsdl:part element="tns:citedReferencesRetrieve" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="citedReferencesRetrieveResponse">
+            <wsdl:part element="tns:citedReferencesRetrieveResponse" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="QueryException_Exception">
+            <wsdl:part element="tns:QueryException" name="QueryException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="InvalidInputException_Exception">
+            <wsdl:part element="tns:InvalidInputException" name="InvalidInputException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="citedReferencesResponse">
+            <wsdl:part element="tns:citedReferencesResponse" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="SessionException_Exception">
+            <wsdl:part element="tns:SessionException" name="SessionException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:portType name="WokSearch">
+            <wsdl:operation name="citedReferences">
+              <wsdl:input message="tns:citedReferences" name="citedReferences">
+            </wsdl:input>
+              <wsdl:output message="tns:citedReferencesResponse" name="citedReferencesResponse">
+            </wsdl:output>
+              <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="citedReferencesRetrieve">
+              <wsdl:input message="tns:citedReferencesRetrieve" name="citedReferencesRetrieve">
+            </wsdl:input>
+              <wsdl:output message="tns:citedReferencesRetrieveResponse" name="citedReferencesRetrieveResponse">
+            </wsdl:output>
+              <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="relatedRecords">
+              <wsdl:input message="tns:relatedRecords" name="relatedRecords">
+            </wsdl:input>
+              <wsdl:output message="tns:relatedRecordsResponse" name="relatedRecordsResponse">
+            </wsdl:output>
+              <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="retrieveById">
+              <wsdl:input message="tns:retrieveById" name="retrieveById">
+            </wsdl:input>
+              <wsdl:output message="tns:retrieveByIdResponse" name="retrieveByIdResponse">
+            </wsdl:output>
+              <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="retrieve">
+              <wsdl:input message="tns:retrieve" name="retrieve">
+            </wsdl:input>
+              <wsdl:output message="tns:retrieveResponse" name="retrieveResponse">
+            </wsdl:output>
+              <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="search">
+              <wsdl:input message="tns:search" name="search">
+            </wsdl:input>
+              <wsdl:output message="tns:searchResponse" name="searchResponse">
+            </wsdl:output>
+              <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="citingArticles">
+              <wsdl:input message="tns:citingArticles" name="citingArticles">
+            </wsdl:input>
+              <wsdl:output message="tns:citingArticlesResponse" name="citingArticlesResponse">
+            </wsdl:output>
+              <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+            </wsdl:operation>
+          </wsdl:portType>
+          <wsdl:binding name="WokSearchServiceSoapBinding" type="tns:WokSearch">
+            <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+            <wsdl:operation name="citedReferences">
+              <soap:operation soapAction="" style="document"/>
+              <wsdl:input name="citedReferences">
+                <soap:body use="literal"/>
+              </wsdl:input>
+              <wsdl:output name="citedReferencesResponse">
+                <soap:body use="literal"/>
+              </wsdl:output>
+              <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+              </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="citedReferencesRetrieve">
+              <soap:operation soapAction="" style="document"/>
+              <wsdl:input name="citedReferencesRetrieve">
+                <soap:body use="literal"/>
+              </wsdl:input>
+              <wsdl:output name="citedReferencesRetrieveResponse">
+                <soap:body use="literal"/>
+              </wsdl:output>
+              <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+              </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="relatedRecords">
+              <soap:operation soapAction="" style="document"/>
+              <wsdl:input name="relatedRecords">
+                <soap:body use="literal"/>
+              </wsdl:input>
+              <wsdl:output name="relatedRecordsResponse">
+                <soap:body use="literal"/>
+              </wsdl:output>
+              <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+              </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="retrieveById">
+              <soap:operation soapAction="" style="document"/>
+              <wsdl:input name="retrieveById">
+                <soap:body use="literal"/>
+              </wsdl:input>
+              <wsdl:output name="retrieveByIdResponse">
+                <soap:body use="literal"/>
+              </wsdl:output>
+              <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+              </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="retrieve">
+              <soap:operation soapAction="" style="document"/>
+              <wsdl:input name="retrieve">
+                <soap:body use="literal"/>
+              </wsdl:input>
+              <wsdl:output name="retrieveResponse">
+                <soap:body use="literal"/>
+              </wsdl:output>
+              <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+              </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="search">
+              <soap:operation soapAction="" style="document"/>
+              <wsdl:input name="search">
+                <soap:body use="literal"/>
+              </wsdl:input>
+              <wsdl:output name="searchResponse">
+                <soap:body use="literal"/>
+              </wsdl:output>
+              <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+              </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="citingArticles">
+              <soap:operation soapAction="" style="document"/>
+              <wsdl:input name="citingArticles">
+                <soap:body use="literal"/>
+              </wsdl:input>
+              <wsdl:output name="citingArticlesResponse">
+                <soap:body use="literal"/>
+              </wsdl:output>
+              <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+              </wsdl:fault>
+            </wsdl:operation>
+          </wsdl:binding>
+          <wsdl:service name="WokSearchService">
+            <wsdl:port binding="tns:WokSearchServiceSoapBinding" name="WokSearchPort">
+              <soap:address location="http://search.webofknowledge.com/esti/wokmws/ws/WokSearch"/>
+            </wsdl:port>
+          </wsdl:service>
+        </wsdl:definitions>
+    http_version: 
+  recorded_at: Tue, 30 Jan 2018 23:30:04 GMT
+- request:
+    method: post
+    uri: http://search.webofknowledge.com/esti/wokmws/ws/WokSearch
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://woksearch.v3.wokmws.thomsonreuters.com"
+        xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Body><tns:retrieveById><databaseId>WOK</databaseId><uid>MEDLINE:24930130</uid><queryLanguage>en</queryLanguage><retrieveParameters><firstRecord>1</firstRecord><count>100</count><option><key>RecordIDs</key><value>On</value></option><option><key>targetNamespace</key><value>http://scientific.thomsonreuters.com/schema/wok5.4/public/FullRecord</value></option></retrieveParameters></tns:retrieveById></soapenv:Body></soapenv:Envelope>
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.4.1 (2017-03-22))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 30 Jan 2018 23:30:04 GMT
+      Cookie:
+      - SID="5A7GtrdfrfFgPd11f55"
+      Soapaction:
+      - ''
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Content-Length:
+      - '711'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Date:
+      - Tue, 30 Jan 2018 23:30:04 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Content-Length:
+      - '20254'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><ns2:retrieveByIdResponse xmlns:ns2="http://woksearch.v3.wokmws.thomsonreuters.com"><return><queryId>1</queryId><recordsFound>1</recordsFound><recordsSearched>75592049</recordsSearched><optionValue><label>RecordIDs</label><value>MEDLINE:24930130</value></optionValue><records>&lt;records xmlns="http://scientific.thomsonreuters.com/schema/wok5.4/public/FullRecord">
+        &lt;REC r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>MEDLINE:24930130&lt;/UID>&lt;static_data>&lt;summary>&lt;EWUID>&lt;WUID coll_id="MEDLINE">&lt;/WUID>&lt;edition value="MEDLINE.MEDLINE">&lt;/edition>&lt;/EWUID>&lt;pub_info sortdate="2014-08-01" pubyear="2014" pubmonth="Aug" coverdate="2014-Aug" edate="2014-06-15" vol="11" issue="8" pubtype="Journal" medium="Internet" model="Print-Electronic" has_abstract="Y">&lt;page begin="855" end="60">855-60&lt;/page>&lt;/pub_info>&lt;titles count="4">&lt;title type="item">Chemically defined generation of human cardiomyocytes.&lt;/title>&lt;title type="source">Nature methods&lt;/title>&lt;title type="abbrev_iso">Nat. Methods&lt;/title>&lt;title type="source_abbrev">Nat Methods&lt;/title>&lt;/titles>&lt;names count="15">&lt;name seq_no="1" role="author" display="Y">&lt;display_name>Burridge, Paul W&lt;/display_name>&lt;full_name>Burridge, Paul W&lt;/full_name>&lt;initials>PW&lt;/initials>&lt;/name>&lt;name seq_no="2" role="author" display="Y">&lt;display_name>Matsa, Elena&lt;/display_name>&lt;full_name>Matsa, Elena&lt;/full_name>&lt;initials>E&lt;/initials>&lt;/name>&lt;name seq_no="3" role="author" display="Y">&lt;display_name>Shukla, Praveen&lt;/display_name>&lt;full_name>Shukla, Praveen&lt;/full_name>&lt;initials>P&lt;/initials>&lt;/name>&lt;name seq_no="4" role="author" display="Y">&lt;display_name>Lin, Ziliang C&lt;/display_name>&lt;full_name>Lin, Ziliang C&lt;/full_name>&lt;initials>ZC&lt;/initials>&lt;/name>&lt;name seq_no="5" role="author" display="Y">&lt;display_name>Churko, Jared M&lt;/display_name>&lt;full_name>Churko, Jared M&lt;/full_name>&lt;initials>JM&lt;/initials>&lt;/name>&lt;name seq_no="6" role="author" display="Y">&lt;display_name>Ebert, Antje D&lt;/display_name>&lt;full_name>Ebert, Antje D&lt;/full_name>&lt;initials>AD&lt;/initials>&lt;/name>&lt;name seq_no="7" role="author" display="Y">&lt;display_name>Lan, Feng&lt;/display_name>&lt;full_name>Lan, Feng&lt;/full_name>&lt;initials>F&lt;/initials>&lt;/name>&lt;name seq_no="8" role="author" display="Y">&lt;display_name>Diecke, Sebastian&lt;/display_name>&lt;full_name>Diecke, Sebastian&lt;/full_name>&lt;initials>S&lt;/initials>&lt;/name>&lt;name seq_no="9" role="author" display="Y">&lt;display_name>Huber, Bruno&lt;/display_name>&lt;full_name>Huber, Bruno&lt;/full_name>&lt;initials>B&lt;/initials>&lt;/name>&lt;name seq_no="10" role="author" display="Y">&lt;display_name>Mordwinkin, Nicholas M&lt;/display_name>&lt;full_name>Mordwinkin, Nicholas M&lt;/full_name>&lt;initials>NM&lt;/initials>&lt;/name>&lt;name seq_no="11" role="author" display="Y">&lt;display_name>Plews, Jordan R&lt;/display_name>&lt;full_name>Plews, Jordan R&lt;/full_name>&lt;initials>JR&lt;/initials>&lt;/name>&lt;name seq_no="12" role="author" display="Y">&lt;display_name&gt;Abilez, Oscar J&lt;/display_name>&lt;full_name>Abilez, Oscar J&lt;/full_name>&lt;initials>OJ&lt;/initials>&lt;/name>&lt;name seq_no="13" role="author" display="Y">&lt;display_name>Cui, Bianxiao&lt;/display_name>&lt;full_name>Cui, Bianxiao&lt;/full_name>&lt;initials>B&lt;/initials>&lt;/name>&lt;name seq_no="14" role="author" display="Y">&lt;display_name>Gold, Joseph D&lt;/display_name>&lt;full_name>Gold, Joseph D&lt;/full_name>&lt;initials>JD&lt;/initials>&lt;/name>&lt;name seq_no="15" role="author" display="Y">&lt;display_name>Wu, Joseph C&lt;/display_name>&lt;full_name>Wu, Joseph C&lt;/full_name>&lt;initials>JC&lt;/initials>&lt;/name>&lt;/names>&lt;doctypes count="3">&lt;doctype>Journal Article&lt;/doctype>&lt;doctype>Research Support, N.I.H., Extramural&lt;/doctype>&lt;doctype>Research Support, Non-U.S. Gov&amp;apos;t&lt;/doctype>&lt;/doctypes>&lt;/summary>&lt;fullrecord_metadata>&lt;languages count="1">&lt;language type="primary">English&lt;/language>&lt;/languages>&lt;normalized_languages count="1">&lt;language type="primary">English&lt;/language>&lt;/normalized_languages>&lt;normalized_doctypes count="2">&lt;doctype>Article&lt;/doctype>&lt;doctype>Other&lt;/doctype>&lt;/normalized_doctypes>&lt;addresses count="1">&lt;address_name>&lt;address_spec addr_no="1">&lt;full_address>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.&lt;/full_address>&lt;/address_spec>&lt;/address_name>&lt;/addresses>&lt;category_info>&lt;headings count="1">&lt;heading>Science &amp;amp; Technology&lt;/heading>&lt;/headings>&lt;subheadings count="1">&lt;subheading>Life Sciences &amp;amp; Biomedicine&lt;/subheading>&lt;/subheadings>&lt;subjects count="2">&lt;subject ascatype="traditional" code="DR">CELL BIOLOGY&lt;/subject>&lt;subject ascatype="extended">Cell Biology&lt;/subject>&lt;/subjects>&lt;/category_info>&lt;fund_ack>&lt;grants count="6" complete="Y">&lt;grant>&lt;grant_agency>NHLBI NIH HHS&lt;/grant_agency>&lt;grant_ids count="1">&lt;grant_id>R01 HL113006&lt;/grant_id>&lt;/grant_ids>&lt;country>United States&lt;/country>&lt;acronym>HL&lt;/acronym>&lt;/grant>&lt;grant>&lt;grant_agency>NIBIB NIH HHS&lt;/grant_agency>&lt;grant_ids count="1">&lt;grant_id>T32 EB009035&lt;/grant_id>&lt;/grant_ids>&lt;country>United States&lt;/country>&lt;acronym>EB&lt;/acronym>&lt;/grant>&lt;grant>&lt;grant_agency>NHLBI NIH HHS&lt;/grant_agency>&lt;grant_ids count="1">&lt;grant_id>U01 HL099776&lt;/grant_id>&lt;/grant_ids>&lt;country>United States&lt;/country>&lt;acronym>HL&lt;/acronym>&lt;/grant>&lt;grant>&lt;grant_agency>NHLBI NIH HHS&lt;/grant_agency>&lt;grant_ids count="1">&lt;grant_id>R24 HL117756&lt;/grant_id>&lt;/grant_ids>&lt;country>United States&lt;/country>&lt;acronym>HL&lt;/acronym>&lt;/grant>&lt;grant>&lt;grant_agency>NHLBI NIH HHS&lt;/grant_agency>&lt;grant_ids count="1">&lt;grant_id>K99 HL121177&lt;/grant_id>&lt;/grant_ids>&lt;country>United States&lt;/country>&lt;acronym>HL&lt;/acronym>&lt;/grant>&lt;grant>&lt;grant_agency>NHLBI NIH HHS&lt;/grant_agency>&lt;grant_ids count="1">&lt;grant_id>R00 HL121177&lt;/grant_id>&lt;/grant_ids>&lt;country>United States&lt;/country>&lt;acronym>HL&lt;/acronym>&lt;/grant>&lt;/grants>&lt;/fund_ack>&lt;abstracts count="1">&lt;abstract>&lt;abstract_text>&lt;p>Existing methods for human induced pluripotent stem cell (hiPSC) cardiac differentiation are efficient but require complex, undefined medium constituents that hinder further elucidation of the molecular mechanisms of cardiomyogenesis. Using hiPSCs derived under chemically defined conditions on synthetic matrices, we systematically developed an optimized cardiac differentiation strategy, using a chemically defined medium consisting of just three components: the basal medium RPMI 1640, L-ascorbic acid 2-phosphate and rice-derived recombinant human albumin. Along with small molecule-based induction of differentiation, this protocol produced contractile sheets of up to 95% TNNT2(+) cardiomyocytes at a yield of up to 100 cardiomyocytes for every input pluripotent cell and was effective in 11 hiPSC lines tested. This chemically defined platform for cardiac specification of hiPSCs will allow the elucidation of cardiomyocyte macromolecular and metabolic requirements and will provide a minimal system for the study of maturation and subtype specification. &lt;/p>&lt;/abstract_text>&lt;/abstract>&lt;/abstracts>&lt;/fullrecord_metadata>&lt;item xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Owner="NLM" Status="MEDLINE" xsi:type="itemType_medline" coll_id="MEDLINE">&lt;MedlineJournalInfo>&lt;Country>United States&lt;/Country>&lt;NlmUniqueID>101215604&lt;/NlmUniqueID>&lt;ISSNLinking>1548-7091&lt;/ISSNLinking>&lt;/MedlineJournalInfo>&lt;DateCreated>2014-07-31&lt;/DateCreated>&lt;DateCompleted>2014-09-29&lt;/DateCompleted>&lt;DateRevised>2016-11-14&lt;/DateRevised>&lt;Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.&lt;/Affiliation>&lt;ChemicalList>&lt;Chemical>&lt;RegistryNumber>0&lt;/RegistryNumber>&lt;NameOfSubstance UI="D003470">Culture Media&lt;/NameOfSubstance>&lt;/Chemical>&lt;/ChemicalList>&lt;CitationSubset>IM&lt;/CitationSubset>&lt;CommentsCorrectionsList>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>PLoS One. 2011;6(4):e18293&lt;/RefSource>&lt;PMID Version="1">21494607&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Nat Methods. 2011 May;8(5):409-12&lt;/RefSource>&lt;PMID Version="1">21460823&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Nat Methods. 2011 May;8(5):424-9&lt;/RefSource>&lt;PMID Version="1">21478862&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Nature. 2011 May 19;473(7347):326-35&lt;/RefSource>&lt;PMID Version="1">21593865&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>PLoS One. 2011;6(8):e23657&lt;/RefSource>&lt;PMID Version="1">21876760&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Nat Methods. 2011 Dec;8(12):1037-40&lt;/RefSource>&lt;PMID Version="1">22020065&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Cell Res. 2012 Jan;22(1):219-36&lt;/RefSource>&lt;PMID Version="1">22143566&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Cell Stem Cell. 2012 Jan 6;10(1):16-28&lt;/RefSource>&lt;PMID Version="1">22226352&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Nat Nanotechnol. 2012 Mar;7(3):185-90&lt;/RefSource>&lt;PMID Version="1">22327876&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Stem Cells Dev. 2012 Apr 10;21(6):977-86&lt;/RefSource>&lt;PMID Version="1">22182484&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Proc Natl Acad Sci U S A. 2012 Jul 3;109(27):E1848-57&lt;/RefSource>&lt;PMID Version="1">22645348&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Cell Stem Cell. 2012 Aug 3;11(2):242-52&lt;/RefSource>&lt;PMID Version="1">22862949&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Annu Rev Cell Dev Biol. 2012;28:523-53&lt;/RefSource>&lt;PMID Version="1">23057746&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Brain Res. 1989 Aug 7;494(1):65-74&lt;/RefSource>&lt;PMID Version="1">2765923&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Science. 1998 Nov 6;282(5391):1145-7&lt;/RefSource>&lt;PMID Version="1">9804556&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>J Mol Histol. 2004 Jun;35(5):463-70&lt;/RefSource>&lt;PMID Version="1">15571324&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Dev Dyn. 2006 Jul;235(7):1994-2002&lt;/RefSource>&lt;PMID Version="1">16649168&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Can J Physiol Pharmacol. 2006 Aug-Sep;84(8-9):935-41&lt;/RefSource>&lt;PMID Version="1">17111039&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Cell Res. 2011 Apr;21(4):579-87&lt;/RefSource>&lt;PMID Version="1">21102549&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Stem Cells. 2007 Apr;25(4):929-38&lt;/RefSource>&lt;PMID Version="1">17185609&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Nat Biotechnol. 2007 Sep;25(9):1015-24&lt;/RefSource>&lt;PMID Version="1">17721512&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Differentiation. 2008 Apr;76(4):357-70&lt;/RefSource>&lt;PMID Version="1">18021257&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Nat Protoc. 2008;3(5):768-76&lt;/RefSource>&lt;PMID Version="1">18451785&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Stem Cells. 2008 Sep;26(9):2257-65&lt;/RefSource>&lt;PMID Version="1">18599809&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Proc Jpn Acad Ser B Phys Biol Sci. 2009;85(8):348-62&lt;/RefSource>&lt;PMID Version="1">19838014&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Stem Cells. 2010 Apr;28(4):713-20&lt;/RefSource>&lt;PMID Version="1">20201064&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Nat Biotechnol. 2010 Jun;28(6):606-10&lt;/RefSource>&lt;PMID Version="1">20512120&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Nat Biotechnol. 2010 Jun;28(6):611-5&lt;/RefSource>&lt;PMID Version="1">20512123&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>PLoS One. 2010;5(6):e11134&lt;/RefSource>&lt;PMID Version="1">20559569&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>BMC Dev Biol. 2010;10:60&lt;/RefSource>&lt;PMID Version="1">20525219&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Am J Physiol Cell Physiol. 2010 Dec;299(6):C1234-49&lt;/RefSource>&lt;PMID Version="1">20844252&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Tissue Eng Part C Methods. 2011 Feb;17(2):193-207&lt;/RefSource>&lt;PMID Version="1">20726687&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Cell Stem Cell. 2011 Feb 4;8(2):228-40&lt;/RefSource>&lt;PMID Version="1">21295278&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Circ Res. 2012 Oct 12;111(9):1125-36&lt;/RefSource>&lt;PMID Version="1">22912385&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Cell Rep. 2012 Nov 29;2(5):1448-60&lt;/RefSource>&lt;PMID Version="1">23103164&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Nat Commun. 2012;3:1236&lt;/RefSource>&lt;PMID Version="1">23212365&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Cell Stem Cell. 2013 Jan 3;12(1):127-37&lt;/RefSource>&lt;PMID Version="1">23168164&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>PLoS One. 2012;7(12):e52405&lt;/RefSource>&lt;PMID Version="1">23300662&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Stem Cells Dev. 2013 Aug 15;22(16):2315-25&lt;/RefSource>&lt;PMID Version="1">23517131&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Nature. 2013 Aug 8;500(7461):222-6&lt;/RefSource>&lt;PMID Version="1">23812591&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Nat Commun. 2014;5:3195&lt;/RefSource>&lt;PMID Version="1">24463987&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Nat Commun. 2014;5:3206&lt;/RefSource>&lt;PMID Version="1">24487777&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Nature. 2008 May 22;453(7194):524-8&lt;/RefSource>&lt;PMID Version="1">18432194&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Circulation. 2003 Apr 15;107(14):1912-6&lt;/RefSource>&lt;PMID Version="1">12668514&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Cardiovasc Res. 2003 May 1;58(2):423-34&lt;/RefSource>&lt;PMID Version="1">12757876&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>JAMA. 1967 Feb 20;199(8):519-24&lt;/RefSource>&lt;PMID Version="1">4960081&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>J Biol Chem. 1981 Jan 25;256(2):964-8&lt;/RefSource>&lt;PMID Version="1">7451483&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Cell Res. 2011 Mar;21(3):518-29&lt;/RefSource>&lt;PMID Version="1">21243013&lt;/PMID>&lt;/CommentsCorrections>&lt;/CommentsCorrectionsList>&lt;MeshHeadingList>&lt;MeshHeading>&lt;DescriptorName MajorTopicYN="N" UI="D002454">Cell Differentiation&lt;/DescriptorName>&lt;TreeCodeList>&lt;TreeCode MajorTopicYN="N">G04.299.151&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;MeshHeading>&lt;DescriptorName MajorTopicYN="N" UI="D003470">Culture Media&lt;/DescriptorName>&lt;TreeCodeList>&lt;TreeCode MajorTopicYN="N">D27.720.470.305&lt;/TreeCode>&lt;TreeCode MajorTopicYN="N">E07.206&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;MeshHeading>&lt;DescriptorName MajorTopicYN="N" UI="D006801">Humans&lt;/DescriptorName>&lt;TreeCodeList>&lt;TreeCode MajorTopicYN="N">B01.050.150.900.649.801.400.112.400.400&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;MeshHeading>&lt;DescriptorName MajorTopicYN="N" UI="D057026">Induced Pluripotent Stem Cells&lt;/DescriptorName>&lt;QualifierName MajorTopicYN="N" UI="Q000166">cytology&lt;/QualifierName>&lt;TreeCodeList>&lt;TreeCode MajorTopicYN="N">A11.872.040.500&lt;/TreeCode>&lt;TreeCode MajorTopicYN="N">A11.872.700.500&lt;/TreeCode>&lt;TreeCode MajorTopicYN="N">Y02.020&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;MeshHeading>&lt;DescriptorName MajorTopicYN="N" UI="D032383">Myocytes, Cardiac&lt;/DescriptorName>&lt;QualifierName MajorTopicYN="Y" UI="Q000166">cytology&lt;/QualifierName>&lt;TreeCodeList>&lt;TreeCode MajorTopicYN="N">A07.541.704.570&lt;/TreeCode>&lt;TreeCode MajorTopicYN="N">A10.690.552.750.570&lt;/TreeCode>&lt;TreeCode MajorTopicYN="N">A11.620.500&lt;/TreeCode>&lt;TreeCode MajorTopicYN="Y">Y02.020&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;/MeshHeadingList>&lt;OtherID Source="NLM">NIHMS599769&lt;/OtherID>&lt;OtherID Source="NLM">PMC4169698&lt;/OtherID>&lt;/item>&lt;contributors count="3">&lt;contributor>&lt;name seq_no="1" role="researcher_id" r_id="D-2336-2015">&lt;display_name>Matsa, Elena&lt;/display_name>&lt;full_name>Matsa, Elena&lt;/full_name>&lt;first_name>Elena&lt;/first_name>&lt;last_name>Matsa&lt;/last_name>&lt;/name>&lt;/contributor>&lt;contributor>&lt;name seq_no="2" role="researcher_id" orcid_id="0000-0002-3019-0170">&lt;display_name>Mordwinkin, Nicholas&lt;/display_name>&lt;full_name>Mordwinkin, Nicholas&lt;/full_name>&lt;first_name>Nicholas&lt;/first_name>&lt;last_name>Mordwinkin&lt;/last_name>&lt;/name>&lt;/contributor>&lt;contributor>&lt;name seq_no="3" role="researcher_id" orcid_id="0000-0002-9991-400X">&lt;display_name>Abilez, Oscar&lt;/display_name>&lt;full_name>Abilez, Oscar&lt;/full_name>&lt;first_name>Oscar&lt;/first_name>&lt;last_name>Abilez&lt;/last_name>&lt;/name>&lt;/contributor>&lt;/contributors>&lt;/static_data>&lt;dynamic_data>&lt;citation_related>&lt;tc_list>&lt;silo_tc coll_id="MEDLINE" local_count="0">&lt;/silo_tc>&lt;/tc_list>&lt;/citation_related>&lt;cluster_related>&lt;identifiers>&lt;identifier type="doi" value="10.1038/nmeth.2999">&lt;/identifier>&lt;identifier type="eissn" value="1548-7105">&lt;/identifier>&lt;identifier type="pmid" value="MEDLINE:24930130">&lt;/identifier>&lt;/identifiers>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>
+        &lt;/records></records></return></ns2:retrieveByIdResponse></soap:Body></soap:Envelope>
+    http_version: 
+  recorded_at: Tue, 30 Jan 2018 23:30:04 GMT
+recorded_with: VCR 4.0.0

--- a/lib/pubmed_harvester.rb
+++ b/lib/pubmed_harvester.rb
@@ -25,7 +25,7 @@ class PubmedHarvester
     # Only clean out manual/batch if there's a mix
     if result.size > 1 && result.any? { |p| p.is_a? Hash }
       result.reject! do |pub|
-        pub.is_a?(Publication) && pub.pub_hash[:provanance] =~ /cap|batch/i
+        pub.is_a?(Publication) && !pub.authoritative_pmid_source?
       end
     end
 

--- a/lib/pubmed_harvester.rb
+++ b/lib/pubmed_harvester.rb
@@ -1,42 +1,49 @@
 class PubmedHarvester
-  # Searches locally (twice), then ScienceWire, then Pubmed for a publication by PubmedId
+  # Searches locally (twice), then ScienceWire/WOS, then Pubmed for a publication by PubmedId
   # Is paranoid, searches both publications and publication_identifiers identifiers for pmid
   # @param [String] pmid Pubmed ID
   # @return [Array<Hash>] publications in BibJson format or, if none found, an empty Array
   def self.search_all_sources_by_pmid(pmid)
-    result = Publication.where(pmid: pmid).to_a # TODO: index manual and batch with pmid?
-    result = [Publication.find_by_pmid_pub_id(pmid)].compact if result.empty?
+    pub = Publication.find_by(pmid: pmid) || Publication.find_by_pmid_pub_id(pmid)
+    return [pub.pub_hash] if pub && pub.authoritative_pmid_source?
+    result = fetch_remote_pubmed(pmid)
+    return result unless result.empty?
+    [pub.pub_hash] # non-authoritative local hit
+  end
 
-    if result.none?(&:authoritative_pmid_source?)
+  # @param [String] pmid Pubmed ID
+  # @return [Array<Hash>] pub_hashes or an empty Array
+  def self.fetch_remote_pubmed(pmid)
+    if Settings.SCIENCEWIRE.enabled
       sw_records_doc = ScienceWireClient.new.pull_records_from_sciencewire_for_pmids(pmid)
-      sw_records_doc.xpath('//PublicationItem').each do |sw_doc|
-        result << SciencewireSourceRecord.convert_sw_publication_doc_to_hash(sw_doc)
+      result = sw_records_doc.xpath('//PublicationItem').map do |sw_doc|
+        add_citation(SciencewireSourceRecord.convert_sw_publication_doc_to_hash(sw_doc))
       end
-
-      if result.none? { |p| p.is_a? Hash }
-        pm_xml = PubmedClient.new.fetch_records_for_pmid_list(pmid)
-        Nokogiri::XML(pm_xml).xpath('//PubmedArticle').each do |doc|
-          result << PubmedSourceRecord.new.convert_pubmed_publication_doc_to_hash(doc)
-        end
-      end
+      return result unless result.empty?
     end
 
-    # If we have more than one result, we could have a mix of local and pubmed/SW records
-    # Only clean out manual/batch if there's a mix
-    if result.size > 1 && result.any? { |p| p.is_a? Hash }
-      result.reject! do |pub|
-        pub.is_a?(Publication) && !pub.authoritative_pmid_source?
-      end
+    # note: only works because all results expected to fit inside one "batch"
+    if Settings.WOS.enabled
+      result = WebOfScience.queries.retrieve_by_pmid([pmid]).next_batch.map { |rec| add_citation(rec.pub_hash) }
+      return result unless result.empty?
     end
 
-    # Turn everything into a pub_hash, then generate citations if needed
-    result.map do |pub|
-      pub_hash = pub.respond_to?(:pub_hash) ? pub.pub_hash : pub
-      cite = Csl::Citation.new(pub_hash)
-      pub_hash[:apa_citation] ||= cite.to_apa_citation
-      pub_hash[:mla_citation] ||= cite.to_mla_citation
-      pub_hash[:chicago_citation] ||= cite.to_chicago_citation
-      pub_hash
+    # PubMed, oddly enough, the last resort
+    pm_xml = PubmedClient.new.fetch_records_for_pmid_list(pmid)
+    Nokogiri::XML(pm_xml).xpath('//PubmedArticle').map do |doc|
+      add_citation(PubmedSourceRecord.new.convert_pubmed_publication_doc_to_hash(doc))
     end
   end
+  private_class_method :fetch_remote_pubmed
+
+  # @param [Hash] pub_hash modifies passed hash to include citation k/v pairs
+  # @return [Hash] the same modified hash
+  def self.add_citation(pub_hash)
+    cite = Csl::Citation.new(pub_hash)
+    pub_hash[:apa_citation] ||= cite.to_apa_citation
+    pub_hash[:mla_citation] ||= cite.to_mla_citation
+    pub_hash[:chicago_citation] ||= cite.to_chicago_citation
+    pub_hash
+  end
+  private_class_method :add_citation
 end

--- a/spec/factories/publication.rb
+++ b/spec/factories/publication.rb
@@ -4,9 +4,9 @@ FactoryBot.define do
     year '1972'
     pub_hash do
       {
-        title: 'How I learned Rails',
-        type: 'article',
-        year: '1972',
+        title: title,
+        type: publication_type,
+        year: year,
         author: [
           { name: 'Jackson, Joe' }
         ],

--- a/spec/lib/pubmed_harvester_spec.rb
+++ b/spec/lib/pubmed_harvester_spec.rb
@@ -1,7 +1,5 @@
-
 describe PubmedHarvester, :vcr do
-  let(:author) { FactoryBot.create :author }
-
+  let(:author) { create :author }
   let(:pub_hash) do
     {
       title: 'some title',
@@ -10,26 +8,29 @@ describe PubmedHarvester, :vcr do
       pages: '34-56',
       author: [{ name: 'jackson joe' }],
       authorship: [{ sul_author_id: author.id, status: 'denied', visibility: 'public', featured: true }],
-      identifier: [{ type: 'x', id: 'y', url: 'z' }]
+      identifier: [{ type: 'x', id: 'y', url: 'z' }],
+      provenance: 'pubmed'
     }
   end
-
-  let(:publication) do
-    FactoryBot.create :pub_with_sw_id_and_pmid, pub_hash: pub_hash
-  end
+  let!(:publication) { create(:publication, pmid: 10_048_354, pub_hash: pub_hash) }
 
   before(:each) do
-    publication
+    allow(Settings.SCIENCEWIRE).to receive(:enabled).and_return(true) # default
+    allow(Settings.WOS).to receive(:enabled).and_return(false) # default
   end
 
   describe '.search_all_sources_by_pmid' do
     it 'searches for a local Publication by pmid and returns a pubhash' do
-      h = PubmedHarvester.search_all_sources_by_pmid 10_048_354
+      expect(ScienceWireClient).not_to receive(:new)
+      expect(PubmedClient).not_to receive(:new)
+      h = PubmedHarvester.search_all_sources_by_pmid(10_048_354)
+      expect(h.size).to eq 1
       expect(h.first[:issn]).to eq '32242424'
     end
 
     it 'searches ScienceWire by pmid when not found locally and returns a pubhash' do
-      h = PubmedHarvester.search_all_sources_by_pmid 10_487_815
+      h = PubmedHarvester.search_all_sources_by_pmid(10_487_815)
+      expect(h.size).to eq 1
       expect(h.first[:sw_id]).to eq '10340243'
       expect(h.first[:chicago_citation]).to match(/Convergence and Correlations/)
     end
@@ -38,7 +39,7 @@ describe PubmedHarvester, :vcr do
       skip 'find an example pubmid not yet in sw'
       # This pmid might eventually show up in SW.  If that's the case, search the recent production logs for publication sourcelookups with this format:
       # /publications/sourcelookup?pmid=
-      h = PubmedHarvester.search_all_sources_by_pmid 24_930_130
+      h = PubmedHarvester.search_all_sources_by_pmid(24_930_130)
       expect(h.first[:provenance]).to eq('pubmed')
       expect(h.first[:identifier]).to include(type: 'doi', id: '10.1038/nmeth.2999', url: 'https://dx.doi.org/10.1038/nmeth.2999')
       expect(h.first[:chicago_citation]).to match(/Chemically Defined Generation/)
@@ -46,32 +47,25 @@ describe PubmedHarvester, :vcr do
 
     context 'mix of local plus SW/pubmed results' do
       it 'filters out batch/manual pubs from the resultset if SW/pubmed records were found' do
-        pub2 = Publication.new
-        pub2.pub_hash = pub_hash
-        pub2.pub_hash[:provanance] = 'batch'
-        pub2.pmid = 10_487_815
-        pub2.save
-
-        h = PubmedHarvester.search_all_sources_by_pmid 10_487_815
+        Publication.create!(
+          pub_hash: pub_hash.merge(provenance: 'batch'),
+          pmid: 10_487_815
+        )
+        expect(PubmedClient).not_to receive(:new)
+        h = PubmedHarvester.search_all_sources_by_pmid(10_487_815)
         expect(h.size).to eq 1
         expect(h.first[:sw_id]).to eq '10340243'
       end
 
       it 'does not do any filtering with a resultset of 2 manual/batch pubs' do
-        ph = pub_hash.clone
-        ph[:provanance] = 'cap'
         publication.pmid = 99_999_999 # Pubmed ID that does not exist
-        publication.pub_hash = ph
-        publication.save
-
-        pub2 = Publication.new
-        pub2.pub_hash = pub_hash
-        pub2.pub_hash[:title] = 'batch pub'
-        pub2.pub_hash[:provanance] = 'batch'
-        pub2.pmid = 99_999_999
-        pub2.save
-
-        h = PubmedHarvester.search_all_sources_by_pmid 99_999_999
+        publication.pub_hash = pub_hash.merge(provenance: 'cap')
+        publication.save!
+        Publication.create!(
+          pub_hash: pub_hash.merge(title: 'batch pub', provenance: 'batch'),
+          pmid: 99_999_999
+        )
+        h = PubmedHarvester.search_all_sources_by_pmid(99_999_999)
         expect(h.size).to eq 2
         expect(h.map { |hash| hash[:title] }).to include('batch pub', 'some title')
       end

--- a/spec/lib/pubmed_harvester_spec.rb
+++ b/spec/lib/pubmed_harvester_spec.rb
@@ -12,14 +12,15 @@ describe PubmedHarvester, :vcr do
       provenance: 'pubmed'
     }
   end
-  let!(:publication) { create(:publication, pmid: 10_048_354, pub_hash: pub_hash) }
 
   before(:each) do
-    allow(Settings.SCIENCEWIRE).to receive(:enabled).and_return(true) # default
-    allow(Settings.WOS).to receive(:enabled).and_return(false) # default
+    allow(Settings.SCIENCEWIRE).to receive(:enabled).and_return(true) # legacy tests VCR'd w/ SW + PubMed
+    allow(Settings.WOS).to receive(:enabled).and_return(false) # but not WOS
   end
 
   describe '.search_all_sources_by_pmid' do
+    let!(:publication) { create(:publication, pmid: 10_048_354, pub_hash: pub_hash) }
+
     it 'searches for a local Publication by pmid and returns a pubhash' do
       expect(ScienceWireClient).not_to receive(:new)
       expect(PubmedClient).not_to receive(:new)
@@ -39,35 +40,101 @@ describe PubmedHarvester, :vcr do
       skip 'find an example pubmid not yet in sw'
       # This pmid might eventually show up in SW.  If that's the case, search the recent production logs for publication sourcelookups with this format:
       # /publications/sourcelookup?pmid=
-      h = PubmedHarvester.search_all_sources_by_pmid(24_930_130)
-      expect(h.first[:provenance]).to eq('pubmed')
-      expect(h.first[:identifier]).to include(type: 'doi', id: '10.1038/nmeth.2999', url: 'https://dx.doi.org/10.1038/nmeth.2999')
-      expect(h.first[:chicago_citation]).to match(/Chemically Defined Generation/)
+      h = PubmedHarvester.search_all_sources_by_pmid(24_930_130).first
+      expect(h[:provenance]).to eq('pubmed')
+      expect(h[:identifier]).to include(type: 'doi', id: '10.1038/nmeth.2999', url: 'https://dx.doi.org/10.1038/nmeth.2999')
+      expect(h[:chicago_citation]).to match(/Chemically Defined Generation/)
     end
 
-    context 'mix of local plus SW/pubmed results' do
-      it 'filters out batch/manual pubs from the resultset if SW/pubmed records were found' do
+    context 'local hits of varied provenance' do
+      before { allow(PubmedHarvester).to receive(:fetch_remote_pubmed).and_return([]) }
+
+      it 'filters out batch/manual pubs from the resultset if previous SW/pubmed records were found' do
         Publication.create!(
           pub_hash: pub_hash.merge(provenance: 'batch'),
           pmid: 10_487_815
         )
-        expect(PubmedClient).not_to receive(:new)
         h = PubmedHarvester.search_all_sources_by_pmid(10_487_815)
         expect(h.size).to eq 1
-        expect(h.first[:sw_id]).to eq '10340243'
       end
 
-      it 'does not do any filtering with a resultset of 2 manual/batch pubs' do
-        publication.pmid = 99_999_999 # Pubmed ID that does not exist
-        publication.pub_hash = pub_hash.merge(provenance: 'cap')
-        publication.save!
-        Publication.create!(
-          pub_hash: pub_hash.merge(title: 'batch pub', provenance: 'batch'),
-          pmid: 99_999_999
-        )
-        h = PubmedHarvester.search_all_sources_by_pmid(99_999_999)
-        expect(h.size).to eq 2
-        expect(h.map { |hash| hash[:title] }).to include('batch pub', 'some title')
+      context 'duplicate PMIDs' do
+        before do
+          publication.pmid = 99_999_999 # Pubmed ID that does not exist
+          publication.pub_hash = pub_hash.merge(provenance: 'cap')
+          publication.save!
+          Publication.create!(
+            pub_hash: pub_hash.merge(title: 'batch pub', provenance: 'batch'),
+            pmid: 99_999_999
+          )
+        end
+
+        it 'returns first of local matches' do
+          h = PubmedHarvester.search_all_sources_by_pmid(99_999_999)
+          expect(h.size).to eq 1
+        end
+      end
+    end
+  end
+
+  # private
+  describe '.fetch_remote_pubmed' do
+    subject(:hits) { described_class.send(:fetch_remote_pubmed, 24_930_130) } # backed by VCR cassettes for each provider
+
+    before(:each) do
+      allow(Settings.SCIENCEWIRE).to receive(:enabled).and_return(false) # default
+      allow(Settings.WOS).to receive(:enabled).and_return(false) # default
+    end
+
+    context 'WOS and ScienceWire, both disabled' do
+      it 'searches only pubmed' do
+        expect(ScienceWireClient).not_to receive(:new)
+        expect(WebOfScience).not_to receive(:queries)
+        expect(hits.size).to eq(1)
+        expect(hits.first[:title]).to eq('Chemically defined generation of human cardiomyocytes.')
+        expect(hits.first[:chicago_citation]).to match(/Chemically Defined Generation/)
+      end
+    end
+
+    context 'WOS disabled, ScienceWire enabled' do
+      before { allow(Settings.SCIENCEWIRE).to receive(:enabled).and_return(true) }
+
+      it 'searches only ScienceWire' do
+        expect(WebOfScience).not_to receive(:queries)
+        expect(PubmedClient).not_to receive(:new)
+        expect(hits.size).to eq(1)
+        expect(hits.first[:title]).to eq('Chemically defined generation of human cardiomyocytes') # no period, meh
+        expect(hits.first[:chicago_citation]).to match(/Chemically Defined Generation/)
+      end
+    end
+
+    context 'WOS enabled, ScienceWire disabled' do
+      before { allow(Settings.WOS).to receive(:enabled).and_return(true) }
+
+      it 'searches only WOS' do
+        expect(ScienceWireClient).not_to receive(:new)
+        expect(PubmedClient).not_to receive(:new)
+        expect(hits.size).to eq(1)
+        expect(hits.first[:title]).to eq('Chemically defined generation of human cardiomyocytes.')
+        expect(hits.first[:chicago_citation]).to match(/Chemically Defined Generation/)
+      end
+    end
+
+    context 'Everything enabled' do
+      before(:each) do
+        allow(Settings.SCIENCEWIRE).to receive(:enabled).and_return(true)
+        allow(Settings.WOS).to receive(:enabled).and_return(true)
+      end
+
+      it 'without hits, fails over across services' do
+        expect(WebOfScience.queries).to receive(:retrieve_by_pmid)
+          .with([24_930_130])
+          .and_return(instance_double(WebOfScience::Retriever, next_batch: WebOfScience::Records.new(records: '<xml/>')))
+        expect(PubmedClient).to receive(:new)
+          .and_return(instance_double(PubmedClient, fetch_records_for_pmid_list: []))
+        expect(ScienceWireClient).to receive(:new)
+          .and_return(instance_double(ScienceWireClient, pull_records_from_sciencewire_for_pmids: Nokogiri::XML('<xml/>')))
+        expect(hits).to eq([])
       end
     end
   end


### PR DESCRIPTION
Fix #690 

- Broke out the remote searching to a private_class_method.
- Changed the expectations w/ regards to local hits based on analysis of actual duplicate values in #693. No reason to present the user with indifferentiable duplicate records.
- Honor configs

100% disinterested in Code Climate Cognitive Complexity for the same reasons as before, already anticipating removing SW code, which would make it pretty basic.  This PR reduces the flagged complexity from 13 to 8.  