### PR TITLE
[WIP] WebOfScience::QueryAuthor - use settings to modify the query time span

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -50,6 +50,7 @@ WOS:
     - WOS
     - MEDLINE
   AUTH_CODE: secret
+  AUTHOR_UPDATE: 30 # days ago
   LOG: log/web_of_science.log
   LOG_LEVEL: warn
 

--- a/lib/tasks/wos.rake
+++ b/lib/tasks/wos.rake
@@ -1,6 +1,13 @@
 namespace :wos do
-  desc 'Harvest from Web of Science, for all authors'
+  desc 'Harvest from Web of Science, for all authors, for all time'
   task harvest_authors: :environment do
+    Settings.WOS.AUTHOR_UPDATE = 0 # harvest publications from the beginning of time
+    WebOfScience.harvester.harvest_all
+  end
+
+  desc 'Harvest monthly updates from Web of Science, for all authors'
+  task harvest_authors_monthly: :environment do
+    Settings.WOS.AUTHOR_UPDATE = 30 # harvest publications from the past 30 days
     WebOfScience.harvester.harvest_all
   end
 

--- a/lib/web_of_science/query_author.rb
+++ b/lib/web_of_science/query_author.rb
@@ -32,8 +32,24 @@ module WebOfScience
       # @return [Hash]
       def author_query
         params = queries.params_for_fields(empty_fields)
-        params[:queryParameters][:userQuery] = "AU=(#{names}) AND AD=(#{institution})"
+        update_time_span(params)
+        update_user_query(params)
         params
+      end
+
+      # Use Settings to limit the time span for harvesting publications to the past N days
+      # @param [Hash] params from queries.params_for_fields
+      # @return [void]
+      def update_time_span(params)
+        return if Settings.WOS.AUTHOR_UPDATE.blank? || Settings.WOS.AUTHOR_UPDATE <= 0
+        days_ago = (Time.zone.now - Settings.WOS.AUTHOR_UPDATE.days).strftime('%Y-%m-%d')
+        params[:queryParameters][:timeSpan][:begin] = days_ago
+      end
+
+      # @param [Hash] params from queries.params_for_fields
+      # @return [void]
+      def update_user_query(params)
+        params[:queryParameters][:userQuery] = "AU=(#{names}) AND AD=(#{institution})"
       end
 
       def empty_fields

--- a/spec/fixtures/wos_client/wos_search_author_query_response.xml
+++ b/spec/fixtures/wos_client/wos_search_author_query_response.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <ns2:searchResponse xmlns:ns2="http://woksearch.v3.wokmws.thomsonreuters.com">
+      <return>
+        <queryId>1</queryId>
+        <recordsFound>2</recordsFound>
+        <recordsSearched>152552</recordsSearched>
+        <optionValue>
+          <label>RecordIDs</label>
+          <value>MEDLINE:29218869</value>
+          <value>WOS:000422723300003</value>
+        </optionValue>
+        <records>&lt;records xmlns="http://scientific.thomsonreuters.com/schema/wok5.4/public/Fields">
+  &lt;REC r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>MEDLINE:29218869&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>
+  &lt;REC r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000422723300003&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>
+  &lt;/records></records>
+      </return>
+    </ns2:searchResponse>
+  </soap:Body>
+</soap:Envelope>

--- a/spec/lib/web_of_science/query_author_spec.rb
+++ b/spec/lib/web_of_science/query_author_spec.rb
@@ -1,0 +1,140 @@
+# http://savonrb.com/version2/testing.html
+# require the helper module
+require 'savon/mock/spec_helper'
+
+describe WebOfScience::QueryAuthor do
+  include Savon::SpecHelper
+
+  # set Savon in and out of mock mode
+  before(:all) { savon.mock!   }
+  after(:all)  { savon.unmock! }
+
+  subject(:query_author) { described_class.new(author) }
+
+  let(:names) { query_author.send(:names) }
+  let(:institution) { query_author.send(:institution) }
+
+  # These wos_uids are in the wos_search_author_query_response.xml
+  let(:wos_uids) { %w[MEDLINE:29218869 WOS:000422723300003] }
+  let(:wos_search_author_query_response) { File.read('spec/fixtures/wos_client/wos_search_author_query_response.xml') }
+
+  let(:author) do
+    # public data from
+    # - https://stanfordwho.stanford.edu
+    # - https://med.stanford.edu/profiles/russ-altman
+    author = FactoryBot.create(:author,
+                                 preferred_first_name: 'Russ',
+                                 preferred_last_name: 'Altman',
+                                 preferred_middle_name: 'Biagio',
+                                 email: 'Russ.Altman@stanford.edu',
+                                 cap_import_enabled: true)
+    # create some `author.alternative_identities`
+    FactoryBot.create(:author_identity,
+                       author: author,
+                       first_name: 'R',
+                       middle_name: 'B',
+                       last_name: 'Altman',
+                       email: nil,
+                       institution: 'Stanford University')
+    FactoryBot.create(:author_identity,
+                       author: author,
+                       first_name: 'Russ',
+                       middle_name: nil,
+                       last_name: 'Altman',
+                       email: nil,
+                       institution: nil)
+    author
+  end
+
+  it 'works' do
+    expect(query_author).to be_a described_class
+  end
+
+  describe '#uids' do
+    let(:wos_auth_response) { File.read('spec/fixtures/wos_client/authenticate.xml') }
+
+    before do
+      wos_client = WebOfScience::Client.new('secret')
+      allow(WebOfScience).to receive(:client).and_return(wos_client)
+      savon.expects(:authenticate).returns(wos_auth_response)
+      savon.expects(:search).with(message: :any).returns(wos_search_author_query_response)
+    end
+
+    it 'returns an Array<String> of WOS-UIDs' do
+      expect(query_author.uids).to eq wos_uids
+    end
+  end
+
+  # PRIVATE
+
+  describe '#author_query' do
+    let(:query) { query_author.send(:author_query) }
+    let(:params) { query[:queryParameters] }
+
+    it 'contains query parameters' do
+      expect(query).to include(queryParameters: Hash)
+      expect(params).to include(databaseId: String, userQuery: String, timeSpan: Hash, queryLanguage: String)
+    end
+
+    it 'contains author name' do
+      expect(params[:userQuery]).to include(names)
+    end
+
+    it 'contains author institution' do
+      expect(params[:userQuery]).to include(institution)
+    end
+
+    it 'contains timeSpan' do
+      expect(params[:timeSpan]).to include(begin: String, end: String)
+    end
+
+    it 'uses settings to determine the timeSpan when Settings.WOS.AUTHOR_UPDATE > 0' do
+      settings = double
+      expect(settings).to receive(:AUTHOR_UPDATE).and_return(30).at_least(:once)
+      expect(settings).to receive(:ACCEPTED_DBS).and_return(%w[WOS MEDLINE])
+      expect(Settings).to receive(:WOS).and_return(settings).at_least(:once)
+      # Try to put Dr Who out of a job so this spec might work
+      now = Time.zone.now
+      allow(Time.zone).to receive(:now).and_return(now)
+      start = (now - Settings.WOS.AUTHOR_UPDATE.days).strftime('%Y-%m-%d')
+      stop = now.strftime('%Y-%m-%d')
+      expect(params[:timeSpan]).to eq(begin: start, end: stop)
+    end
+
+    it 'uses a default timeSpan when Settings.WOS.AUTHOR_UPDATE <= 0' do
+      settings = double
+      expect(settings).to receive(:AUTHOR_UPDATE).and_return(0).at_least(:once)
+      expect(settings).to receive(:ACCEPTED_DBS).and_return(%w[WOS MEDLINE])
+      expect(Settings).to receive(:WOS).and_return(settings).at_least(:once)
+      # Try to put Dr Who out of a job so this spec might work
+      now = Time.zone.now
+      allow(Time.zone).to receive(:now).and_return(now)
+      start = WebOfScience::Queries::START_DATE # default start date
+      stop = now.strftime('%Y-%m-%d')
+      expect(params[:timeSpan]).to eq(begin: start, end: stop)
+    end
+  end
+
+  describe '#names' do
+    #=> "\"Altman,Russ\" or \"Altman,R\" or \"Altman,Russ,Biagio\" or \"Altman,Russ,B\" or \"Altman,R,B\""
+    it 'author name includes the preferred last name' do
+      expect(Agent::AuthorName).to receive(:new).and_call_original
+      expect(names).to include(author.preferred_last_name)
+    end
+  end
+
+  describe '#institution' do
+    it 'author institution is a normalized name' do
+      expect(Agent::AuthorInstitution).to receive(:new).and_call_original
+      expect(institution).to eq 'stanford'
+    end
+  end
+
+  describe '#empty_fields' do
+    let(:fields) { query_author.send(:empty_fields) }
+
+    it 'has collections with empty fields' do
+      expect(fields).to include(collectionName: String, fieldName: [''])
+    end
+  end
+end


### PR DESCRIPTION
### Update
- work on this branch is getting extracted in other PRs
- an alternative implementation is in progress in #711 



Fix #663

- this applies the spirit of #663, if not the letter.
- had to add specs for this class, which was otherwise exercised by the harvester specs
- added rake tasks so the suite of tasks includes:
  - harvest all authors, for the past 30 days
  - harvest all authors, for all time

## Implementation Notes
- this applies a specific setting to change the time span only for author search queries
  - the scope of the issue does not require surfacing a generic time-span option for all queries
  - for most queries, the encapsulated time span in WOS-queries is the appropriate one to use
- as the spec fixture indicates, when using this PR, the records matched for Russ Altman decrease from 400+ matches to only 2 for the period of Jan 2018; this will have the desired effect of substantially speeding up the scheduled harvests for authors
