### PR TITLE
Harvester::Base - allow options

### DIFF
--- a/lib/harvester/base.rb
+++ b/lib/harvester/base.rb
@@ -2,20 +2,22 @@ module Harvester
   # An iota of abstraction for things a harvester must do.
   # The starting point is always one or more Authors.
   class Base
+    # @param [Hash] options
     # @return [void]
-    def harvest_all
+    def harvest_all(options = {})
       total = authors_query.count
       count = 0
       authors_query.find_in_batches(batch_size: batch_size).each do |batch|
-        harvest(batch)
+        harvest(batch, options)
         count += batch_size
         logger.info "completed #{count} of #{total} authors for harvest"
       end
     end
 
     # @param [Enumerable<Author>] _authors
+    # @param [Hash] _options
     # @return [void]
-    def harvest(_authors)
+    def harvest(_authors, _options = {})
       raise "harvest must be implemented in subclass"
     end
 


### PR DESCRIPTION
Open the harvest base class to harvesting options.  The base class is agnostic to any details of the options and uses none by default.