### PR TITLE
WOS harvester options

### DIFF
--- a/lib/web_of_science/harvester.rb
+++ b/lib/web_of_science/harvester.rb
@@ -11,11 +11,11 @@ module WebOfScience
 
     # @param [Enumerable<Author>] authors
     # @return [void]
-    def harvest(authors)
+    def harvest(authors, options = {})
       log_info(nil, "started harvest(authors) batch - #{authors.count} authors")
       author_success = 0
       authors.each do |author|
-        process_author(author)
+        process_author(author, options)
         author_success += 1
       end
       log_info(nil, "completed harvest(authors) batch - #{author_success} processed")
@@ -26,10 +26,10 @@ module WebOfScience
     # Harvest all publications for an author
     # @param author [Author]
     # @return [Array<String>] WosUIDs that create Publications
-    def process_author(author)
+    def process_author(author, options = {})
       raise(ArgumentError, 'author must be an Author') unless author.is_a? Author
       log_info(author, 'processing')
-      uids = WebOfScience::QueryAuthor.new(author).uids
+      uids = WebOfScience::QueryAuthor.new(author, options).uids
       log_info(author, "#{uids.count} found by author query")
       uids = process_uids(author, uids)
       log_info(author, "#{uids.count} new publications")

--- a/lib/web_of_science/query_author.rb
+++ b/lib/web_of_science/query_author.rb
@@ -3,7 +3,7 @@ module WebOfScience
   # Use author name-institution logic to find WOS publications for an Author
   class QueryAuthor
 
-    def initialize(author)
+    def initialize(author, options = {})
       raise(ArgumentError, 'author must be an Author') unless author.is_a? Author
       @names = Agent::AuthorName.new(
         author.last_name,
@@ -11,6 +11,7 @@ module WebOfScience
         Settings.HARVESTER.USE_MIDDLE_NAME ? author.middle_name : ''
       ).text_search_query
       @institution = Agent::AuthorInstitution.new(author.institution).normalize_name
+      @options = options
     end
 
     # Find all WOS-UIDs for an author
@@ -28,6 +29,7 @@ module WebOfScience
 
       attr_reader :names
       attr_reader :institution
+      attr_reader :options
 
       # @return [Hash]
       def author_query


### PR DESCRIPTION
This is a necessary first step toward an alternative implementation to #699 
- this propagates generic options into the author harvest and queries
- it defaults to empty options