### PR TITLE
Query efficiently

### DIFF
--- a/lib/web_of_science/contributions.rb
+++ b/lib/web_of_science/contributions.rb
@@ -76,30 +76,11 @@ module WebOfScience
     # @param value [String]
     # @return [Boolean] contribution exists
     def contribution_by_identifier?(author, type, value)
-      contrib = contribution_by_identifier(author, type, value)
+      return false if type.blank? || value.blank?
+      pub_id = PublicationIdentifier.find_by(identifier_type: type, identifier_value: value)
+      return false if pub_id.nil?
+      contrib = find_or_create_contribution(author, pub_id.publication)
       contrib.nil? ? false : contrib.persisted?
     end
-
-    # Find any matching contribution by author and PublicationIdentifier
-    # @param author [Author]
-    # @param type [String]
-    # @param value [String]
-    # @return [Contribution, nil]
-    def contribution_by_identifier(author, type, value)
-      pub_id = publication_identifier(type, value)
-      return if pub_id.nil?
-      find_or_create_contribution(author, pub_id.publication)
-    end
-
-    # Is there a PublicationIdentifier matching the type and value?
-    # @param type [String]
-    # @param value [String]
-    # @return [PublicationIdentifier, nil]
-    def publication_identifier(type, value)
-      return if type.blank? || value.blank?
-      pub_ids = PublicationIdentifier.where(identifier_type: type, identifier_value: value)
-      pub_ids.empty? ? nil : pub_ids.first
-    end
-
   end
 end

--- a/lib/web_of_science/contributions.rb
+++ b/lib/web_of_science/contributions.rb
@@ -53,7 +53,7 @@ module WebOfScience
     # @param [Author] author
     # @param [WebOfScience::Record] record
     # @return [::Contribution, nil] a matched or newly minted Contribution
-    def found_contribution?(author, record)
+    def matching_contribution(author, record)
       pub = Publication.joins(:publication_identifiers).where(
         "publication_identifiers.identifier_value IS NOT NULL AND (
          (publication_identifiers.identifier_type = 'WosUID' AND publication_identifiers.identifier_value = ?) OR

--- a/lib/web_of_science/process_record.rb
+++ b/lib/web_of_science/process_record.rb
@@ -49,14 +49,14 @@ module WebOfScience
       # @return [String, nil] WosUID that create a new Publication
       def process_record
         save_record # as WebOfScienceSourceRecord
-        return if found_contribution?(author, record)
+        return if matching_contribution(author, record)
         contrib_persisted = create_publication
         pubmed_addition
         record.uid if contrib_persisted
       end
 
       # Save a new WebOfScienceSourceRecord
-      # Note: add nothing to PublicationIdentifiers here, or found_contribution? could skip processing this record
+      # Note: add nothing to PublicationIdentifiers here, or matching_contribution could skip processing this record
       def save_record
         return unless WebOfScienceSourceRecord.find_by(uid: record.uid).nil?
         attr = { source_data: record.to_xml }

--- a/lib/web_of_science/process_records.rb
+++ b/lib/web_of_science/process_records.rb
@@ -98,33 +98,18 @@ module WebOfScience
       # @return [void]
       def process_links
         links = retrieve_links
-        records.each { |rec| update_links(rec, links[rec.uid]) }
+        records.each { |rec| rec.identifiers.update(links[rec.uid]) if rec.database == 'WOS' }
       rescue StandardError => err
-        message = "Author: #{author.id}, process_links failed"
-        NotificationManager.error(err, message, self)
+        NotificationManager.error(err, "Author: #{author.id}, process_links failed", self)
       end
 
       # Retrieve a batch of publication identifiers for WOS records from the Links-API
       # @example {"WOS:000288663100014"=>{"pmid"=>"21253920", "doi"=>"10.1007/s12630-011-9462-1"}}
       # @return [Hash<String => Hash<String => String>>]
       def retrieve_links
-        uids = records.map { |rec| rec.uid if rec.database == 'WOS' }.compact
-        links_client.links uids
+        links_client.links records.map { |rec| rec.uid if rec.database == 'WOS' }.compact
       rescue StandardError => err
-        message = "Author: #{author.id}, retrieve_links failed"
-        NotificationManager.error(err, message, self)
+        NotificationManager.error(err, "Author: #{author.id}, retrieve_links failed", self)
       end
-
-      # @param record [WebOfScience::Record]
-      # @param links [Hash<String => String>] other identifiers (from Links API)
-      # @return [void]
-      def update_links(record, links)
-        return unless record.database == 'WOS'
-        record.identifiers.update links
-      rescue StandardError => err
-        message = "Author: #{author.id}, #{record.uid}, update_links failed"
-        NotificationManager.error(err, message, self)
-      end
-
   end
 end

--- a/lib/web_of_science/process_records.rb
+++ b/lib/web_of_science/process_records.rb
@@ -43,7 +43,7 @@ module WebOfScience
       def create_publications
         select_new_wos_records # cf. WebOfScienceSourceRecord
         save_wos_records # save WebOfScienceSourceRecord
-        records.select! { |rec| !found_contribution?(author, rec) && create_publication(rec) }
+        records.select! { |rec| !matching_contribution(author, rec) && create_publication(rec) }
         pubmed_additions(records)
         records.map(&:uid)
       end

--- a/lib/web_of_science/process_records.rb
+++ b/lib/web_of_science/process_records.rb
@@ -71,13 +71,12 @@ module WebOfScience
       # @param [WebOfScience::Record] record
       # @return [Boolean] WebOfScience::Record created a new Publication?
       def create_publication(record)
-        pub = Publication.new(
+        pub = Publication.create!(
           active: true,
           pub_hash: record.pub_hash,
-          wos_uid: record.uid
+          wos_uid: record.uid,
+          pubhash_needs_update: true
         )
-        pub.pubhash_needs_update!
-        pub.save!
         contrib = find_or_create_contribution(author, pub)
         contrib.persisted?
       rescue StandardError => err


### PR DESCRIPTION
Most of the work here is in `WebOfScience::Contributions`.
- use `find_or_create_by!` with a block to collapse two methods.  
- several guard clause checks move further up the chain
- Avoid querying `publication_identifiers` up to 4x serially by using an single query covering all 4 types.  The volume of these queries were indicated as one bottleneck in #671.
- Return fewer Booleans.  Instead: for the `true` case, return an object the caller might use (to avoid another query), for `false`, return `nil`.  

The resulting SQL (from execution) looks like:
```
SELECT  `publications`.* FROM `publications` INNER JOIN `publication_identifiers` ON `publication_identifiers`.`publication_id` = `publications`.`id` 
WHERE (publication_identifiers.identifier_value IS NOT NULL AND (
     (publication_identifiers.identifier_type = 'WosUID' AND publication_identifiers.identifier_value = 1) OR
     (publication_identifiers.identifier_type = 'WosItemID' AND publication_identifiers.identifier_value = 2) OR
     (publication_identifiers.identifier_type = 'doi' AND publication_identifiers.identifier_value = 3) OR
     (publication_identifiers.identifier_type = 'pmid' AND publication_identifiers.identifier_value = 4)))  
ORDER BY CASE
          WHEN publication_identifiers.identifier_type = 'WosUID' THEN 0
          WHEN publication_identifiers.identifier_type = 'WosItemID' THEN 1
          WHEN publication_identifiers.identifier_type = 'doi' THEN 2
          WHEN publication_identifiers.identifier_type = 'pmid' THEN 3
END LIMIT 1
```