### PR TITLE
Add a validator for identifier_type presence

### DIFF
--- a/app/models/publication_identifier.rb
+++ b/app/models/publication_identifier.rb
@@ -1,8 +1,8 @@
 class PublicationIdentifier < ActiveRecord::Base
   belongs_to :publication, required: true, inverse_of: :publication_identifiers
+  validates :identifier_type, presence: true
 
-  # A pub_hash[:identifier] entry
-  # @return [Hash]
+  # @return [Hash<Symbol => String>] an entry for pub_hash[:identifier]
   def identifier
     ident_hash = {}
     ident_hash[:type] = identifier_type if identifier_type.present?
@@ -12,9 +12,9 @@ class PublicationIdentifier < ActiveRecord::Base
   end
 
   # Update the identifier_type entries in publication.pub_hash[:identifier];
-  # the publication.pub_hash[:identifier] is not persisted by this method, to
+  # the publication is not persisted by this method, to
   # avoid complex recurrent call stacks in the rails callback stack.
-  # @param delete [Boolean] delete this identifier from the pub_hash[:identifier] (default: false)
+  # @param delete [Boolean] delete this identifier from pub_hash[:identifier]
   def pub_hash_update(delete: false)
     publication.pub_hash[:identifier] = pub_hash_reject
     publication.pub_hash[:identifier] << identifier unless delete
@@ -29,5 +29,4 @@ class PublicationIdentifier < ActiveRecord::Base
       pub_ids = publication.pub_hash[:identifier] || []
       pub_ids.reject { |id| id[:type] == identifier_type }
     end
-
 end


### PR DESCRIPTION
Obviously, the pub ID record is useless if it doesn't identify what kind of ID it is.

We would want to add validation for `identifier_value` as well, but, ironically, that is blocked because it breaks dozens of lines of specs for code designed to clean up Pub IDs.  So the code meant to clean up values is what prevents us from ensuring values are even there.  :\

TODO: We could also choose to enumerate valid values for type.