### PR TITLE
WebOfScience WSDL stubs

### DIFF
--- a/spec/fixtures/wos_client/authenticate_wsdl.xml
+++ b/spec/fixtures/wos_client/authenticate_wsdl.xml
@@ -1,0 +1,189 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<wsdl:definitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="http://auth.cxf.wokmws.thomsonreuters.com" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" name="WOKMWSAuthenticateService" targetNamespace="http://auth.cxf.wokmws.thomsonreuters.com">
+    <wsdl:types>
+        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://auth.cxf.wokmws.thomsonreuters.com" targetNamespace="http://auth.cxf.wokmws.thomsonreuters.com" version="1.0">
+            <xs:element name="AuthenticationException" type="tns:AuthenticationException"/>
+            <xs:element name="ESTIWSException" type="tns:ESTIWSException"/>
+            <xs:element name="InternalServerException" type="tns:InternalServerException"/>
+            <xs:element name="InvalidInputException" type="tns:InvalidInputException"/>
+            <xs:element name="QueryException" type="tns:QueryException"/>
+            <xs:element name="SessionException" type="tns:SessionException"/>
+            <xs:element name="authenticate" type="tns:authenticate"/>
+            <xs:element name="authenticateResponse" type="tns:authenticateResponse"/>
+            <xs:element name="closeSession" type="tns:closeSession"/>
+            <xs:element name="closeSessionResponse" type="tns:closeSessionResponse"/>
+            <xs:complexType name="closeSession">
+                <xs:sequence/>
+            </xs:complexType>
+            <xs:complexType name="closeSessionResponse">
+                <xs:sequence/>
+            </xs:complexType>
+            <xs:complexType name="QueryException">
+                <xs:sequence/>
+            </xs:complexType>
+            <xs:complexType name="ESTIWSException">
+                <xs:sequence/>
+            </xs:complexType>
+            <xs:complexType name="InvalidInputException">
+                <xs:sequence/>
+            </xs:complexType>
+            <xs:complexType name="InternalServerException">
+                <xs:sequence/>
+            </xs:complexType>
+            <xs:complexType name="SessionException">
+                <xs:sequence/>
+            </xs:complexType>
+            <xs:complexType name="AuthenticationException">
+                <xs:sequence/>
+            </xs:complexType>
+            <xs:complexType name="authenticate">
+                <xs:sequence/>
+            </xs:complexType>
+            <xs:complexType name="authenticateResponse">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="return" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
+        </xs:schema>
+    </wsdl:types>
+    <wsdl:message name="closeSession">
+        <wsdl:part element="tns:closeSession" name="parameters">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="QueryException_Exception">
+        <wsdl:part element="tns:QueryException" name="QueryException_Exception">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="ESTIWSException_Exception">
+        <wsdl:part element="tns:ESTIWSException" name="ESTIWSException_Exception">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="InvalidInputException_Exception">
+        <wsdl:part element="tns:InvalidInputException" name="InvalidInputException_Exception">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="InternalServerException_Exception">
+        <wsdl:part element="tns:InternalServerException" name="InternalServerException_Exception">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="SessionException_Exception">
+        <wsdl:part element="tns:SessionException" name="SessionException_Exception">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="authenticate">
+        <wsdl:part element="tns:authenticate" name="parameters">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="closeSessionResponse">
+        <wsdl:part element="tns:closeSessionResponse" name="parameters">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="authenticateResponse">
+        <wsdl:part element="tns:authenticateResponse" name="parameters">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="AuthenticationException_Exception">
+        <wsdl:part element="tns:AuthenticationException" name="AuthenticationException_Exception">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:portType name="WOKMWSAuthenticate">
+        <wsdl:operation name="closeSession">
+            <wsdl:input message="tns:closeSession" name="closeSession">
+            </wsdl:input>
+            <wsdl:output message="tns:closeSessionResponse" name="closeSessionResponse">
+            </wsdl:output>
+            <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="authenticate">
+            <wsdl:input message="tns:authenticate" name="authenticate">
+            </wsdl:input>
+            <wsdl:output message="tns:authenticateResponse" name="authenticateResponse">
+            </wsdl:output>
+            <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="WOKMWSAuthenticateServiceSoapBinding" type="tns:WOKMWSAuthenticate">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="closeSession">
+            <soap:operation soapAction="" style="document"/>
+            <wsdl:input name="closeSession">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output name="closeSessionResponse">
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="authenticate">
+            <soap:operation soapAction="" style="document"/>
+            <wsdl:input name="authenticate">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output name="authenticateResponse">
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="WOKMWSAuthenticateService">
+        <wsdl:port binding="tns:WOKMWSAuthenticateServiceSoapBinding" name="WOKMWSAuthenticatePort">
+            <soap:address location="http://search.webofknowledge.com/esti/wokmws/ws/WOKMWSAuthenticate"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/spec/fixtures/wos_client/authenticate_wsdl.xml
+++ b/spec/fixtures/wos_client/authenticate_wsdl.xml
@@ -1,189 +1,188 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<wsdl:definitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="http://auth.cxf.wokmws.thomsonreuters.com" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" name="WOKMWSAuthenticateService" targetNamespace="http://auth.cxf.wokmws.thomsonreuters.com">
-    <wsdl:types>
-        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://auth.cxf.wokmws.thomsonreuters.com" targetNamespace="http://auth.cxf.wokmws.thomsonreuters.com" version="1.0">
-            <xs:element name="AuthenticationException" type="tns:AuthenticationException"/>
-            <xs:element name="ESTIWSException" type="tns:ESTIWSException"/>
-            <xs:element name="InternalServerException" type="tns:InternalServerException"/>
-            <xs:element name="InvalidInputException" type="tns:InvalidInputException"/>
-            <xs:element name="QueryException" type="tns:QueryException"/>
-            <xs:element name="SessionException" type="tns:SessionException"/>
-            <xs:element name="authenticate" type="tns:authenticate"/>
-            <xs:element name="authenticateResponse" type="tns:authenticateResponse"/>
-            <xs:element name="closeSession" type="tns:closeSession"/>
-            <xs:element name="closeSessionResponse" type="tns:closeSessionResponse"/>
-            <xs:complexType name="closeSession">
-                <xs:sequence/>
-            </xs:complexType>
-            <xs:complexType name="closeSessionResponse">
-                <xs:sequence/>
-            </xs:complexType>
-            <xs:complexType name="QueryException">
-                <xs:sequence/>
-            </xs:complexType>
-            <xs:complexType name="ESTIWSException">
-                <xs:sequence/>
-            </xs:complexType>
-            <xs:complexType name="InvalidInputException">
-                <xs:sequence/>
-            </xs:complexType>
-            <xs:complexType name="InternalServerException">
-                <xs:sequence/>
-            </xs:complexType>
-            <xs:complexType name="SessionException">
-                <xs:sequence/>
-            </xs:complexType>
-            <xs:complexType name="AuthenticationException">
-                <xs:sequence/>
-            </xs:complexType>
-            <xs:complexType name="authenticate">
-                <xs:sequence/>
-            </xs:complexType>
-            <xs:complexType name="authenticateResponse">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="return" type="xs:string"/>
-                </xs:sequence>
-            </xs:complexType>
-        </xs:schema>
-    </wsdl:types>
-    <wsdl:message name="closeSession">
-        <wsdl:part element="tns:closeSession" name="parameters">
-        </wsdl:part>
-    </wsdl:message>
-    <wsdl:message name="QueryException_Exception">
-        <wsdl:part element="tns:QueryException" name="QueryException_Exception">
-        </wsdl:part>
-    </wsdl:message>
-    <wsdl:message name="ESTIWSException_Exception">
-        <wsdl:part element="tns:ESTIWSException" name="ESTIWSException_Exception">
-        </wsdl:part>
-    </wsdl:message>
-    <wsdl:message name="InvalidInputException_Exception">
-        <wsdl:part element="tns:InvalidInputException" name="InvalidInputException_Exception">
-        </wsdl:part>
-    </wsdl:message>
-    <wsdl:message name="InternalServerException_Exception">
-        <wsdl:part element="tns:InternalServerException" name="InternalServerException_Exception">
-        </wsdl:part>
-    </wsdl:message>
-    <wsdl:message name="SessionException_Exception">
-        <wsdl:part element="tns:SessionException" name="SessionException_Exception">
-        </wsdl:part>
-    </wsdl:message>
-    <wsdl:message name="authenticate">
-        <wsdl:part element="tns:authenticate" name="parameters">
-        </wsdl:part>
-    </wsdl:message>
-    <wsdl:message name="closeSessionResponse">
-        <wsdl:part element="tns:closeSessionResponse" name="parameters">
-        </wsdl:part>
-    </wsdl:message>
-    <wsdl:message name="authenticateResponse">
-        <wsdl:part element="tns:authenticateResponse" name="parameters">
-        </wsdl:part>
-    </wsdl:message>
-    <wsdl:message name="AuthenticationException_Exception">
-        <wsdl:part element="tns:AuthenticationException" name="AuthenticationException_Exception">
-        </wsdl:part>
-    </wsdl:message>
-    <wsdl:portType name="WOKMWSAuthenticate">
-        <wsdl:operation name="closeSession">
-            <wsdl:input message="tns:closeSession" name="closeSession">
-            </wsdl:input>
-            <wsdl:output message="tns:closeSessionResponse" name="closeSessionResponse">
-            </wsdl:output>
-            <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="authenticate">
-            <wsdl:input message="tns:authenticate" name="authenticate">
-            </wsdl:input>
-            <wsdl:output message="tns:authenticateResponse" name="authenticateResponse">
-            </wsdl:output>
-            <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
-            </wsdl:fault>
-        </wsdl:operation>
-    </wsdl:portType>
-    <wsdl:binding name="WOKMWSAuthenticateServiceSoapBinding" type="tns:WOKMWSAuthenticate">
-        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
-        <wsdl:operation name="closeSession">
-            <soap:operation soapAction="" style="document"/>
-            <wsdl:input name="closeSession">
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output name="closeSessionResponse">
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="SessionException_Exception">
-                <soap:fault name="SessionException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="AuthenticationException_Exception">
-                <soap:fault name="AuthenticationException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="ESTIWSException_Exception">
-                <soap:fault name="ESTIWSException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="InvalidInputException_Exception">
-                <soap:fault name="InvalidInputException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="InternalServerException_Exception">
-                <soap:fault name="InternalServerException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="QueryException_Exception">
-                <soap:fault name="QueryException_Exception" use="literal"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="authenticate">
-            <soap:operation soapAction="" style="document"/>
-            <wsdl:input name="authenticate">
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output name="authenticateResponse">
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="SessionException_Exception">
-                <soap:fault name="SessionException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="AuthenticationException_Exception">
-                <soap:fault name="AuthenticationException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="ESTIWSException_Exception">
-                <soap:fault name="ESTIWSException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="InvalidInputException_Exception">
-                <soap:fault name="InvalidInputException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="InternalServerException_Exception">
-                <soap:fault name="InternalServerException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="QueryException_Exception">
-                <soap:fault name="QueryException_Exception" use="literal"/>
-            </wsdl:fault>
-        </wsdl:operation>
-    </wsdl:binding>
-    <wsdl:service name="WOKMWSAuthenticateService">
-        <wsdl:port binding="tns:WOKMWSAuthenticateServiceSoapBinding" name="WOKMWSAuthenticatePort">
-            <soap:address location="http://search.webofknowledge.com/esti/wokmws/ws/WOKMWSAuthenticate"/>
-        </wsdl:port>
-    </wsdl:service>
+<?xml version='1.0' encoding='UTF-8'?><wsdl:definitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="http://auth.cxf.wokmws.thomsonreuters.com" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" name="WOKMWSAuthenticateService" targetNamespace="http://auth.cxf.wokmws.thomsonreuters.com">
+  <wsdl:types>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://auth.cxf.wokmws.thomsonreuters.com" targetNamespace="http://auth.cxf.wokmws.thomsonreuters.com" version="1.0">
+<xs:element name="AuthenticationException" type="tns:AuthenticationException"/>
+<xs:element name="ESTIWSException" type="tns:ESTIWSException"/>
+<xs:element name="InternalServerException" type="tns:InternalServerException"/>
+<xs:element name="InvalidInputException" type="tns:InvalidInputException"/>
+<xs:element name="QueryException" type="tns:QueryException"/>
+<xs:element name="SessionException" type="tns:SessionException"/>
+<xs:element name="authenticate" type="tns:authenticate"/>
+<xs:element name="authenticateResponse" type="tns:authenticateResponse"/>
+<xs:element name="closeSession" type="tns:closeSession"/>
+<xs:element name="closeSessionResponse" type="tns:closeSessionResponse"/>
+<xs:complexType name="closeSession">
+    <xs:sequence/>
+  </xs:complexType>
+<xs:complexType name="closeSessionResponse">
+    <xs:sequence/>
+  </xs:complexType>
+<xs:complexType name="QueryException">
+    <xs:sequence/>
+  </xs:complexType>
+<xs:complexType name="ESTIWSException">
+    <xs:sequence/>
+  </xs:complexType>
+<xs:complexType name="InvalidInputException">
+    <xs:sequence/>
+  </xs:complexType>
+<xs:complexType name="InternalServerException">
+    <xs:sequence/>
+  </xs:complexType>
+<xs:complexType name="SessionException">
+    <xs:sequence/>
+  </xs:complexType>
+<xs:complexType name="AuthenticationException">
+    <xs:sequence/>
+  </xs:complexType>
+<xs:complexType name="authenticate">
+    <xs:sequence/>
+  </xs:complexType>
+<xs:complexType name="authenticateResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="return" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>
+  </wsdl:types>
+  <wsdl:message name="closeSession">
+    <wsdl:part element="tns:closeSession" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="QueryException_Exception">
+    <wsdl:part element="tns:QueryException" name="QueryException_Exception">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="ESTIWSException_Exception">
+    <wsdl:part element="tns:ESTIWSException" name="ESTIWSException_Exception">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="InvalidInputException_Exception">
+    <wsdl:part element="tns:InvalidInputException" name="InvalidInputException_Exception">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="InternalServerException_Exception">
+    <wsdl:part element="tns:InternalServerException" name="InternalServerException_Exception">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="SessionException_Exception">
+    <wsdl:part element="tns:SessionException" name="SessionException_Exception">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="authenticate">
+    <wsdl:part element="tns:authenticate" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="closeSessionResponse">
+    <wsdl:part element="tns:closeSessionResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="authenticateResponse">
+    <wsdl:part element="tns:authenticateResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="AuthenticationException_Exception">
+    <wsdl:part element="tns:AuthenticationException" name="AuthenticationException_Exception">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:portType name="WOKMWSAuthenticate">
+    <wsdl:operation name="closeSession">
+      <wsdl:input message="tns:closeSession" name="closeSession">
+    </wsdl:input>
+      <wsdl:output message="tns:closeSessionResponse" name="closeSessionResponse">
+    </wsdl:output>
+      <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+    </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="authenticate">
+      <wsdl:input message="tns:authenticate" name="authenticate">
+    </wsdl:input>
+      <wsdl:output message="tns:authenticateResponse" name="authenticateResponse">
+    </wsdl:output>
+      <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+    </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="WOKMWSAuthenticateServiceSoapBinding" type="tns:WOKMWSAuthenticate">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="closeSession">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="closeSession">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="closeSessionResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SessionException_Exception">
+        <soap:fault name="SessionException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="AuthenticationException_Exception">
+        <soap:fault name="AuthenticationException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="ESTIWSException_Exception">
+        <soap:fault name="ESTIWSException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="InvalidInputException_Exception">
+        <soap:fault name="InvalidInputException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="InternalServerException_Exception">
+        <soap:fault name="InternalServerException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="QueryException_Exception">
+        <soap:fault name="QueryException_Exception" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="authenticate">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="authenticate">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="authenticateResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SessionException_Exception">
+        <soap:fault name="SessionException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="AuthenticationException_Exception">
+        <soap:fault name="AuthenticationException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="ESTIWSException_Exception">
+        <soap:fault name="ESTIWSException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="InvalidInputException_Exception">
+        <soap:fault name="InvalidInputException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="InternalServerException_Exception">
+        <soap:fault name="InternalServerException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="QueryException_Exception">
+        <soap:fault name="QueryException_Exception" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="WOKMWSAuthenticateService">
+    <wsdl:port binding="tns:WOKMWSAuthenticateServiceSoapBinding" name="WOKMWSAuthenticatePort">
+      <soap:address location="http://search.webofknowledge.com/esti/wokmws/ws/WOKMWSAuthenticate"/>
+    </wsdl:port>
+  </wsdl:service>
 </wsdl:definitions>

--- a/spec/fixtures/wos_client/search_wsdl.xml
+++ b/spec/fixtures/wos_client/search_wsdl.xml
@@ -1,682 +1,681 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<wsdl:definitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="http://woksearch.v3.wokmws.thomsonreuters.com" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" name="WokSearchService" targetNamespace="http://woksearch.v3.wokmws.thomsonreuters.com">
-    <wsdl:types>
-        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://woksearch.v3.wokmws.thomsonreuters.com" targetNamespace="http://woksearch.v3.wokmws.thomsonreuters.com" version="1.0">
-            <xs:element name="AuthenticationException" type="tns:AuthenticationException"/>
-            <xs:element name="ESTIWSException" type="tns:ESTIWSException"/>
-            <xs:element name="InternalServerException" type="tns:InternalServerException"/>
-            <xs:element name="InvalidInputException" type="tns:InvalidInputException"/>
-            <xs:element name="QueryException" type="tns:QueryException"/>
-            <xs:element name="SessionException" type="tns:SessionException"/>
-            <xs:element name="citedReferences" type="tns:citedReferences"/>
-            <xs:element name="citedReferencesResponse" type="tns:citedReferencesResponse"/>
-            <xs:element name="citedReferencesRetrieve" type="tns:citedReferencesRetrieve"/>
-            <xs:element name="citedReferencesRetrieveResponse" type="tns:citedReferencesRetrieveResponse"/>
-            <xs:element name="citingArticles" type="tns:citingArticles"/>
-            <xs:element name="citingArticlesResponse" type="tns:citingArticlesResponse"/>
-            <xs:element name="relatedRecords" type="tns:relatedRecords"/>
-            <xs:element name="relatedRecordsResponse" type="tns:relatedRecordsResponse"/>
-            <xs:element name="retrieve" type="tns:retrieve"/>
-            <xs:element name="retrieveById" type="tns:retrieveById"/>
-            <xs:element name="retrieveByIdResponse" type="tns:retrieveByIdResponse"/>
-            <xs:element name="retrieveResponse" type="tns:retrieveResponse"/>
-            <xs:element name="search" type="tns:search"/>
-            <xs:element name="searchResponse" type="tns:searchResponse"/>
-            <xs:complexType name="citedReferences">
-                <xs:sequence>
-                    <xs:element name="databaseId" type="xs:string"/>
-                    <xs:element name="uid" type="xs:string"/>
-                    <xs:element name="queryLanguage" type="xs:string"/>
-                    <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="retrieveParameters">
-                <xs:sequence>
-                    <xs:element name="firstRecord" type="xs:int"/>
-                    <xs:element name="count" type="xs:int"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="sortField" nillable="true" type="tns:sortField"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="viewField" nillable="true" type="tns:viewField"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="option" nillable="true" type="tns:keyValuePair"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="sortField">
-                <xs:sequence>
-                    <xs:element name="name" type="xs:string"/>
-                    <xs:element name="sort" type="xs:string"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="viewField">
-                <xs:sequence>
-                    <xs:element name="collectionName" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="fieldName" nillable="true" type="xs:string"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="keyValuePair">
-                <xs:sequence>
-                    <xs:element name="key" type="xs:string"/>
-                    <xs:element name="value" nillable="true" type="xs:string"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="citedReferencesResponse">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="return" type="tns:citedReferencesSearchResults"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="citedReferencesSearchResults">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="queryId" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="references" nillable="true" type="tns:citedReference"/>
-                    <xs:element name="recordsFound" type="xs:int"/>
-                    <xs:element name="recordsSearched" type="xs:long"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="citedReference">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="uid" type="xs:string"/>
-                    <xs:element minOccurs="0" name="docid" type="xs:string"/>
-                    <xs:element minOccurs="0" name="articleId" type="xs:string"/>
-                    <xs:element minOccurs="0" name="citedAuthor" type="xs:string"/>
-                    <xs:element minOccurs="0" name="timesCited" type="xs:string"/>
-                    <xs:element minOccurs="0" name="year" type="xs:string"/>
-                    <xs:element minOccurs="0" name="page" type="xs:string"/>
-                    <xs:element minOccurs="0" name="volume" type="xs:string"/>
-                    <xs:element minOccurs="0" name="citedTitle" type="xs:string"/>
-                    <xs:element minOccurs="0" name="citedWork" type="xs:string"/>
-                    <xs:element minOccurs="0" name="hot" type="xs:string"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="QueryException">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
-                    <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="FaultInformation">
-                <xs:sequence>
-                    <xs:element name="code" type="xs:string"/>
-                    <xs:element minOccurs="0" name="message" type="xs:string"/>
-                    <xs:element minOccurs="0" name="reason" type="xs:string"/>
-                    <xs:element minOccurs="0" name="causeType" type="xs:string"/>
-                    <xs:element minOccurs="0" name="cause" type="xs:string"/>
-                    <xs:element minOccurs="0" name="supportingWebServiceException" type="tns:SupportingWebServiceException"/>
-                    <xs:element minOccurs="0" name="remedy" type="xs:string"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="SupportingWebServiceException">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="remoteNamespace" type="xs:string"/>
-                    <xs:element minOccurs="0" name="remoteOperation" type="xs:string"/>
-                    <xs:element minOccurs="0" name="remoteCode" type="xs:string"/>
-                    <xs:element minOccurs="0" name="remoteReason" type="xs:string"/>
-                    <xs:element minOccurs="0" name="handshakeCauseId" type="xs:string"/>
-                    <xs:element minOccurs="0" name="handshakeCause" type="xs:string"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="RawFaultInformation">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="rawFaultstring" type="xs:string"/>
-                    <xs:element minOccurs="0" name="rawMessage" type="xs:string"/>
-                    <xs:element minOccurs="0" name="rawReason" type="xs:string"/>
-                    <xs:element minOccurs="0" name="rawCause" type="xs:string"/>
-                    <xs:element minOccurs="0" name="rawRemedy" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="messageData" nillable="true" type="xs:string"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="InvalidInputException">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
-                    <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="ESTIWSException">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
-                    <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="InternalServerException">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
-                    <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="AuthenticationException">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
-                    <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="SessionException">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
-                    <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="citedReferencesRetrieve">
-                <xs:sequence>
-                    <xs:element name="queryId" type="xs:string"/>
-                    <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="citedReferencesRetrieveResponse">
-                <xs:sequence>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="return" type="tns:citedReference"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="relatedRecords">
-                <xs:sequence>
-                    <xs:element name="databaseId" type="xs:string"/>
-                    <xs:element name="uid" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="editions" nillable="true" type="tns:editionDesc"/>
-                    <xs:element minOccurs="0" name="timeSpan" type="tns:timeSpan"/>
-                    <xs:element name="queryLanguage" type="xs:string"/>
-                    <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="editionDesc">
-                <xs:sequence>
-                    <xs:element name="collection" type="xs:string"/>
-                    <xs:element name="edition" type="xs:string"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="timeSpan">
-                <xs:sequence>
-                    <xs:element name="begin" type="xs:string"/>
-                    <xs:element name="end" type="xs:string"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="relatedRecordsResponse">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="return" type="tns:fullRecordSearchResults"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="fullRecordSearchResults">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="queryId" type="xs:string"/>
-                    <xs:element name="recordsFound" type="xs:int"/>
-                    <xs:element name="recordsSearched" type="xs:long"/>
-                    <xs:element minOccurs="0" name="parent" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="optionValue" nillable="true" type="tns:labelValuesPair"/>
-                    <xs:element minOccurs="0" name="records" type="xs:string"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="labelValuesPair">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="label" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="value" nillable="true" type="xs:string"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="retrieveById">
-                <xs:sequence>
-                    <xs:element name="databaseId" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" name="uid" type="xs:string"/>
-                    <xs:element name="queryLanguage" type="xs:string"/>
-                    <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="retrieveByIdResponse">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="return" type="tns:fullRecordSearchResults"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="retrieve">
-                <xs:sequence>
-                    <xs:element name="queryId" type="xs:string"/>
-                    <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="retrieveResponse">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="return" type="tns:fullRecordData"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="fullRecordData">
-                <xs:sequence>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="optionValue" nillable="true" type="tns:labelValuesPair"/>
-                    <xs:element minOccurs="0" name="records" type="xs:string"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="search">
-                <xs:sequence>
-                    <xs:element name="queryParameters" type="tns:queryParameters"/>
-                    <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="queryParameters">
-                <xs:sequence>
-                    <xs:element name="databaseId" type="xs:string"/>
-                    <xs:element name="userQuery" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="editions" nillable="true" type="tns:editionDesc"/>
-                    <xs:element minOccurs="0" name="symbolicTimeSpan" type="xs:string"/>
-                    <xs:element minOccurs="0" name="timeSpan" type="tns:timeSpan"/>
-                    <xs:element name="queryLanguage" type="xs:string"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="searchResponse">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="return" type="tns:fullRecordSearchResults"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="citingArticles">
-                <xs:sequence>
-                    <xs:element name="databaseId" type="xs:string"/>
-                    <xs:element name="uid" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="editions" nillable="true" type="tns:editionDesc"/>
-                    <xs:element minOccurs="0" name="timeSpan" type="tns:timeSpan"/>
-                    <xs:element name="queryLanguage" type="xs:string"/>
-                    <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="citingArticlesResponse">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="return" type="tns:fullRecordSearchResults"/>
-                </xs:sequence>
-            </xs:complexType>
-        </xs:schema>
-    </wsdl:types>
-    <wsdl:message name="relatedRecordsResponse">
-        <wsdl:part element="tns:relatedRecordsResponse" name="parameters">
-        </wsdl:part>
-    </wsdl:message>
-    <wsdl:message name="relatedRecords">
-        <wsdl:part element="tns:relatedRecords" name="parameters">
-        </wsdl:part>
-    </wsdl:message>
-    <wsdl:message name="retrieveById">
-        <wsdl:part element="tns:retrieveById" name="parameters">
-        </wsdl:part>
-    </wsdl:message>
-    <wsdl:message name="retrieveResponse">
-        <wsdl:part element="tns:retrieveResponse" name="parameters">
-        </wsdl:part>
-    </wsdl:message>
-    <wsdl:message name="ESTIWSException_Exception">
-        <wsdl:part element="tns:ESTIWSException" name="ESTIWSException_Exception">
-        </wsdl:part>
-    </wsdl:message>
-    <wsdl:message name="InternalServerException_Exception">
-        <wsdl:part element="tns:InternalServerException" name="InternalServerException_Exception">
-        </wsdl:part>
-    </wsdl:message>
-    <wsdl:message name="retrieve">
-        <wsdl:part element="tns:retrieve" name="parameters">
-        </wsdl:part>
-    </wsdl:message>
-    <wsdl:message name="searchResponse">
-        <wsdl:part element="tns:searchResponse" name="parameters">
-        </wsdl:part>
-    </wsdl:message>
-    <wsdl:message name="citingArticlesResponse">
-        <wsdl:part element="tns:citingArticlesResponse" name="parameters">
-        </wsdl:part>
-    </wsdl:message>
-    <wsdl:message name="AuthenticationException_Exception">
-        <wsdl:part element="tns:AuthenticationException" name="AuthenticationException_Exception">
-        </wsdl:part>
-    </wsdl:message>
-    <wsdl:message name="retrieveByIdResponse">
-        <wsdl:part element="tns:retrieveByIdResponse" name="parameters">
-        </wsdl:part>
-    </wsdl:message>
-    <wsdl:message name="search">
-        <wsdl:part element="tns:search" name="parameters">
-        </wsdl:part>
-    </wsdl:message>
-    <wsdl:message name="citingArticles">
-        <wsdl:part element="tns:citingArticles" name="parameters">
-        </wsdl:part>
-    </wsdl:message>
-    <wsdl:message name="citedReferences">
-        <wsdl:part element="tns:citedReferences" name="parameters">
-        </wsdl:part>
-    </wsdl:message>
-    <wsdl:message name="citedReferencesRetrieve">
-        <wsdl:part element="tns:citedReferencesRetrieve" name="parameters">
-        </wsdl:part>
-    </wsdl:message>
-    <wsdl:message name="citedReferencesRetrieveResponse">
-        <wsdl:part element="tns:citedReferencesRetrieveResponse" name="parameters">
-        </wsdl:part>
-    </wsdl:message>
-    <wsdl:message name="QueryException_Exception">
-        <wsdl:part element="tns:QueryException" name="QueryException_Exception">
-        </wsdl:part>
-    </wsdl:message>
-    <wsdl:message name="InvalidInputException_Exception">
-        <wsdl:part element="tns:InvalidInputException" name="InvalidInputException_Exception">
-        </wsdl:part>
-    </wsdl:message>
-    <wsdl:message name="citedReferencesResponse">
-        <wsdl:part element="tns:citedReferencesResponse" name="parameters">
-        </wsdl:part>
-    </wsdl:message>
-    <wsdl:message name="SessionException_Exception">
-        <wsdl:part element="tns:SessionException" name="SessionException_Exception">
-        </wsdl:part>
-    </wsdl:message>
-    <wsdl:portType name="WokSearch">
-        <wsdl:operation name="citedReferences">
-            <wsdl:input message="tns:citedReferences" name="citedReferences">
-            </wsdl:input>
-            <wsdl:output message="tns:citedReferencesResponse" name="citedReferencesResponse">
-            </wsdl:output>
-            <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="citedReferencesRetrieve">
-            <wsdl:input message="tns:citedReferencesRetrieve" name="citedReferencesRetrieve">
-            </wsdl:input>
-            <wsdl:output message="tns:citedReferencesRetrieveResponse" name="citedReferencesRetrieveResponse">
-            </wsdl:output>
-            <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="relatedRecords">
-            <wsdl:input message="tns:relatedRecords" name="relatedRecords">
-            </wsdl:input>
-            <wsdl:output message="tns:relatedRecordsResponse" name="relatedRecordsResponse">
-            </wsdl:output>
-            <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="retrieveById">
-            <wsdl:input message="tns:retrieveById" name="retrieveById">
-            </wsdl:input>
-            <wsdl:output message="tns:retrieveByIdResponse" name="retrieveByIdResponse">
-            </wsdl:output>
-            <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="retrieve">
-            <wsdl:input message="tns:retrieve" name="retrieve">
-            </wsdl:input>
-            <wsdl:output message="tns:retrieveResponse" name="retrieveResponse">
-            </wsdl:output>
-            <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="search">
-            <wsdl:input message="tns:search" name="search">
-            </wsdl:input>
-            <wsdl:output message="tns:searchResponse" name="searchResponse">
-            </wsdl:output>
-            <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="citingArticles">
-            <wsdl:input message="tns:citingArticles" name="citingArticles">
-            </wsdl:input>
-            <wsdl:output message="tns:citingArticlesResponse" name="citingArticlesResponse">
-            </wsdl:output>
-            <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
-            </wsdl:fault>
-            <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
-            </wsdl:fault>
-        </wsdl:operation>
-    </wsdl:portType>
-    <wsdl:binding name="WokSearchServiceSoapBinding" type="tns:WokSearch">
-        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
-        <wsdl:operation name="citedReferences">
-            <soap:operation soapAction="" style="document"/>
-            <wsdl:input name="citedReferences">
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output name="citedReferencesResponse">
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="SessionException_Exception">
-                <soap:fault name="SessionException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="AuthenticationException_Exception">
-                <soap:fault name="AuthenticationException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="InvalidInputException_Exception">
-                <soap:fault name="InvalidInputException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="ESTIWSException_Exception">
-                <soap:fault name="ESTIWSException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="InternalServerException_Exception">
-                <soap:fault name="InternalServerException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="QueryException_Exception">
-                <soap:fault name="QueryException_Exception" use="literal"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="citedReferencesRetrieve">
-            <soap:operation soapAction="" style="document"/>
-            <wsdl:input name="citedReferencesRetrieve">
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output name="citedReferencesRetrieveResponse">
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="SessionException_Exception">
-                <soap:fault name="SessionException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="AuthenticationException_Exception">
-                <soap:fault name="AuthenticationException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="InvalidInputException_Exception">
-                <soap:fault name="InvalidInputException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="ESTIWSException_Exception">
-                <soap:fault name="ESTIWSException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="InternalServerException_Exception">
-                <soap:fault name="InternalServerException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="QueryException_Exception">
-                <soap:fault name="QueryException_Exception" use="literal"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="relatedRecords">
-            <soap:operation soapAction="" style="document"/>
-            <wsdl:input name="relatedRecords">
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output name="relatedRecordsResponse">
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="SessionException_Exception">
-                <soap:fault name="SessionException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="AuthenticationException_Exception">
-                <soap:fault name="AuthenticationException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="InvalidInputException_Exception">
-                <soap:fault name="InvalidInputException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="ESTIWSException_Exception">
-                <soap:fault name="ESTIWSException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="InternalServerException_Exception">
-                <soap:fault name="InternalServerException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="QueryException_Exception">
-                <soap:fault name="QueryException_Exception" use="literal"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="retrieveById">
-            <soap:operation soapAction="" style="document"/>
-            <wsdl:input name="retrieveById">
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output name="retrieveByIdResponse">
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="SessionException_Exception">
-                <soap:fault name="SessionException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="AuthenticationException_Exception">
-                <soap:fault name="AuthenticationException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="InvalidInputException_Exception">
-                <soap:fault name="InvalidInputException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="ESTIWSException_Exception">
-                <soap:fault name="ESTIWSException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="InternalServerException_Exception">
-                <soap:fault name="InternalServerException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="QueryException_Exception">
-                <soap:fault name="QueryException_Exception" use="literal"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="retrieve">
-            <soap:operation soapAction="" style="document"/>
-            <wsdl:input name="retrieve">
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output name="retrieveResponse">
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="SessionException_Exception">
-                <soap:fault name="SessionException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="AuthenticationException_Exception">
-                <soap:fault name="AuthenticationException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="InvalidInputException_Exception">
-                <soap:fault name="InvalidInputException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="ESTIWSException_Exception">
-                <soap:fault name="ESTIWSException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="InternalServerException_Exception">
-                <soap:fault name="InternalServerException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="QueryException_Exception">
-                <soap:fault name="QueryException_Exception" use="literal"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="search">
-            <soap:operation soapAction="" style="document"/>
-            <wsdl:input name="search">
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output name="searchResponse">
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="SessionException_Exception">
-                <soap:fault name="SessionException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="AuthenticationException_Exception">
-                <soap:fault name="AuthenticationException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="InvalidInputException_Exception">
-                <soap:fault name="InvalidInputException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="ESTIWSException_Exception">
-                <soap:fault name="ESTIWSException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="InternalServerException_Exception">
-                <soap:fault name="InternalServerException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="QueryException_Exception">
-                <soap:fault name="QueryException_Exception" use="literal"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="citingArticles">
-            <soap:operation soapAction="" style="document"/>
-            <wsdl:input name="citingArticles">
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output name="citingArticlesResponse">
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="SessionException_Exception">
-                <soap:fault name="SessionException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="AuthenticationException_Exception">
-                <soap:fault name="AuthenticationException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="InvalidInputException_Exception">
-                <soap:fault name="InvalidInputException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="ESTIWSException_Exception">
-                <soap:fault name="ESTIWSException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="InternalServerException_Exception">
-                <soap:fault name="InternalServerException_Exception" use="literal"/>
-            </wsdl:fault>
-            <wsdl:fault name="QueryException_Exception">
-                <soap:fault name="QueryException_Exception" use="literal"/>
-            </wsdl:fault>
-        </wsdl:operation>
-    </wsdl:binding>
-    <wsdl:service name="WokSearchService">
-        <wsdl:port binding="tns:WokSearchServiceSoapBinding" name="WokSearchPort">
-            <soap:address location="http://search.webofknowledge.com/esti/wokmws/ws/WokSearch"/>
-        </wsdl:port>
-    </wsdl:service>
+<?xml version='1.0' encoding='UTF-8'?><wsdl:definitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="http://woksearch.v3.wokmws.thomsonreuters.com" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" name="WokSearchService" targetNamespace="http://woksearch.v3.wokmws.thomsonreuters.com">
+  <wsdl:types>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://woksearch.v3.wokmws.thomsonreuters.com" targetNamespace="http://woksearch.v3.wokmws.thomsonreuters.com" version="1.0">
+<xs:element name="AuthenticationException" type="tns:AuthenticationException"/>
+<xs:element name="ESTIWSException" type="tns:ESTIWSException"/>
+<xs:element name="InternalServerException" type="tns:InternalServerException"/>
+<xs:element name="InvalidInputException" type="tns:InvalidInputException"/>
+<xs:element name="QueryException" type="tns:QueryException"/>
+<xs:element name="SessionException" type="tns:SessionException"/>
+<xs:element name="citedReferences" type="tns:citedReferences"/>
+<xs:element name="citedReferencesResponse" type="tns:citedReferencesResponse"/>
+<xs:element name="citedReferencesRetrieve" type="tns:citedReferencesRetrieve"/>
+<xs:element name="citedReferencesRetrieveResponse" type="tns:citedReferencesRetrieveResponse"/>
+<xs:element name="citingArticles" type="tns:citingArticles"/>
+<xs:element name="citingArticlesResponse" type="tns:citingArticlesResponse"/>
+<xs:element name="relatedRecords" type="tns:relatedRecords"/>
+<xs:element name="relatedRecordsResponse" type="tns:relatedRecordsResponse"/>
+<xs:element name="retrieve" type="tns:retrieve"/>
+<xs:element name="retrieveById" type="tns:retrieveById"/>
+<xs:element name="retrieveByIdResponse" type="tns:retrieveByIdResponse"/>
+<xs:element name="retrieveResponse" type="tns:retrieveResponse"/>
+<xs:element name="search" type="tns:search"/>
+<xs:element name="searchResponse" type="tns:searchResponse"/>
+<xs:complexType name="citedReferences">
+    <xs:sequence>
+      <xs:element name="databaseId" type="xs:string"/>
+      <xs:element name="uid" type="xs:string"/>
+      <xs:element name="queryLanguage" type="xs:string"/>
+      <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="retrieveParameters">
+    <xs:sequence>
+      <xs:element name="firstRecord" type="xs:int"/>
+      <xs:element name="count" type="xs:int"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="sortField" nillable="true" type="tns:sortField"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="viewField" nillable="true" type="tns:viewField"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="option" nillable="true" type="tns:keyValuePair"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="sortField">
+    <xs:sequence>
+      <xs:element name="name" type="xs:string"/>
+      <xs:element name="sort" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="viewField">
+    <xs:sequence>
+      <xs:element name="collectionName" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="fieldName" nillable="true" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="keyValuePair">
+    <xs:sequence>
+      <xs:element name="key" type="xs:string"/>
+      <xs:element name="value" nillable="true" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="citedReferencesResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="return" type="tns:citedReferencesSearchResults"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="citedReferencesSearchResults">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="queryId" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="references" nillable="true" type="tns:citedReference"/>
+      <xs:element name="recordsFound" type="xs:int"/>
+      <xs:element name="recordsSearched" type="xs:long"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="citedReference">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="uid" type="xs:string"/>
+      <xs:element minOccurs="0" name="docid" type="xs:string"/>
+      <xs:element minOccurs="0" name="articleId" type="xs:string"/>
+      <xs:element minOccurs="0" name="citedAuthor" type="xs:string"/>
+      <xs:element minOccurs="0" name="timesCited" type="xs:string"/>
+      <xs:element minOccurs="0" name="year" type="xs:string"/>
+      <xs:element minOccurs="0" name="page" type="xs:string"/>
+      <xs:element minOccurs="0" name="volume" type="xs:string"/>
+      <xs:element minOccurs="0" name="citedTitle" type="xs:string"/>
+      <xs:element minOccurs="0" name="citedWork" type="xs:string"/>
+      <xs:element minOccurs="0" name="hot" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="QueryException">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
+      <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="FaultInformation">
+    <xs:sequence>
+      <xs:element name="code" type="xs:string"/>
+      <xs:element minOccurs="0" name="message" type="xs:string"/>
+      <xs:element minOccurs="0" name="reason" type="xs:string"/>
+      <xs:element minOccurs="0" name="causeType" type="xs:string"/>
+      <xs:element minOccurs="0" name="cause" type="xs:string"/>
+      <xs:element minOccurs="0" name="supportingWebServiceException" type="tns:SupportingWebServiceException"/>
+      <xs:element minOccurs="0" name="remedy" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="SupportingWebServiceException">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="remoteNamespace" type="xs:string"/>
+      <xs:element minOccurs="0" name="remoteOperation" type="xs:string"/>
+      <xs:element minOccurs="0" name="remoteCode" type="xs:string"/>
+      <xs:element minOccurs="0" name="remoteReason" type="xs:string"/>
+      <xs:element minOccurs="0" name="handshakeCauseId" type="xs:string"/>
+      <xs:element minOccurs="0" name="handshakeCause" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="RawFaultInformation">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="rawFaultstring" type="xs:string"/>
+      <xs:element minOccurs="0" name="rawMessage" type="xs:string"/>
+      <xs:element minOccurs="0" name="rawReason" type="xs:string"/>
+      <xs:element minOccurs="0" name="rawCause" type="xs:string"/>
+      <xs:element minOccurs="0" name="rawRemedy" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="messageData" nillable="true" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="InvalidInputException">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
+      <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="ESTIWSException">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
+      <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="InternalServerException">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
+      <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="AuthenticationException">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
+      <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="SessionException">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
+      <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="citedReferencesRetrieve">
+    <xs:sequence>
+      <xs:element name="queryId" type="xs:string"/>
+      <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="citedReferencesRetrieveResponse">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="return" type="tns:citedReference"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="relatedRecords">
+    <xs:sequence>
+      <xs:element name="databaseId" type="xs:string"/>
+      <xs:element name="uid" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="editions" nillable="true" type="tns:editionDesc"/>
+      <xs:element minOccurs="0" name="timeSpan" type="tns:timeSpan"/>
+      <xs:element name="queryLanguage" type="xs:string"/>
+      <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="editionDesc">
+    <xs:sequence>
+      <xs:element name="collection" type="xs:string"/>
+      <xs:element name="edition" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="timeSpan">
+    <xs:sequence>
+      <xs:element name="begin" type="xs:string"/>
+      <xs:element name="end" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="relatedRecordsResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="return" type="tns:fullRecordSearchResults"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="fullRecordSearchResults">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="queryId" type="xs:string"/>
+      <xs:element name="recordsFound" type="xs:int"/>
+      <xs:element name="recordsSearched" type="xs:long"/>
+      <xs:element minOccurs="0" name="parent" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="optionValue" nillable="true" type="tns:labelValuesPair"/>
+      <xs:element minOccurs="0" name="records" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="labelValuesPair">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="label" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="value" nillable="true" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="retrieveById">
+    <xs:sequence>
+      <xs:element name="databaseId" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" name="uid" type="xs:string"/>
+      <xs:element name="queryLanguage" type="xs:string"/>
+      <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="retrieveByIdResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="return" type="tns:fullRecordSearchResults"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="retrieve">
+    <xs:sequence>
+      <xs:element name="queryId" type="xs:string"/>
+      <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="retrieveResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="return" type="tns:fullRecordData"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="fullRecordData">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="optionValue" nillable="true" type="tns:labelValuesPair"/>
+      <xs:element minOccurs="0" name="records" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="search">
+    <xs:sequence>
+      <xs:element name="queryParameters" type="tns:queryParameters"/>
+      <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="queryParameters">
+    <xs:sequence>
+      <xs:element name="databaseId" type="xs:string"/>
+      <xs:element name="userQuery" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="editions" nillable="true" type="tns:editionDesc"/>
+      <xs:element minOccurs="0" name="symbolicTimeSpan" type="xs:string"/>
+      <xs:element minOccurs="0" name="timeSpan" type="tns:timeSpan"/>
+      <xs:element name="queryLanguage" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="searchResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="return" type="tns:fullRecordSearchResults"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="citingArticles">
+    <xs:sequence>
+      <xs:element name="databaseId" type="xs:string"/>
+      <xs:element name="uid" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="editions" nillable="true" type="tns:editionDesc"/>
+      <xs:element minOccurs="0" name="timeSpan" type="tns:timeSpan"/>
+      <xs:element name="queryLanguage" type="xs:string"/>
+      <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+    </xs:sequence>
+  </xs:complexType>
+<xs:complexType name="citingArticlesResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="return" type="tns:fullRecordSearchResults"/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>
+  </wsdl:types>
+  <wsdl:message name="relatedRecordsResponse">
+    <wsdl:part element="tns:relatedRecordsResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="relatedRecords">
+    <wsdl:part element="tns:relatedRecords" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="retrieveById">
+    <wsdl:part element="tns:retrieveById" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="retrieveResponse">
+    <wsdl:part element="tns:retrieveResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="ESTIWSException_Exception">
+    <wsdl:part element="tns:ESTIWSException" name="ESTIWSException_Exception">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="InternalServerException_Exception">
+    <wsdl:part element="tns:InternalServerException" name="InternalServerException_Exception">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="retrieve">
+    <wsdl:part element="tns:retrieve" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="searchResponse">
+    <wsdl:part element="tns:searchResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="citingArticlesResponse">
+    <wsdl:part element="tns:citingArticlesResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="AuthenticationException_Exception">
+    <wsdl:part element="tns:AuthenticationException" name="AuthenticationException_Exception">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="retrieveByIdResponse">
+    <wsdl:part element="tns:retrieveByIdResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="search">
+    <wsdl:part element="tns:search" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="citingArticles">
+    <wsdl:part element="tns:citingArticles" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="citedReferences">
+    <wsdl:part element="tns:citedReferences" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="citedReferencesRetrieve">
+    <wsdl:part element="tns:citedReferencesRetrieve" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="citedReferencesRetrieveResponse">
+    <wsdl:part element="tns:citedReferencesRetrieveResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="QueryException_Exception">
+    <wsdl:part element="tns:QueryException" name="QueryException_Exception">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="InvalidInputException_Exception">
+    <wsdl:part element="tns:InvalidInputException" name="InvalidInputException_Exception">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="citedReferencesResponse">
+    <wsdl:part element="tns:citedReferencesResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="SessionException_Exception">
+    <wsdl:part element="tns:SessionException" name="SessionException_Exception">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:portType name="WokSearch">
+    <wsdl:operation name="citedReferences">
+      <wsdl:input message="tns:citedReferences" name="citedReferences">
+    </wsdl:input>
+      <wsdl:output message="tns:citedReferencesResponse" name="citedReferencesResponse">
+    </wsdl:output>
+      <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+    </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="citedReferencesRetrieve">
+      <wsdl:input message="tns:citedReferencesRetrieve" name="citedReferencesRetrieve">
+    </wsdl:input>
+      <wsdl:output message="tns:citedReferencesRetrieveResponse" name="citedReferencesRetrieveResponse">
+    </wsdl:output>
+      <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+    </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="relatedRecords">
+      <wsdl:input message="tns:relatedRecords" name="relatedRecords">
+    </wsdl:input>
+      <wsdl:output message="tns:relatedRecordsResponse" name="relatedRecordsResponse">
+    </wsdl:output>
+      <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+    </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="retrieveById">
+      <wsdl:input message="tns:retrieveById" name="retrieveById">
+    </wsdl:input>
+      <wsdl:output message="tns:retrieveByIdResponse" name="retrieveByIdResponse">
+    </wsdl:output>
+      <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+    </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="retrieve">
+      <wsdl:input message="tns:retrieve" name="retrieve">
+    </wsdl:input>
+      <wsdl:output message="tns:retrieveResponse" name="retrieveResponse">
+    </wsdl:output>
+      <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+    </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="search">
+      <wsdl:input message="tns:search" name="search">
+    </wsdl:input>
+      <wsdl:output message="tns:searchResponse" name="searchResponse">
+    </wsdl:output>
+      <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+    </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="citingArticles">
+      <wsdl:input message="tns:citingArticles" name="citingArticles">
+    </wsdl:input>
+      <wsdl:output message="tns:citingArticlesResponse" name="citingArticlesResponse">
+    </wsdl:output>
+      <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+    </wsdl:fault>
+      <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+    </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="WokSearchServiceSoapBinding" type="tns:WokSearch">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="citedReferences">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="citedReferences">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="citedReferencesResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SessionException_Exception">
+        <soap:fault name="SessionException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="AuthenticationException_Exception">
+        <soap:fault name="AuthenticationException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="InvalidInputException_Exception">
+        <soap:fault name="InvalidInputException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="ESTIWSException_Exception">
+        <soap:fault name="ESTIWSException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="InternalServerException_Exception">
+        <soap:fault name="InternalServerException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="QueryException_Exception">
+        <soap:fault name="QueryException_Exception" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="citedReferencesRetrieve">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="citedReferencesRetrieve">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="citedReferencesRetrieveResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SessionException_Exception">
+        <soap:fault name="SessionException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="AuthenticationException_Exception">
+        <soap:fault name="AuthenticationException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="InvalidInputException_Exception">
+        <soap:fault name="InvalidInputException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="ESTIWSException_Exception">
+        <soap:fault name="ESTIWSException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="InternalServerException_Exception">
+        <soap:fault name="InternalServerException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="QueryException_Exception">
+        <soap:fault name="QueryException_Exception" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="relatedRecords">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="relatedRecords">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="relatedRecordsResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SessionException_Exception">
+        <soap:fault name="SessionException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="AuthenticationException_Exception">
+        <soap:fault name="AuthenticationException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="InvalidInputException_Exception">
+        <soap:fault name="InvalidInputException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="ESTIWSException_Exception">
+        <soap:fault name="ESTIWSException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="InternalServerException_Exception">
+        <soap:fault name="InternalServerException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="QueryException_Exception">
+        <soap:fault name="QueryException_Exception" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="retrieveById">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="retrieveById">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="retrieveByIdResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SessionException_Exception">
+        <soap:fault name="SessionException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="AuthenticationException_Exception">
+        <soap:fault name="AuthenticationException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="InvalidInputException_Exception">
+        <soap:fault name="InvalidInputException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="ESTIWSException_Exception">
+        <soap:fault name="ESTIWSException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="InternalServerException_Exception">
+        <soap:fault name="InternalServerException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="QueryException_Exception">
+        <soap:fault name="QueryException_Exception" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="retrieve">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="retrieve">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="retrieveResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SessionException_Exception">
+        <soap:fault name="SessionException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="AuthenticationException_Exception">
+        <soap:fault name="AuthenticationException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="InvalidInputException_Exception">
+        <soap:fault name="InvalidInputException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="ESTIWSException_Exception">
+        <soap:fault name="ESTIWSException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="InternalServerException_Exception">
+        <soap:fault name="InternalServerException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="QueryException_Exception">
+        <soap:fault name="QueryException_Exception" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="search">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="search">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="searchResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SessionException_Exception">
+        <soap:fault name="SessionException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="AuthenticationException_Exception">
+        <soap:fault name="AuthenticationException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="InvalidInputException_Exception">
+        <soap:fault name="InvalidInputException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="ESTIWSException_Exception">
+        <soap:fault name="ESTIWSException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="InternalServerException_Exception">
+        <soap:fault name="InternalServerException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="QueryException_Exception">
+        <soap:fault name="QueryException_Exception" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="citingArticles">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="citingArticles">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="citingArticlesResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SessionException_Exception">
+        <soap:fault name="SessionException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="AuthenticationException_Exception">
+        <soap:fault name="AuthenticationException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="InvalidInputException_Exception">
+        <soap:fault name="InvalidInputException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="ESTIWSException_Exception">
+        <soap:fault name="ESTIWSException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="InternalServerException_Exception">
+        <soap:fault name="InternalServerException_Exception" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="QueryException_Exception">
+        <soap:fault name="QueryException_Exception" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="WokSearchService">
+    <wsdl:port binding="tns:WokSearchServiceSoapBinding" name="WokSearchPort">
+      <soap:address location="http://search.webofknowledge.com/esti/wokmws/ws/WokSearch"/>
+    </wsdl:port>
+  </wsdl:service>
 </wsdl:definitions>

--- a/spec/fixtures/wos_client/search_wsdl.xml
+++ b/spec/fixtures/wos_client/search_wsdl.xml
@@ -1,0 +1,682 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<wsdl:definitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="http://woksearch.v3.wokmws.thomsonreuters.com" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" name="WokSearchService" targetNamespace="http://woksearch.v3.wokmws.thomsonreuters.com">
+    <wsdl:types>
+        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://woksearch.v3.wokmws.thomsonreuters.com" targetNamespace="http://woksearch.v3.wokmws.thomsonreuters.com" version="1.0">
+            <xs:element name="AuthenticationException" type="tns:AuthenticationException"/>
+            <xs:element name="ESTIWSException" type="tns:ESTIWSException"/>
+            <xs:element name="InternalServerException" type="tns:InternalServerException"/>
+            <xs:element name="InvalidInputException" type="tns:InvalidInputException"/>
+            <xs:element name="QueryException" type="tns:QueryException"/>
+            <xs:element name="SessionException" type="tns:SessionException"/>
+            <xs:element name="citedReferences" type="tns:citedReferences"/>
+            <xs:element name="citedReferencesResponse" type="tns:citedReferencesResponse"/>
+            <xs:element name="citedReferencesRetrieve" type="tns:citedReferencesRetrieve"/>
+            <xs:element name="citedReferencesRetrieveResponse" type="tns:citedReferencesRetrieveResponse"/>
+            <xs:element name="citingArticles" type="tns:citingArticles"/>
+            <xs:element name="citingArticlesResponse" type="tns:citingArticlesResponse"/>
+            <xs:element name="relatedRecords" type="tns:relatedRecords"/>
+            <xs:element name="relatedRecordsResponse" type="tns:relatedRecordsResponse"/>
+            <xs:element name="retrieve" type="tns:retrieve"/>
+            <xs:element name="retrieveById" type="tns:retrieveById"/>
+            <xs:element name="retrieveByIdResponse" type="tns:retrieveByIdResponse"/>
+            <xs:element name="retrieveResponse" type="tns:retrieveResponse"/>
+            <xs:element name="search" type="tns:search"/>
+            <xs:element name="searchResponse" type="tns:searchResponse"/>
+            <xs:complexType name="citedReferences">
+                <xs:sequence>
+                    <xs:element name="databaseId" type="xs:string"/>
+                    <xs:element name="uid" type="xs:string"/>
+                    <xs:element name="queryLanguage" type="xs:string"/>
+                    <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="retrieveParameters">
+                <xs:sequence>
+                    <xs:element name="firstRecord" type="xs:int"/>
+                    <xs:element name="count" type="xs:int"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="sortField" nillable="true" type="tns:sortField"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="viewField" nillable="true" type="tns:viewField"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="option" nillable="true" type="tns:keyValuePair"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="sortField">
+                <xs:sequence>
+                    <xs:element name="name" type="xs:string"/>
+                    <xs:element name="sort" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="viewField">
+                <xs:sequence>
+                    <xs:element name="collectionName" type="xs:string"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="fieldName" nillable="true" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="keyValuePair">
+                <xs:sequence>
+                    <xs:element name="key" type="xs:string"/>
+                    <xs:element name="value" nillable="true" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="citedReferencesResponse">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="return" type="tns:citedReferencesSearchResults"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="citedReferencesSearchResults">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="queryId" type="xs:string"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="references" nillable="true" type="tns:citedReference"/>
+                    <xs:element name="recordsFound" type="xs:int"/>
+                    <xs:element name="recordsSearched" type="xs:long"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="citedReference">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="uid" type="xs:string"/>
+                    <xs:element minOccurs="0" name="docid" type="xs:string"/>
+                    <xs:element minOccurs="0" name="articleId" type="xs:string"/>
+                    <xs:element minOccurs="0" name="citedAuthor" type="xs:string"/>
+                    <xs:element minOccurs="0" name="timesCited" type="xs:string"/>
+                    <xs:element minOccurs="0" name="year" type="xs:string"/>
+                    <xs:element minOccurs="0" name="page" type="xs:string"/>
+                    <xs:element minOccurs="0" name="volume" type="xs:string"/>
+                    <xs:element minOccurs="0" name="citedTitle" type="xs:string"/>
+                    <xs:element minOccurs="0" name="citedWork" type="xs:string"/>
+                    <xs:element minOccurs="0" name="hot" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="QueryException">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
+                    <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="FaultInformation">
+                <xs:sequence>
+                    <xs:element name="code" type="xs:string"/>
+                    <xs:element minOccurs="0" name="message" type="xs:string"/>
+                    <xs:element minOccurs="0" name="reason" type="xs:string"/>
+                    <xs:element minOccurs="0" name="causeType" type="xs:string"/>
+                    <xs:element minOccurs="0" name="cause" type="xs:string"/>
+                    <xs:element minOccurs="0" name="supportingWebServiceException" type="tns:SupportingWebServiceException"/>
+                    <xs:element minOccurs="0" name="remedy" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="SupportingWebServiceException">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="remoteNamespace" type="xs:string"/>
+                    <xs:element minOccurs="0" name="remoteOperation" type="xs:string"/>
+                    <xs:element minOccurs="0" name="remoteCode" type="xs:string"/>
+                    <xs:element minOccurs="0" name="remoteReason" type="xs:string"/>
+                    <xs:element minOccurs="0" name="handshakeCauseId" type="xs:string"/>
+                    <xs:element minOccurs="0" name="handshakeCause" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="RawFaultInformation">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="rawFaultstring" type="xs:string"/>
+                    <xs:element minOccurs="0" name="rawMessage" type="xs:string"/>
+                    <xs:element minOccurs="0" name="rawReason" type="xs:string"/>
+                    <xs:element minOccurs="0" name="rawCause" type="xs:string"/>
+                    <xs:element minOccurs="0" name="rawRemedy" type="xs:string"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="messageData" nillable="true" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="InvalidInputException">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
+                    <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="ESTIWSException">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
+                    <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="InternalServerException">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
+                    <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="AuthenticationException">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
+                    <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="SessionException">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
+                    <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="citedReferencesRetrieve">
+                <xs:sequence>
+                    <xs:element name="queryId" type="xs:string"/>
+                    <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="citedReferencesRetrieveResponse">
+                <xs:sequence>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="return" type="tns:citedReference"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="relatedRecords">
+                <xs:sequence>
+                    <xs:element name="databaseId" type="xs:string"/>
+                    <xs:element name="uid" type="xs:string"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="editions" nillable="true" type="tns:editionDesc"/>
+                    <xs:element minOccurs="0" name="timeSpan" type="tns:timeSpan"/>
+                    <xs:element name="queryLanguage" type="xs:string"/>
+                    <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="editionDesc">
+                <xs:sequence>
+                    <xs:element name="collection" type="xs:string"/>
+                    <xs:element name="edition" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="timeSpan">
+                <xs:sequence>
+                    <xs:element name="begin" type="xs:string"/>
+                    <xs:element name="end" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="relatedRecordsResponse">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="return" type="tns:fullRecordSearchResults"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="fullRecordSearchResults">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="queryId" type="xs:string"/>
+                    <xs:element name="recordsFound" type="xs:int"/>
+                    <xs:element name="recordsSearched" type="xs:long"/>
+                    <xs:element minOccurs="0" name="parent" type="xs:string"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="optionValue" nillable="true" type="tns:labelValuesPair"/>
+                    <xs:element minOccurs="0" name="records" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="labelValuesPair">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="label" type="xs:string"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="value" nillable="true" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="retrieveById">
+                <xs:sequence>
+                    <xs:element name="databaseId" type="xs:string"/>
+                    <xs:element maxOccurs="unbounded" name="uid" type="xs:string"/>
+                    <xs:element name="queryLanguage" type="xs:string"/>
+                    <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="retrieveByIdResponse">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="return" type="tns:fullRecordSearchResults"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="retrieve">
+                <xs:sequence>
+                    <xs:element name="queryId" type="xs:string"/>
+                    <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="retrieveResponse">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="return" type="tns:fullRecordData"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="fullRecordData">
+                <xs:sequence>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="optionValue" nillable="true" type="tns:labelValuesPair"/>
+                    <xs:element minOccurs="0" name="records" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="search">
+                <xs:sequence>
+                    <xs:element name="queryParameters" type="tns:queryParameters"/>
+                    <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="queryParameters">
+                <xs:sequence>
+                    <xs:element name="databaseId" type="xs:string"/>
+                    <xs:element name="userQuery" type="xs:string"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="editions" nillable="true" type="tns:editionDesc"/>
+                    <xs:element minOccurs="0" name="symbolicTimeSpan" type="xs:string"/>
+                    <xs:element minOccurs="0" name="timeSpan" type="tns:timeSpan"/>
+                    <xs:element name="queryLanguage" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="searchResponse">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="return" type="tns:fullRecordSearchResults"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="citingArticles">
+                <xs:sequence>
+                    <xs:element name="databaseId" type="xs:string"/>
+                    <xs:element name="uid" type="xs:string"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="editions" nillable="true" type="tns:editionDesc"/>
+                    <xs:element minOccurs="0" name="timeSpan" type="tns:timeSpan"/>
+                    <xs:element name="queryLanguage" type="xs:string"/>
+                    <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="citingArticlesResponse">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="return" type="tns:fullRecordSearchResults"/>
+                </xs:sequence>
+            </xs:complexType>
+        </xs:schema>
+    </wsdl:types>
+    <wsdl:message name="relatedRecordsResponse">
+        <wsdl:part element="tns:relatedRecordsResponse" name="parameters">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="relatedRecords">
+        <wsdl:part element="tns:relatedRecords" name="parameters">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="retrieveById">
+        <wsdl:part element="tns:retrieveById" name="parameters">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="retrieveResponse">
+        <wsdl:part element="tns:retrieveResponse" name="parameters">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="ESTIWSException_Exception">
+        <wsdl:part element="tns:ESTIWSException" name="ESTIWSException_Exception">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="InternalServerException_Exception">
+        <wsdl:part element="tns:InternalServerException" name="InternalServerException_Exception">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="retrieve">
+        <wsdl:part element="tns:retrieve" name="parameters">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="searchResponse">
+        <wsdl:part element="tns:searchResponse" name="parameters">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="citingArticlesResponse">
+        <wsdl:part element="tns:citingArticlesResponse" name="parameters">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="AuthenticationException_Exception">
+        <wsdl:part element="tns:AuthenticationException" name="AuthenticationException_Exception">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="retrieveByIdResponse">
+        <wsdl:part element="tns:retrieveByIdResponse" name="parameters">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="search">
+        <wsdl:part element="tns:search" name="parameters">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="citingArticles">
+        <wsdl:part element="tns:citingArticles" name="parameters">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="citedReferences">
+        <wsdl:part element="tns:citedReferences" name="parameters">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="citedReferencesRetrieve">
+        <wsdl:part element="tns:citedReferencesRetrieve" name="parameters">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="citedReferencesRetrieveResponse">
+        <wsdl:part element="tns:citedReferencesRetrieveResponse" name="parameters">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="QueryException_Exception">
+        <wsdl:part element="tns:QueryException" name="QueryException_Exception">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="InvalidInputException_Exception">
+        <wsdl:part element="tns:InvalidInputException" name="InvalidInputException_Exception">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="citedReferencesResponse">
+        <wsdl:part element="tns:citedReferencesResponse" name="parameters">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="SessionException_Exception">
+        <wsdl:part element="tns:SessionException" name="SessionException_Exception">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:portType name="WokSearch">
+        <wsdl:operation name="citedReferences">
+            <wsdl:input message="tns:citedReferences" name="citedReferences">
+            </wsdl:input>
+            <wsdl:output message="tns:citedReferencesResponse" name="citedReferencesResponse">
+            </wsdl:output>
+            <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="citedReferencesRetrieve">
+            <wsdl:input message="tns:citedReferencesRetrieve" name="citedReferencesRetrieve">
+            </wsdl:input>
+            <wsdl:output message="tns:citedReferencesRetrieveResponse" name="citedReferencesRetrieveResponse">
+            </wsdl:output>
+            <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="relatedRecords">
+            <wsdl:input message="tns:relatedRecords" name="relatedRecords">
+            </wsdl:input>
+            <wsdl:output message="tns:relatedRecordsResponse" name="relatedRecordsResponse">
+            </wsdl:output>
+            <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="retrieveById">
+            <wsdl:input message="tns:retrieveById" name="retrieveById">
+            </wsdl:input>
+            <wsdl:output message="tns:retrieveByIdResponse" name="retrieveByIdResponse">
+            </wsdl:output>
+            <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="retrieve">
+            <wsdl:input message="tns:retrieve" name="retrieve">
+            </wsdl:input>
+            <wsdl:output message="tns:retrieveResponse" name="retrieveResponse">
+            </wsdl:output>
+            <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="search">
+            <wsdl:input message="tns:search" name="search">
+            </wsdl:input>
+            <wsdl:output message="tns:searchResponse" name="searchResponse">
+            </wsdl:output>
+            <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="citingArticles">
+            <wsdl:input message="tns:citingArticles" name="citingArticles">
+            </wsdl:input>
+            <wsdl:output message="tns:citingArticlesResponse" name="citingArticlesResponse">
+            </wsdl:output>
+            <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+            <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="WokSearchServiceSoapBinding" type="tns:WokSearch">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="citedReferences">
+            <soap:operation soapAction="" style="document"/>
+            <wsdl:input name="citedReferences">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output name="citedReferencesResponse">
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="citedReferencesRetrieve">
+            <soap:operation soapAction="" style="document"/>
+            <wsdl:input name="citedReferencesRetrieve">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output name="citedReferencesRetrieveResponse">
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="relatedRecords">
+            <soap:operation soapAction="" style="document"/>
+            <wsdl:input name="relatedRecords">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output name="relatedRecordsResponse">
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="retrieveById">
+            <soap:operation soapAction="" style="document"/>
+            <wsdl:input name="retrieveById">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output name="retrieveByIdResponse">
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="retrieve">
+            <soap:operation soapAction="" style="document"/>
+            <wsdl:input name="retrieve">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output name="retrieveResponse">
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="search">
+            <soap:operation soapAction="" style="document"/>
+            <wsdl:input name="search">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output name="searchResponse">
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="citingArticles">
+            <soap:operation soapAction="" style="document"/>
+            <wsdl:input name="citingArticles">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output name="citingArticlesResponse">
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+            </wsdl:fault>
+            <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="WokSearchService">
+        <wsdl:port binding="tns:WokSearchServiceSoapBinding" name="WokSearchPort">
+            <soap:address location="http://search.webofknowledge.com/esti/wokmws/ws/WokSearch"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/spec/lib/web_of_science/client_spec.rb
+++ b/spec/lib/web_of_science/client_spec.rb
@@ -1,8 +1,9 @@
 # http://savonrb.com/version2/testing.html
 # require the helper module
 require 'savon/mock/spec_helper'
+require_relative 'wsdl'
 
-describe WebOfScience::Client do
+describe WebOfScience::Client, :vcr do
   include Savon::SpecHelper
 
   # set Savon in and out of mock mode
@@ -15,6 +16,8 @@ describe WebOfScience::Client do
   let(:no_session_matches) { File.read('spec/fixtures/wos_client/wos_session_close_fault_response.xml') }
 
   before do
+    WebOfScience::WSDL.stub_auth_wsdl
+    WebOfScience::WSDL.stub_search_wsdl
     null_logger = Logger.new('/dev/null')
     allow(wos_client).to receive(:logger).and_return(null_logger)
   end

--- a/spec/lib/web_of_science/wsdl.rb
+++ b/spec/lib/web_of_science/wsdl.rb
@@ -1,0 +1,41 @@
+# rubocop:disable Style/ClassVars
+require 'faraday'
+require 'webmock'
+
+module WebOfScience
+  # WebOfScience WSDL files
+  class WSDL
+    WSDL_AUTH_FILE = Rails.root.join('spec', 'fixtures', 'wos_client', 'authenticate_wsdl.xml').freeze
+    WSDL_SEARCH_FILE = Rails.root.join('spec', 'fixtures', 'wos_client', 'search_wsdl.xml').freeze
+
+    WSDL_AUTH = 'http://search.webofknowledge.com/esti/wokmws/ws/WOKMWSAuthenticate?wsdl'.freeze
+    WSDL_SEARCH = 'http://search.webofknowledge.com/esti/wokmws/ws/WokSearch?wsdl'.freeze
+
+    class << self
+
+      @@fetched = false
+
+      def stub_auth_wsdl
+        fetch
+        WebMock.stub_request(:get, WSDL_AUTH)
+               .to_return(status: 200, body: File.read(WSDL_AUTH_FILE))
+      end
+
+      def stub_search_wsdl
+        fetch
+        WebMock.stub_request(:get, WSDL_SEARCH)
+               .to_return(status: 200, body: File.read(WSDL_SEARCH_FILE))
+      end
+
+      def fetch
+        return if @@fetched
+        response = Faraday.get(WSDL_AUTH)
+        File.open(WSDL_AUTH_FILE, 'w') { |f| f.write(response.body) } if response.success?
+        response = Faraday.get(WSDL_SEARCH)
+        File.open(WSDL_SEARCH_FILE, 'w') { |f| f.write(response.body) } if response.success?
+        @@fetched = true
+      end
+    end
+  end
+end
+# rubocop:enable Style/ClassVars

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -168,18 +168,5 @@ def default_institution
   )
 end
 
-
-WOS_AUTH_WSDL = File.read('spec/fixtures/wos_client/authenticate_wsdl.xml')
-def stub_wos_auth_wsdl
-  raise unless WebOfScience::Client::API_VERSION == '3.0'
-  stub_request(:get, WebOfScience::Client::AUTH_WSDL).
-    to_return(status: 200, body: WOS_AUTH_WSDL)
-end
-
-WOS_SEARCH_WSDL = File.read('spec/fixtures/wos_client/search_wsdl.xml')
-def stub_wos_search_wsdl
-  raise unless WebOfScience::Client::API_VERSION == '3.0'
-  stub_request(:get, WebOfScience::Client::SEARCH_WSDL).
-    to_return(status: 200, body: WOS_SEARCH_WSDL)
-end
-
+require_relative 'lib/web_of_science/wsdl'
+WebOfScience::WSDL.fetch

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -167,3 +167,19 @@ def default_institution
     Agent::AuthorAddress.new(Settings.HARVESTER.INSTITUTION.address.to_hash)
   )
 end
+
+
+WOS_AUTH_WSDL = File.read('spec/fixtures/wos_client/authenticate_wsdl.xml')
+def stub_wos_auth_wsdl
+  raise unless WebOfScience::Client::API_VERSION == '3.0'
+  stub_request(:get, WebOfScience::Client::AUTH_WSDL).
+    to_return(status: 200, body: WOS_AUTH_WSDL)
+end
+
+WOS_SEARCH_WSDL = File.read('spec/fixtures/wos_client/search_wsdl.xml')
+def stub_wos_search_wsdl
+  raise unless WebOfScience::Client::API_VERSION == '3.0'
+  stub_request(:get, WebOfScience::Client::SEARCH_WSDL).
+    to_return(status: 200, body: WOS_SEARCH_WSDL)
+end
+


### PR DESCRIPTION
Try to lighten the load of VCR recordings for WOS specs.  The intention of this PR is to provide two generic methods that stub the retrieval of WSDL data for the authentication and search endpoints of the WOS-API.  It's beyond the scope of this PR to apply them everywhere, which can be done in follow on PRs.

- if it were possible, it would be better to initialize the `WebOfScience::Client` with these files every time so that the auth and search Savon clients could be initialized with them.  AFAICT, this is not an option for the Savon client, it only accepts a WSDL URL.  If I'm wrong about this (and I hope so), then these fixture files could be used as such and the nature of this PR would change substantially - the focus could shift from using these fixtures in specs only to using them all the time.


### Testing
- wos-client tests with `:vcr` enabled shows recordings of the WSDLs, the content of the following files includes the WSDL when those requests are _not_ stubbed.
```
$ tree fixtures/vcr_cassettes/WebOfScience_Client/
fixtures/vcr_cassettes/WebOfScience_Client/
├── _authenticate
│   └── authenticates_with_the_service.yml
├── _search
│   └── works.yml
├── _session_close
│   ├── resets_the_client.yml
│   └── when_there_are_no_matches_returned_for_SessionID
│       └── creates_a_logger_and_works.yml
└── _session_id
    └── works.yml
```
- when the WSDL requests are stubbed, with `:vcr` enabled, there are no recordings:
```
$ ls -l fixtures/vcr_cassettes/WebOfScience_Client
ls: cannot access 'fixtures/vcr_cassettes/WebOfScience_Client': No such file or directory
```
