### PR TITLE
Sync identifiers in pub hash checks

### DIFF
--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -256,7 +256,8 @@ class Publication < ActiveRecord::Base
       pub_hash[:provenance].to_s.downcase
     end
 
-    # doesn't actually write the Pub to DB, presumed to be part of before_save callback or explicit save
+    # Doesn't actually write the Pub to DB, presumed to be part of before_save callback or explicit save
+    # Does delete pub_ids!
     def sync_identifiers_in_pub_hash
       incoming_types = Array(pub_hash[:identifier]).map { |id| id[:type] }
       publication_identifiers.each do |id|
@@ -265,7 +266,8 @@ class Publication < ActiveRecord::Base
       end
 
       Array(pub_hash[:identifier]).each do |identifier|
-        next if identifier[:type] =~ /^SULPubId$/i
+        next if identifier[:type].blank? || identifier[:type] =~ /^SULPubId$/i
+        next if identifier[:id].blank? # don't reproduce bad data
         i = publication_identifiers.find { |x| x.identifier_type == identifier[:type] } # find includes not yet saved pub ids
         i ||= publication_identifiers.find_or_initialize_by(identifier_type: identifier[:type])
         i.certainty        = 'confirmed'

--- a/spec/api/sul_bib/publications_api_spec.rb
+++ b/spec/api/sul_bib/publications_api_spec.rb
@@ -22,6 +22,7 @@ describe SulBib::API, :vcr do
     }
   end
   let(:valid_json_for_post) { valid_hash_for_post.to_json }
+  let(:doi_pub_id) { create(:doi_pub_id, identifier_value: '18819910019') }
 
   let(:invalid_json_for_post) do
     valid_hash_for_post.reject { |k, _| k == :authorship }.to_json
@@ -32,9 +33,9 @@ describe SulBib::API, :vcr do
       author: [{ name: 'henry lowe' }],
       authorship: [{
         cap_profile_id: '3810',
-       status: 'denied',
-       visibility: 'public',
-       featured: true
+        status: 'denied',
+        visibility: 'public',
+        featured: true
       }]
     ).to_json
   end
@@ -56,7 +57,7 @@ describe SulBib::API, :vcr do
       etal: true,
       identifier: [
         { type: 'isbn', id: '1177188188181' },
-        { type: 'doi', url: '18819910019' }
+        doi_pub_id.identifier
       ],
       last_updated: '2013-08-10T21:03Z',
       provenance: 'CAP',
@@ -71,7 +72,7 @@ describe SulBib::API, :vcr do
     valid_hash_for_post.merge(
       identifier: [
         { type: 'isbn', id: '1177188188181' },
-        { type: 'doi', url: '18819910019-updated' },
+        { type: 'doi', id: '18819910019-updated', url: '18819910019-updated' },
         { type: 'SULPubId', id: '164', url: Settings.SULPUB_ID.PUB_URI + '/164' }
       ]
     )
@@ -90,7 +91,7 @@ describe SulBib::API, :vcr do
     with_isbn_hash.merge(
       identifier: [
         { type: 'isbn', id: '1177188188181' },
-        { type: 'doi', url: '18819910019' },
+        doi_pub_id.identifier,
         { type: 'pmid', id: '999999999' },
       ]
     ).to_json
@@ -225,7 +226,7 @@ describe SulBib::API, :vcr do
         expect(result['identifier'].size).to eq(3)
         expect(result['identifier']).to include(
           a_hash_including('id' => '1177188188181', 'type' => 'isbn'),
-          a_hash_including('type' => 'doi', 'url' => '18819910019'),
+          a_hash_including('type' => 'doi', 'url' => 'http://dx.doi.org/18819910019'),
           a_hash_including('type' => 'SULPubId', 'url' => "#{Settings.SULPUB_ID.PUB_URI}/#{last_pub.id}", 'id' => last_pub.id.to_s)
         )
         expect(last_pub.publication_identifiers.size).to eq(2)

--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -134,6 +134,17 @@ describe Publication do
       expect(ids.first.identifier_uri).to eq('z2')
     end
 
+    it 'avoids writing back empty values' do # stop our bad data from spreading
+      pub_xyz.pub_hash = { identifier: [{ type: 'x', id: nil, url: 'z2' }, { type: 'q', id: nil, url: 'z2' }] }
+      pub_xyz.send(:sync_identifiers_in_pub_hash)
+      pub_xyz.save!
+      ids = PublicationIdentifier.where(publication_id: pub_xyz.id).all
+      expect(ids.size).to eq(1)
+      expect(ids.first.identifier_type).to eq('x')
+      expect(ids.first.identifier_value).to eq('y')
+      expect(ids.first.identifier_uri).to eq('z')
+    end
+
     it 'deletes ids from the database that are not longer in the pub_hash' do
       pub_xyz.pub_hash = { identifier: [{ type: 'a', id: 'b', url: 'c' }] }
       pub_xyz.send(:sync_identifiers_in_pub_hash)

--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -103,13 +103,16 @@ describe Publication do
   end
 
   describe 'sync_identifiers_in_pub_hash' do
-    it 'should sync identifiers in the pub hash to the database' do
+    let(:pub_xyz) do
       publication.pub_hash = { identifier: [{ type: 'x', id: 'y', url: 'z' }] }
       publication.send(:sync_identifiers_in_pub_hash)
       publication.save!
-      i = PublicationIdentifier.last
-      expect(i.identifier_type).to eq('x')
-      expect(publication.publication_identifiers.reload).to include(i)
+      publication
+    end
+
+    it 'should sync identifiers in the pub hash to the database' do
+      expect(pub_xyz.publication_identifiers.reload)
+        .to include(PublicationIdentifier.find_by(identifier_type: 'x', identifier_value: 'y'))
     end
 
     it 'should not persist SULPubIds' do
@@ -121,29 +124,22 @@ describe Publication do
     end
 
     it 'updates existing ids with new values' do
-      publication.pub_hash = { identifier: [{ type: 'x', id: 'y', url: 'z' }] }
-      publication.send(:sync_identifiers_in_pub_hash)
-      publication.save!
-      publication.pub_hash = { identifier: [{ type: 'x', id: 'y2', url: 'z2' }] }
-      publication.send(:sync_identifiers_in_pub_hash)
-      publication.save!
-      ids = PublicationIdentifier.where(publication_id: publication.id).all
-      expect(ids).not_to be_empty
+      pub_xyz.pub_hash = { identifier: [{ type: 'x', id: 'y2', url: 'z2' }] }
+      pub_xyz.send(:sync_identifiers_in_pub_hash)
+      pub_xyz.save!
+      ids = PublicationIdentifier.where(publication_id: pub_xyz.id).all
+      expect(ids.size).to eq(1)
       expect(ids.first.identifier_type).to eq('x')
       expect(ids.first.identifier_value).to eq('y2')
       expect(ids.first.identifier_uri).to eq('z2')
-      expect(ids.size).to eq(1)
     end
 
     it 'deletes ids from the database that are not longer in the pub_hash' do
-      publication.pub_hash = { identifier: [{ type: 'x', id: 'y', url: 'z' }] }
-      publication.send(:sync_identifiers_in_pub_hash)
-      publication.save!
-      publication.pub_hash = { identifier: [{ type: 'a', id: 'b', url: 'c' }] }
-      publication.send(:sync_identifiers_in_pub_hash)
-      publication.save!
-      expect(PublicationIdentifier.where(publication_id: publication.id, identifier_type: 'x').count).to eq(0)
-      expect(PublicationIdentifier.where(publication_id: publication.id, identifier_type: 'a').count).to eq(1)
+      pub_xyz.pub_hash = { identifier: [{ type: 'a', id: 'b', url: 'c' }] }
+      pub_xyz.send(:sync_identifiers_in_pub_hash)
+      pub_xyz.save!
+      expect(PublicationIdentifier.where(publication_id: pub_xyz.id, identifier_type: 'x').count).to eq(0)
+      expect(PublicationIdentifier.where(publication_id: pub_xyz.id, identifier_type: 'a').count).to eq(1)
     end
 
     it 'does not delete legacy_cap_pub_id when missing from the incoming pub_hash' do


### PR DESCRIPTION
This should keep us from writing empty data back to the pub IDs table, especially during trying to clean up that same data.

Related to #285