### PR TITLE
WebOfScience::Retriever - refactor to behave as Enumerable

### DIFF
--- a/lib/web_of_science.rb
+++ b/lib/web_of_science.rb
@@ -1,4 +1,5 @@
 # rubocop:disable Style/ClassVars
+require 'set'
 
 # Web of Science (WOS) utilities
 module WebOfScience
@@ -31,10 +32,8 @@ module WebOfScience
   # We check in steps that the response is XML and it includes the correct content.
   def self.working?
     uids = %w[WOS:A1976BW18000001 WOS:A1972N549400003]
-    retriever = queries.retrieve_by_id(uids)
-    records = retriever.next_batch
-    raise 'WebOfScience found no records' unless records.is_a?(WebOfScience::Records) && records.count > 0
-    raise 'WebOfScience failed to parse records' unless records.first.is_a?(WebOfScience::Record)
+    uids_retrieved = queries.retrieve_by_id(uids).map(&:uid)
+    raise 'WebOfScience returned the wrong records' unless uids.to_set == uids_retrieved.to_set
     true
   end
 

--- a/lib/web_of_science/process_records.rb
+++ b/lib/web_of_science/process_records.rb
@@ -8,10 +8,10 @@ module WebOfScience
     include WebOfScience::ProcessPubmed
 
     # @param author [Author]
-    # @param records [WebOfScience::Records]
+    # @param records [Enumerable<WebOfScience::Record>]
     def initialize(author, records)
       raise(ArgumentError, 'author must be an Author') unless author.is_a? Author
-      raise(ArgumentError, 'records must be an WebOfScience::Records') unless records.is_a? WebOfScience::Records
+      raise(ArgumentError, 'records must be an Enumerable') unless records.is_a? Enumerable
       raise 'Nothing to do when Settings.WOS.ACCEPTED_DBS is empty' if Settings.WOS.ACCEPTED_DBS.empty?
       @author = author
       @records = records.select { |rec| Settings.WOS.ACCEPTED_DBS.include? rec.database }

--- a/lib/web_of_science/query_author.rb
+++ b/lib/web_of_science/query_author.rb
@@ -19,8 +19,7 @@ module WebOfScience
     def uids
       # TODO: iterate on author identities also, or leave that to the consumer of this class?
       # Implementation note: these records have a relatively small memory footprint, just UIDs
-      retriever = queries.search(author_query)
-      retriever.merged_uids
+      queries.search(author_query).map(&:uid)
     end
 
     private

--- a/lib/web_of_science/retriever.rb
+++ b/lib/web_of_science/retriever.rb
@@ -6,9 +6,9 @@ module WebOfScience
   # - the "next_batch?" is like "next?"
   # - the "next_batch" is like "next"
   class Retriever
+    include Enumerable
 
     attr_reader :records_found
-    attr_reader :records_retrieved
 
     # @param [Symbol] operation SOAP operation like :search, :retrieve_by_id etc.
     # @param [Hash] message SOAP query message
@@ -16,57 +16,42 @@ module WebOfScience
     # @example
     #   WebOfScience::Retriever.new(:cited_references, message)
     def initialize(operation, message, batch_size = MAX_RECORDS)
+      @batch = []
       @batch_iteration = 0
       @batch_size = batch_size
-      @query = message
       @operation = operation
       @response_type = "#{operation}_response".to_sym
+      @query = message
+      @query_id = -99
+      @records_found = -99
+      @records_retrieved = 0
     end
 
-    # @return [Boolean] all records retrieved?
-    def records_retrieved?
-      @batch_one.nil? ? false : records_retrieved == records_found
-    end
-
-    # Retrieve and merge all records
-    # WARNING - this can exceed memory allocations
-    # @return [WebOfScience::Records]
-    def merged_records
-      all_records = batch_one
-      while next_batch?
-        this_batch = next_batch
-        all_records = all_records.merge_records(this_batch) unless this_batch.nil?
-      end
-      all_records
-    end
-
-    # Retrieve and collect all record UIDs
-    # @return [Array<String>] WosUIDs
-    def merged_uids
-      uids = batch_one.uids
-      uids += next_batch.uids while next_batch?
-      uids
+    # @yield [WebOfScience::Record]
+    def each
+      next_batch.each { |rec| yield rec } while next_batch?
+      reset
     end
 
     # @return [Boolean] are more records available?
     def next_batch?
-      @batch_one.nil? || records_retrieved < records_found
+      records_found < 0 || records_retrieved < records_found
     end
 
     # Retrieve the next batch of records (without merging).
-    # @return [WebOfScience::Records, nil]
+    # @return [Array<WebOfScience::Record>]
     def next_batch
-      return batch_one if @batch_one.nil?
-      return if records_retrieved?
-      retrieve_batch
+      next_batch? ? retrieve_batch : []
     end
 
-    # Reset the batch retrieval to start again (after the first batch)
-    # Never discard batch_one, it belongs to the query_id
+    # Reset the batch retrieval to start again
     # @return [void]
     def reset
+      @batch = []
       @batch_iteration = 0
-      @records_retrieved = batch_one.count
+      @query_id = -99
+      @records_found = -99
+      @records_retrieved = 0
     end
 
     private
@@ -74,42 +59,43 @@ module WebOfScience
       # this is the maximum number that can be returned in a single query by WoS
       MAX_RECORDS = 100
 
+      attr_reader :batch
       attr_reader :batch_size
       attr_reader :operation # SOAP operations, like :search, :retrieve_by_id etc.
       attr_reader :query
       attr_reader :query_id
       attr_reader :response_type
+      attr_reader :records_retrieved
 
       delegate :client, to: WebOfScience
 
       # Fetch the first batch of results.  The first query-response is special; it's the only
       # response that contains the entire query response metadata, with query_id and records_found.
-      # @return [WebOfScience::Records]
+      # @return [Array<WebOfScience::Record>]
       def batch_one
-        @batch_one ||= begin
-          response = client.search.call(operation, message: query)
-          records = response_records(response, response_type)
-          @records_found = response_return(response, response_type)[:records_found].to_i
-          @records_retrieved = records.count
-          @query_id = response_return(response, response_type)[:query_id].to_i
-          records
-        end
+        response = client.search.call(operation, message: query)
+        @batch = response_records(response, response_type)
+        @records_found = response_return(response, response_type)[:records_found].to_i
+        @records_retrieved = batch.count
+        @query_id = response_return(response, response_type)[:query_id].to_i
+        batch
       end
 
       # The retrieve operation is different from the first query, because it uses
       # a query_id and a :retrieve operation to retrieve additional records
-      # @return [WebOfScience::Records]
+      # @return [Array<WebOfScience::Record>]
       def retrieve_batch
         @batch_iteration += 1
+        return batch_one if query_id < 0
         offset = (@batch_iteration * batch_size) + 1
         retrieve_message = {
           queryId: query_id,
           retrieveParameters: query[:retrieveParameters].merge(firstRecord: offset)
         }
         response = client.search.call(retrieve_operation, message: retrieve_message)
-        records = response_records(response, "#{retrieve_operation}_response".to_sym)
-        @records_retrieved += records.count
-        records
+        @batch = response_records(response, "#{retrieve_operation}_response".to_sym)
+        @records_retrieved += batch.count
+        batch
       end
 
       # The retrieve operation is `:retrieve`, except for a :cited_references query
@@ -130,9 +116,9 @@ module WebOfScience
 
       # @param response [Savon::Response] a WoS SOAP response
       # @param response_type [Symbol] a WoS SOAP response type
-      # @return [WebOfScience::Records]
+      # @return [Array<WebOfScience::Record>]
       def response_records(response, response_type)
-        WebOfScience::Records.new(records: response_return(response, response_type)[:records])
+        WebOfScience::Records.new(records: response_return(response, response_type)[:records]).to_a
       end
   end
 end

--- a/spec/lib/web_of_science/process_records_spec.rb
+++ b/spec/lib/web_of_science/process_records_spec.rb
@@ -13,6 +13,9 @@ describe WebOfScience::ProcessRecords, :vcr do
     # ---
     # Happy paths
 
+    it 'accepts an Enumerable for records' do
+      expect { described_class.new(author, []) }.not_to raise_error
+    end
     it 'returns an Array' do
       expect(processor.execute).to be_an Array
     end
@@ -59,7 +62,7 @@ describe WebOfScience::ProcessRecords, :vcr do
       expect { described_class.new('author', records) }.to raise_error(ArgumentError)
     end
     it 'raises ArgumentError for records' do
-      expect { described_class.new(author, []) }.to raise_error(ArgumentError)
+      expect { described_class.new(author, nil) }.to raise_error(ArgumentError)
     end
     it 'raises RuntimeError when Settings.WOS.ACCEPTED_DBS.empty?' do
       wos = Settings.WOS

--- a/spec/lib/web_of_science/queries_spec.rb
+++ b/spec/lib/web_of_science/queries_spec.rb
@@ -78,7 +78,9 @@ describe WebOfScience::Queries do
       expect(retriever.next_batch.count >= 1).to be true
     end
     it 'returns a publication matching the query' do
-      expect(retriever.next_batch.doc.search('titles').text).to include title
+      record = retriever.first
+      expect(record).to be_a WebOfScience::Record
+      expect(record.titles['item']).to eq title
     end
   end
 
@@ -108,7 +110,7 @@ describe WebOfScience::Queries do
       savon.expects(:retrieve_by_id).with(message: :any).returns(wos_retrieve_by_id_response)
       retriever = wos_queries.retrieve_by_id(wos_ids)
       expect(retriever).to be_an WebOfScience::Retriever
-      expect(retriever.next_batch.uids).to eq(wos_ids)
+      expect(retriever.next_batch.map(&:uid)).to eq(wos_ids)
     end
   end
 


### PR DESCRIPTION
- this is a time-boxed PR to explore an Enumerable pattern for the WOS-retriever
  - the `next_batch` method is still public
  - some routine enumerable methods are enabled
  - broken specs have been fixed