### PR TITLE
Remove unused dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gem 'grape', '~> 0.19'
 gem 'rails', '~> 4.2.10'
-gem 'responders', '~> 2.4'
 
 # Use sass-powered bootstrap
 gem 'bootstrap-sass', '~> 3.3.7'
@@ -21,7 +20,6 @@ gem 'activerecord-import'
 # To use ActiveModel has_secure_password
 # gem 'bcrypt-ruby', '~> 3.0.0'
 gem 'bibtex-ruby'
-gem 'bio'
 gem 'citeproc-ruby', '~> 1.1'
 gem 'config'
 gem 'csl-styles', '~> 1.0'
@@ -44,12 +42,10 @@ gem 'okcomputer' # for monitoring
 gem 'paper_trail'
 gem 'parallel'
 gem 'pry-rails'
-gem 'pubmed_search'
 gem 'rake'
 gem 'savon', '~> 2.12'
 gem 'simple_form'
 gem 'StreetAddress', '~> 1.0', '>= 1.0.6'
-gem 'turnout'
 gem 'whenever', require: false
 gem 'yaml_db'
 
@@ -69,7 +65,6 @@ group :development do
   gem 'pry-doc'
   gem 'ruby-prof'
   gem 'thin' # app server
-  gem 'web-console', '~> 3.3'
 end
 
 group :test do
@@ -79,7 +74,6 @@ group :test do
   gem 'equivalent-xml'
   gem 'factory_bot_rails'
   gem 'simplecov', '~> 0.13', require: false
-  gem 'single_cov'
   gem 'vcr'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,6 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     bibtex-ruby (4.4.5)
       latex-decode (~> 0.0)
-    bio (1.5.1)
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
@@ -126,7 +125,6 @@ GEM
       csl (~> 1.0)
     daemons (1.2.6)
     database_cleaner (1.6.2)
-    debug_inspector (0.0.3)
     deep_merge (1.2.1)
     delayed_job (4.1.4)
       activesupport (>= 3.0, < 5.2)
@@ -282,8 +280,6 @@ GEM
     pry-rails (0.3.6)
       pry (>= 0.10.4)
     public_suffix (3.0.1)
-    pubmed_search (0.4.0)
-      nokogiri
     rack (1.6.8)
     rack-accept (0.4.5)
       rack (>= 0.4)
@@ -334,9 +330,6 @@ GEM
       ffi (>= 0.5.0, < 2)
     ref (2.0.0)
     request_store (1.3.2)
-    responders (2.4.0)
-      actionpack (>= 4.2.0, < 5.3)
-      railties (>= 4.2.0, < 5.3)
     retina_tag (1.4.1)
       rails (>= 3.1)
     rspec (3.7.0)
@@ -399,7 +392,6 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    single_cov (0.7.0)
     socksify (1.7.1)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
@@ -425,11 +417,6 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.8)
     tins (1.15.0)
-    turnout (2.4.1)
-      i18n (~> 0.7)
-      rack (>= 1.3, < 3)
-      rack-accept (~> 0.4)
-      tilt (>= 1.4, < 3)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (4.1.6)
@@ -445,10 +432,6 @@ GEM
     wasabi (3.5.0)
       httpi (~> 2.0)
       nokogiri (>= 1.4.2)
-    web-console (3.3.0)
-      activemodel (>= 4.2)
-      debug_inspector
-      railties (>= 4.2)
     webmock (3.3.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -469,7 +452,6 @@ DEPENDENCIES
   StreetAddress (~> 1.0, >= 1.0.6)
   activerecord-import
   bibtex-ruby
-  bio
   bootstrap-sass (~> 3.3.7)
   byebug
   capistrano
@@ -509,11 +491,9 @@ DEPENDENCIES
   parallel
   pry-doc
   pry-rails
-  pubmed_search
   rails (~> 4.2.10)
   rails_db
   rake
-  responders (~> 2.4)
   retina_tag
   rspec
   rspec-rails (~> 3.7)
@@ -522,13 +502,10 @@ DEPENDENCIES
   savon (~> 2.12)
   simple_form
   simplecov (~> 0.13)
-  single_cov
   therubyracer
   thin
-  turnout
   uglifier (~> 4.1)
   vcr
-  web-console (~> 3.3)
   webmock
   whenever
   yaml_db

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-# This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
 
 require 'pry'  # for debugging specs
@@ -7,12 +6,6 @@ Dir.glob(File.join(__dir__, 'fixtures', '**', '*.rb'), &method(:require)) # load
 
 require 'rspec/matchers'
 require 'equivalent-xml'
-
-if ENV['SINGLECOV']
-  require 'single_cov'
-  SingleCov.setup :rspec
-end
-
 require 'simplecov'
 require 'coveralls'
 # Coveralls interferes with coverage reports on a laptop, only wear it on CI builds


### PR DESCRIPTION
- `pubmed_search`: `PubmedSearch` unused;
- `responders`: provides `responders` and `respond_with`, both unused;
- `single_cov`: dev tool, not used;
- `turnout`: rack middleware for going into "maintenance mode", unused;
- `web-console`: not relevant for a JSON API.
- `bio`: a **bio-informatics** lib, obviously unused. WTF? Are we doing genetic sequencing here?