### PR TITLE
Remove identity type from author identity

### DIFF
--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -2,20 +2,7 @@ class Author < ActiveRecord::Base
   has_paper_trail on: [:destroy]
   validates :cap_profile_id, uniqueness: true, presence: true
 
-  has_many :author_identities, dependent: :destroy
-  #
-  # An Author may have zero or more author identities and this method fetches
-  # any matching AuthorIdentity objects tagged as an "alternate"
-  #
-  # @example
-  #   `Author.find_by(1234).alternative_identities.present?`
-  #   `Author.find_by(1234).alternative_identities => [AuthorIdentity1, ...]`
-  #
-  # @return [Array<AuthorIdentity>]
-  #
-  def alternative_identities
-    author_identities.where('identity_type = ?', AuthorIdentity.identity_types[:alternate])
-  end
+  has_many :author_identities, dependent: :destroy, autosave: true
 
   # Provide consistent API for Author and AuthorIdentity
   alias_attribute :first_name, :preferred_first_name

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -73,8 +73,7 @@ class Author < ActiveRecord::Base
 
   # @param [Hash] auth_hash data as-is from CAP API
   def update_from_cap_authorship_profile_hash(auth_hash)
-    seed_hash = Author.build_attribute_hash_from_cap_profile(auth_hash)
-    assign_attributes seed_hash
+    assign_attributes Author.build_attribute_hash_from_cap_profile(auth_hash)
     mirror_author_identities(auth_hash['importSettings'])
   end
 
@@ -83,25 +82,23 @@ class Author < ActiveRecord::Base
   def mirror_author_identities(import_settings)
     return unless import_settings.present?
     transaction do
-      author_identities.clear unless new_record? # drop all existing identities
-
+      author_identities.clear # drop all existing identities
       import_settings.each do |i|
-        # create record with required attributes
-        ai = AuthorIdentity.new(
-          author:         self,
-          identity_type:  :alternate,
-          first_name:     i['firstName'],
-          last_name:      i['lastName']
-        )
-        # update record with optional attributes
-        ai.middle_name = i['middleName']         if i['middleName'].present?
-        ai.email = i['email']                    if i['email'].present?
-        ai.institution = i['institution']        if i['institution'].present?
-        ai.start_date = i['startDate']['value']  if i['startDate'].present?
-        ai.end_date = i['endDate']['value']      if i['endDate'].present?
-
+        # required attributes
+        attribs = {
+          first_name: i['firstName'],
+          last_name:  i['lastName']
+        }
+        # optional attributes
+        attribs[:middle_name] = i['middleName']         if i['middleName'].present?
+        attribs[:email      ] = i['email']              if i['email'].present?
+        attribs[:institution] = i['institution']        if i['institution'].present?
+        attribs[:start_date ] = i['startDate']['value'] if i['startDate'].present?
+        attribs[:end_date   ] = i['endDate']['value']   if i['endDate'].present?
         # ensure that we have a *new* identity worth saving
-        ai.save! if author_identity_different?(ai)
+        next unless author_identity_different?(attribs)
+        # can't call create! on an unsaved record
+        new_record? ? author_identities.build(attribs) : author_identities.create!(attribs)
       end
     end
   end
@@ -141,10 +138,9 @@ class Author < ActiveRecord::Base
   # @return [Author] newly fetched, created and saved Author object
   def self.fetch_from_cap_and_create(profile_id, cap_client = Cap::Client.new)
     profile_hash = cap_client.get_auth_profile(profile_id)
-    a = Author.new
-    a.update_from_cap_authorship_profile_hash(profile_hash)
-    a.save!
-    a
+    Author.create!(Author.build_attribute_hash_from_cap_profile(profile_hash)) do |a|
+      a.mirror_author_identities(auth_hash['importSettings'])
+    end
   end
 
   # @return [Boolean]
@@ -154,17 +150,17 @@ class Author < ActiveRecord::Base
 
   private
 
-    # @param [AuthorIdentity] author_identity is the candidate versus `self`'s identity
+    # @param [Hash<Symbol => String>] attribs the candidate versus `self`'s identity
     # @return [Boolean] Is this author's identity different than our current identity?
-    def author_identity_different?(author_identity)
+    def author_identity_different?(attribs)
       !(
         # not the identical identity where Author is assumed to be Stanford University
         # checks in order of likelihood of changes
         # note that this code works for nil/empty string comparisons by calling `to_s`
-        first_name.to_s.casecmp(author_identity.first_name.to_s) == 0 &&
-        middle_name.to_s.casecmp(author_identity.middle_name.to_s) == 0 &&
-        last_name.to_s.casecmp(author_identity.last_name.to_s) == 0 &&
-        institution.to_s.casecmp(author_identity.institution.to_s) == 0
+        first_name.to_s.casecmp(attribs[:first_name].to_s) == 0 &&
+        middle_name.to_s.casecmp(attribs[:middle_name].to_s) == 0 &&
+        last_name.to_s.casecmp(attribs[:last_name].to_s) == 0 &&
+        institution.to_s.casecmp(attribs[:institution].to_s) == 0
       )
     end
 end

--- a/app/models/author_identity.rb
+++ b/app/models/author_identity.rb
@@ -1,12 +1,9 @@
 class AuthorIdentity < ActiveRecord::Base
   has_paper_trail on: [:destroy]
-
-  belongs_to :author
-
-  enum identity_type: { alternate: 0 } # may be expanded to include other types
+  belongs_to :author, inverse_of: :author_identities
 
   # required attributes will raise exceptions if nil
-  validates :author, :first_name, :last_name, :identity_type, presence: true
+  validates :author, :first_name, :last_name, presence: true
 
   # Converts an AuthorIdentity object to an AuthorAttributes object for use by other classes
   def to_author_attributes

--- a/db/migrate/20180224013914_remove_identity_type_from_author_identity.rb
+++ b/db/migrate/20180224013914_remove_identity_type_from_author_identity.rb
@@ -1,0 +1,5 @@
+class RemoveIdentityTypeFromAuthorIdentity < ActiveRecord::Migration
+  def change
+    remove_column :author_identities, :identity_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,20 +11,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180201233754) do
+ActiveRecord::Schema.define(version: 20180224013914) do
 
   create_table "author_identities", force: :cascade do |t|
-    t.integer  "author_id",     limit: 4,               null: false
-    t.integer  "identity_type", limit: 1,   default: 0, null: false
-    t.string   "first_name",    limit: 255,             null: false
-    t.string   "middle_name",   limit: 255
-    t.string   "last_name",     limit: 255,             null: false
-    t.string   "email",         limit: 255
-    t.string   "institution",   limit: 255
+    t.integer  "author_id",   limit: 4,   null: false
+    t.string   "first_name",  limit: 255, null: false
+    t.string   "middle_name", limit: 255
+    t.string   "last_name",   limit: 255, null: false
+    t.string   "email",       limit: 255
+    t.string   "institution", limit: 255
     t.date     "start_date"
     t.date     "end_date"
-    t.datetime "created_at",                            null: false
-    t.datetime "updated_at",                            null: false
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
   end
 
   add_index "author_identities", ["author_id"], name: "index_author_identities_on_author_id", using: :btree

--- a/lib/science_wire/harvest_broker.rb
+++ b/lib/science_wire/harvest_broker.rb
@@ -54,7 +54,7 @@ module ScienceWire
       # @return [Array<Integer>]
       def ids_for_alternate_names
         return [] unless alternate_name_query
-        author.alternative_identities.select { |author_identity| required_data_for_alt_names_search?(author_identity) }.map do |author_identity|
+        author.author_identities.select { |author_identity| required_data_for_alt_names_search?(author_identity) }.map do |author_identity|
           ids_from_dumb_query(author_identity.to_author_attributes).flatten
         end.flatten.uniq
       end

--- a/spec/factories/author.rb
+++ b/spec/factories/author.rb
@@ -68,7 +68,7 @@ FactoryBot.define do
     preferred_middle_name 'Biagio'
     email 'Russ.Altman@stanford.edu'
     emails_for_harvest 'Russ.Altman@stanford.edu'
-    # create some `author.alternative_identities`
+    # create some `author.author_identities`
     after(:create) do |author, _evaluator|
       create(:author_identity,
              author: author,

--- a/spec/integration/harvest_broker_spec.rb
+++ b/spec/integration/harvest_broker_spec.rb
@@ -58,7 +58,7 @@ feature 'Harvest Brokering', 'data-integration': true do
         # broker calls dumb search for an author with < 50 seeds
         expect(seeds.count).to be < 50
         expect(broker).not_to receive(:ids_from_smart_query)
-        # author.alternative_identities.select{|author_identity| required_data_for_alt_names_search(author_identity)}.count == 11
+        # author.author_identities.select{|author_identity| required_data_for_alt_names_search(author_identity)}.count == 11
         valid_alt_name_count = 11
         expected_calls = 1 + valid_alt_name_count
         expect(broker).to receive(:ids_from_dumb_query).exactly(expected_calls).and_call_original

--- a/spec/lib/cap/authors_poller_spec.rb
+++ b/spec/lib/cap/authors_poller_spec.rb
@@ -114,11 +114,10 @@ describe Cap::AuthorsPoller, :vcr do
     end
 
     context 'with an author retrieved from the CAP API' do
+      let(:author) { create :author }
       before do
         expect(Author).to receive(:find_by_cap_profile_id).with(author.cap_profile_id).and_return(nil)
         expect(Author).to receive(:fetch_from_cap_and_create).with(author.cap_profile_id, instance_of(Cap::Client)).and_return(author)
-        expect(author).to receive(:'save!').and_return(true)
-        allow(author).to receive(:new_record?).and_return(true)
       end
 
       it 'creates a new author' do
@@ -128,8 +127,8 @@ describe Cap::AuthorsPoller, :vcr do
 
       it 'harvests for new authors marked harvestable' do
         expect(author).to receive(:harvestable?).and_return(true)
-        queue = subject.instance_variable_get('@new_or_changed_authors_to_harvest_queue')
         subject.process_record(author_record)
+        queue = subject.instance_variable_get('@new_or_changed_authors_to_harvest_queue')
         expect(queue).to include(author.id)
       end
 

--- a/spec/lib/science_wire/harvest_broker_spec.rb
+++ b/spec/lib/science_wire/harvest_broker_spec.rb
@@ -11,26 +11,26 @@ describe ScienceWire::HarvestBroker do
   let(:alt_author) { create(:author_with_alternate_identities, alt_count: 3) }
   let(:alt_author_varying_institution) do
     auth = alt_author
-    alt = auth.alternative_identities.first
+    alt = auth.author_identities.first
     alt.institution = ''
     alt.save
-    alt = auth.alternative_identities.second
+    alt = auth.author_identities.second
     alt.institution = 'all'
     alt.save
-    alt = auth.alternative_identities.last
+    alt = auth.author_identities.last
     alt.institution = '*'
     alt.save
     auth
   end
   let(:alt_author_missing_name_pieces) do
     auth = alt_author
-    alt = auth.alternative_identities.first
+    alt = auth.author_identities.first
     alt.last_name = ''
     alt.save(validate: false)
-    alt = auth.alternative_identities.second
+    alt = auth.author_identities.second
     alt.first_name = ''
     alt.save(validate: false)
-    alt = auth.alternative_identities.last
+    alt = auth.author_identities.last
     alt.first_name = ''
     alt.last_name = ''
     alt.save(validate: false)

--- a/spec/models/author_spec.rb
+++ b/spec/models/author_spec.rb
@@ -1,4 +1,6 @@
 describe Author do
+  subject { create :author }
+
   let(:auth_hash) do
     JSON.parse(File.open('fixtures/cap_poll_author_3810.json', 'r').read)
   end


### PR DESCRIPTION
This field is identical throughout our production data.  That is to say, it does nothing!  Removing it was a little more cumbersome than I expected, thanks to additional scaffolding and logic that was built around it.

I took the chance to cleanup a couple other points where tests broke or had to be updated.