### PR TITLE
we need to quote the title search provided by the user

### DIFF
--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -60,10 +60,11 @@ class PublicationsController < ApplicationController
       all_matching_records += PubmedHarvester.search_all_sources_by_pmid(params[:pmid].strip)
     else
       raise ActionController::ParameterMissing, :title unless params[:title].presence
-      msg << "title '#{params[:title]}'"
+      title = params[:title].delete('"')
+      msg << "title '#{title}'"
       logger.info(msg)
       if Settings.WOS.enabled
-        query = "TI=\"#{params[:title]}\""
+        query = "TI=\"#{title}\""
         query += " AND PY=#{params[:year]}" if params[:year]
         wos_matches = WebOfScience.queries.user_query(query).next_batch.to_a # limit: only 1 batch
         all_matching_records += wos_matches

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -63,7 +63,7 @@ class PublicationsController < ApplicationController
       msg << "title '#{params[:title]}'"
       logger.info(msg)
       if Settings.WOS.enabled
-        query = "TI=#{params[:title]}"
+        query = "TI=\"#{params[:title]}\""
         query += " AND PY=#{params[:year]}" if params[:year]
         wos_matches = WebOfScience.queries.user_query(query).next_batch.to_a # limit: only 1 batch
         all_matching_records += wos_matches

--- a/spec/controllers/publications_controller_spec.rb
+++ b/spec/controllers/publications_controller_spec.rb
@@ -117,7 +117,12 @@ describe PublicationsController do
         end
         it 'includes year if provided' do
           expect(queries).to receive(:user_query).with('TI="xyz" AND PY=2001').and_return(retriever)
-          get :sourcelookup, title: 'xyz', year: 2001, format: 'json' # Partial title
+          get :sourcelookup, title: 'xyz', year: 2001, format: 'json' # Partial title with year
+        end
+        it 'remove quotes from user query to avoid parsing errors' do
+          expect(ScienceWireClient).not_to receive(:new)
+          expect(queries).to receive(:user_query).with('TI="xyz with quoted values in it"').and_return(retriever)
+          get :sourcelookup, title: 'xyz with "quoted values" in it', format: 'json' # title with quotes
         end
       end
     end

--- a/spec/controllers/publications_controller_spec.rb
+++ b/spec/controllers/publications_controller_spec.rb
@@ -112,11 +112,11 @@ describe PublicationsController do
 
         it 'hits WOS' do
           expect(ScienceWireClient).not_to receive(:new)
-          expect(queries).to receive(:user_query).with('TI=xyz').and_return(retriever)
+          expect(queries).to receive(:user_query).with('TI="xyz"').and_return(retriever)
           get :sourcelookup, title: 'xyz', format: 'json' # Partial title
         end
         it 'includes year if provided' do
-          expect(queries).to receive(:user_query).with('TI=xyz AND PY=2001').and_return(retriever)
+          expect(queries).to receive(:user_query).with('TI="xyz" AND PY=2001').and_return(retriever)
           get :sourcelookup, title: 'xyz', year: 2001, format: 'json' # Partial title
         end
       end


### PR DESCRIPTION
fixes #755
 to avoid issues with boolean operators in the title messing up the search...If you do a title search that includes a boolean operator, e.g. 
```GET https://sulcap-dev.stanford.edu/publications/sourcelookup?title=Nutrition and Mesenteric Issues in Pediatric Cardiac Critical Care.```

you will get a 500, which comes from the Clarivate API.  The reason is that if you don't add quotes around the title when constructing the query to clarivate it will interpret the "and" and "or" in the title incorrectly.