### PR TITLE
add pmcid to pub_hash when available from pubmed

### DIFF
--- a/lib/web_of_science/process_pubmed.rb
+++ b/lib/web_of_science/process_pubmed.rb
@@ -37,7 +37,10 @@ module WebOfScience
       if pubmed_record.nil?
         pubmed_cleanup(pub)
       else
-        pub.pub_hash.reverse_update(pubmed_record.source_as_hash)
+        pubmed_hash = pubmed_record.source_as_hash
+        pub.pub_hash.reverse_update(pubmed_hash)
+        pmc_id = pubmed_hash[:identifier].detect { |id| id[:type] == 'pmc' }
+        pub.pub_hash[:identifier] << pmc_id if pmc_id
         pub.pubhash_needs_update!
         pub.save!
       end

--- a/lib/web_of_science/process_record.rb
+++ b/lib/web_of_science/process_record.rb
@@ -93,6 +93,7 @@ module WebOfScience
         pub.pub_hash.reverse_update(pubmed_hash)
         pmc_id = pubmed_hash[:identifier].detect { |id| id[:type] == 'pmc' }
         pub.pub_hash[:identifier] << pmc_id if pmc_id
+        pub.pubhash_needs_update!
         pub.save
       rescue StandardError => err
         message = "Author: #{author.id}, #{record.uid}, PubmedSourceRecord failed, PMID: #{record.pmid}"

--- a/lib/web_of_science/process_record.rb
+++ b/lib/web_of_science/process_record.rb
@@ -89,7 +89,10 @@ module WebOfScience
         pub.save
         return if record.database == 'MEDLINE'
         pubmed_record = PubmedSourceRecord.for_pmid(record.pmid)
-        pub.pub_hash.reverse_update(pubmed_record.source_as_hash)
+        pubmed_hash = pubmed_record.source_as_hash
+        pub.pub_hash.reverse_update(pubmed_hash)
+        pmc_id = pubmed_hash[:identifier].detect { |id| id[:type] == 'pmc' }
+        pub.pub_hash[:identifier] << pmc_id if pmc_id
         pub.save
       rescue StandardError => err
         message = "Author: #{author.id}, #{record.uid}, PubmedSourceRecord failed, PMID: #{record.pmid}"

--- a/spec/fixtures/pubmed/pubmed_record_21253920.xml
+++ b/spec/fixtures/pubmed/pubmed_record_21253920.xml
@@ -132,6 +132,7 @@
         <ArticleIdList>
             <ArticleId IdType="pubmed">21253920</ArticleId>
             <ArticleId IdType="doi">10.1007/s12630-011-9462-1</ArticleId>
+            <ArticleId IdType="pmc">PMC1234567</ArticleId>
         </ArticleIdList>
     </PubmedData>
 </PubmedArticle>

--- a/spec/lib/web_of_science/process_pubmed_spec.rb
+++ b/spec/lib/web_of_science/process_pubmed_spec.rb
@@ -111,6 +111,12 @@ describe WebOfScience::ProcessPubmed, :vcr do
         expect(wos_pub.reload.pub_hash).to include(:mesh_headings)
       end
 
+      it 'persists PMC in identifier section of hash' do
+        expect(wos_pubmed_rec.pmid).to eq(wos_record.pmid.to_i) # ensure a wos_pubmed record exists
+        processor.pubmed_addition(wos_pub)
+        expect(wos_pub.reload.pub_hash[:identifier]).to include(type: 'pmc', id: 'PMC1234567')
+      end
+
       it 'cannot retrieve a PMID record, try to delete stuff' do
         expect(PubmedSourceRecord).to receive(:for_pmid).and_return(nil)
         expect(PubmedClient).to receive(:working?).and_return(false)

--- a/spec/lib/web_of_science/process_pubmed_spec.rb
+++ b/spec/lib/web_of_science/process_pubmed_spec.rb
@@ -112,9 +112,12 @@ describe WebOfScience::ProcessPubmed, :vcr do
       end
 
       it 'persists PMC in identifier section of hash' do
+        expect(wos_pub.publication_identifiers.where(identifier_type: 'pmc').count).to eq 0 # we not yet have a pmc row in publication identifier table
         expect(wos_pubmed_rec.pmid).to eq(wos_record.pmid.to_i) # ensure a wos_pubmed record exists
         processor.pubmed_addition(wos_pub)
-        expect(wos_pub.reload.pub_hash[:identifier]).to include(type: 'pmc', id: 'PMC1234567')
+        wos_pub.reload
+        expect(wos_pub.pub_hash[:identifier]).to include(type: 'pmc', id: 'PMC1234567')
+        expect(wos_pub.publication_identifiers.where(identifier_type: 'pmc').count).to eq 1 # we now have a pmc row in publication identifier table
       end
 
       it 'cannot retrieve a PMID record, try to delete stuff' do

--- a/spec/lib/web_of_science/process_record_spec.rb
+++ b/spec/lib/web_of_science/process_record_spec.rb
@@ -147,6 +147,13 @@ describe WebOfScience::ProcessRecord, :vcr do
     it_behaves_like '#execute'
     it_behaves_like 'pubs_with_pmid_have_mesh_headings'
 
+    it 'persists PMC in identifier section of hash' do
+      processor.execute
+      pub = Publication.find_by(wos_uid: record.uid)
+      expect(pub).not_to be_nil
+      expect(pub.pub_hash[:identifier]).to include(type: 'pmc', id: 'PMC1234567')
+    end
+
     context 'PubMed integration fails' do
       # only WOS records can be supplemented by PubMed data
       # any failure is not catastrophic - just log it

--- a/spec/lib/web_of_science/process_record_spec.rb
+++ b/spec/lib/web_of_science/process_record_spec.rb
@@ -152,6 +152,7 @@ describe WebOfScience::ProcessRecord, :vcr do
       pub = Publication.find_by(wos_uid: record.uid)
       expect(pub).not_to be_nil
       expect(pub.pub_hash[:identifier]).to include(type: 'pmc', id: 'PMC1234567')
+      expect(pub.publication_identifiers.where(identifier_type: 'pmc').count).to eq 1 # we have a row in publication identifier table
     end
 
     context 'PubMed integration fails' do


### PR DESCRIPTION
fixes #758 

mimics what was done for SW before here: https://github.com/sul-dlss/sul_pub/blob/master/app/models/publication.rb#L277-L286

Notes:
- why are there two methods that do this?  do we know?  can we eliminate one?