### PR TITLE
Add :name key to author block to mimic what is in SW records

### DIFF
--- a/lib/web_of_science/map_names.rb
+++ b/lib/web_of_science/map_names.rb
@@ -88,18 +88,28 @@ module WebOfScience
         name[:given_name] = given
         name[:first_name] = first if first.present?
         name[:middle_name] = middle if middle.present?
+        name[:name] = "#{name[:last_name]},#{name[:first_name]},#{name[:middle_name]}" # full name in the older style format used by Profiles/CAP
         name
       end
 
       # Parse the WOS names and return a Hash compatible with Csl::AuthorName
       # @return [Hash]
       def wos_name(name)
+        # look for the case where the first_name is the initials, with first and middle initials combined
+        # e.g. first_name = "RB", should be first_name = "R", middle_name = "B"
         match = name[:first_name].to_s.match(/\A([A-Z])([A-Z])/)
         if match
-          # first_name is the initials, with first and middle initials combined
           name[:first_name] = match[1]
           name[:middle_name] ||= match[2]
         end
+        # look for the case where the first name includes the middle initial optionally followed by a period
+        # e.g. first_name = "Russel B.", should be first_name = "Russel", middle_name = "B"
+        match = name[:first_name].to_s.match(/[\s][A-Z][.]?\z/)
+        if match
+          name[:first_name].delete!(match[0])
+          name[:middle_name] = match[0].strip[0]
+        end
+        name[:name] = "#{name[:last_name]},#{name[:first_name]},#{name[:middle_name]}" # full name in the older style format used by Profiles/CAP
         name
       end
   end

--- a/lib/web_of_science/map_names.rb
+++ b/lib/web_of_science/map_names.rb
@@ -104,11 +104,10 @@ module WebOfScience
         end
         # look for the case where the first name includes the middle initial optionally followed by a period
         # e.g. first_name = "Russel B.", should be first_name = "Russel", middle_name = "B"
-        match = name[:first_name].to_s.match(/[\s][A-Z][.]?\z/)
-        if match
-          name[:first_name].delete!(match[0])
-          name[:middle_name] = match[0].strip[0]
-        end
+        name[:first_name].gsub!(/\s[[:upper:]]\.?\z/) do |s|
+          name[:middle_name] = s.strip.chomp('.') # remove trailing spaces and periods
+          ''
+        end # block returns empty, removing match
         name[:name] = "#{name[:last_name]},#{name[:first_name]},#{name[:middle_name]}" # full name in the older style format used by Profiles/CAP
         name
       end

--- a/spec/lib/web_of_science/map_names_spec.rb
+++ b/spec/lib/web_of_science/map_names_spec.rb
@@ -33,7 +33,7 @@ describe WebOfScience::MapNames do
   shared_examples 'contains_author_data' do
     it 'has authors with a name key in hash' do
       expect(pub_hash[:author].size).to be > 0
-      pub_hash[:author].each { |author_name| expect(author_name[:name]).not_to be_nil }
+      expect(pub_hash[:author]).to all(match a_hash_including(name: be_present))
     end
     it 'has an authorcount' do
       expect(pub_hash[:authorcount]).not_to be_nil
@@ -60,6 +60,18 @@ describe WebOfScience::MapNames do
       expect(pub_hash_class).to be_an described_class
       expect(pub_hash[:author].size).to eq 9
     end
+    it 'parses wos names where the first and middle initial are in the first name field and adds the :name variant' do
+      name = { first_name: 'John Q.', middle_name: '', last_name: 'Public' }
+      expect(pub_hash_class.send(:wos_name, name)).to eq(first_name: 'John', middle_name: 'Q', last_name: 'Public', name: 'Public,John,Q')
+    end
+    it 'parses wos names where the first and middle initial without a period are in the first name field and adds the :name variant' do
+      name = { first_name: 'John Q', middle_name: '', last_name: 'Public' }
+      expect(pub_hash_class.send(:wos_name, name)).to eq(first_name: 'John', middle_name: 'Q', last_name: 'Public', name: 'Public,John,Q')
+    end
+    it 'parses wos names where the first name has more than word and adds the :name variant' do
+      name = { first_name: 'John Quincy', middle_name: '', last_name: 'Public' }
+      expect(pub_hash_class.send(:wos_name, name)).to eq(first_name: 'John Quincy', middle_name: '', last_name: 'Public', name: 'Public,John Quincy,')
+    end
     it_behaves_like 'pub_hash'
     it_behaves_like 'contains_author_data'
   end
@@ -74,6 +86,7 @@ describe WebOfScience::MapNames do
       csl_authors = described_class.authors_to_csl(pub_hash[:author])
       expect(csl_authors).to eq []
       expect(csl_authors.count).to eq pub_hash[:authorcount]
+      expect(pub_hash_class.send(:extract_names, medline_record_anon)).to eq([{ display_name: '[Anonymous]', role: 'anon', last_name: '[Anonymous]', given_name: nil, name: '[Anonymous],,' }])
     end
     it_behaves_like 'pub_hash'
   end
@@ -84,6 +97,22 @@ describe WebOfScience::MapNames do
 
     it 'works with MEDLINE records' do
       expect(pub_hash_class).to be_an described_class
+    end
+    it 'returns itself if missing the display_name or full_name variants' do
+      name = { first_name: 'John', middle_name: 'Q', last_name: 'Public' }
+      expect(pub_hash_class.send(:medline_name, name)).to eq name
+    end
+    it 'parses full_name if display_name missing and adds the :name variant' do
+      name = { full_name: 'Public, John Q' }
+      expect(pub_hash_class.send(:medline_name, name)).to eq(first_name: 'John', middle_name: 'Q', last_name: 'Public', name: 'Public,John,Q', full_name: 'Public, John Q', given_name: 'John Q')
+    end
+    it 'parses display_name if full_name missing and adds the :name variant' do
+      name = { display_name: 'Public, John Q' }
+      expect(pub_hash_class.send(:medline_name, name)).to eq(first_name: 'John', middle_name: 'Q', last_name: 'Public', name: 'Public,John,Q', display_name: 'Public, John Q', given_name: 'John Q')
+    end
+    it 'parses full_name with just two initials and adds the :name variant' do
+      name = { full_name: 'Public, J Q' }
+      expect(pub_hash_class.send(:medline_name, name)).to eq(first_name: 'J', middle_name: 'Q', last_name: 'Public', name: 'Public,J,Q', full_name: 'Public, J Q', given_name: 'J Q')
     end
     it_behaves_like 'pub_hash'
     it_behaves_like 'contains_author_data'

--- a/spec/lib/web_of_science/map_names_spec.rb
+++ b/spec/lib/web_of_science/map_names_spec.rb
@@ -68,6 +68,14 @@ describe WebOfScience::MapNames do
       name = { first_name: 'John Q', middle_name: '', last_name: 'Public' }
       expect(pub_hash_class.send(:wos_name, name)).to eq(first_name: 'John', middle_name: 'Q', last_name: 'Public', name: 'Public,John,Q')
     end
+    it 'parses wos names where the first name has multiple words including the middle initial and adds the :name variant' do
+      name = { first_name: 'John Quimby Q', middle_name: '', last_name: 'Public' }
+      expect(pub_hash_class.send(:wos_name, name)).to eq(first_name: 'John Quimby', middle_name: 'Q', last_name: 'Public', name: 'Public,John Quimby,Q')
+    end
+    it 'parses wos names where the initial is also in the first name adds the :name variant' do
+      name = { first_name: 'Russel R. R.', middle_name: '', last_name: 'Public' }
+      expect(pub_hash_class.send(:wos_name, name)).to eq(first_name: 'Russel R.', middle_name: 'R', last_name: 'Public', name: 'Public,Russel R.,R')
+    end
     it 'parses wos names where the first name has more than word and adds the :name variant' do
       name = { first_name: 'John Quincy', middle_name: '', last_name: 'Public' }
       expect(pub_hash_class.send(:wos_name, name)).to eq(first_name: 'John Quincy', middle_name: '', last_name: 'Public', name: 'Public,John Quincy,')

--- a/spec/lib/web_of_science/map_names_spec.rb
+++ b/spec/lib/web_of_science/map_names_spec.rb
@@ -31,8 +31,9 @@ describe WebOfScience::MapNames do
   end
 
   shared_examples 'contains_author_data' do
-    it 'has an authors' do
-      expect(pub_hash[:author]).not_to be_nil
+    it 'has authors with a name key in hash' do
+      expect(pub_hash[:author].size).to be > 0
+      pub_hash[:author].each { |author_name| expect(author_name[:name]).not_to be_nil }
     end
     it 'has an authorcount' do
       expect(pub_hash[:authorcount]).not_to be_nil
@@ -57,6 +58,7 @@ describe WebOfScience::MapNames do
 
     it 'works with WOS records' do
       expect(pub_hash_class).to be_an described_class
+      expect(pub_hash[:author].size).to eq 9
     end
     it_behaves_like 'pub_hash'
     it_behaves_like 'contains_author_data'


### PR DESCRIPTION
fixes #762 

* add name key to author block, which mimics what we are returning for SW records, this helps the Profiles team
* parse some WoS records that return first and middle names in the first name field to separate them correctly
* adds more specific tests for name parsing