### PR TITLE
handle a couple more edge cases for WOS names parsing

### DIFF
--- a/lib/web_of_science/map_names.rb
+++ b/lib/web_of_science/map_names.rb
@@ -104,11 +104,13 @@ module WebOfScience
         end
         # look for the case where the first name includes the middle initial optionally followed by a period
         # e.g. first_name = "Russel B.", should be first_name = "Russel", middle_name = "B"
-        name[:first_name].gsub!(/\s[[:upper:]]\.?\z/) do |s|
-          name[:middle_name] = s.strip.chomp('.') # remove trailing spaces and periods
-          ''
-        end # block returns empty, removing match
-        name[:name] = "#{name[:last_name]},#{name[:first_name]},#{name[:middle_name]}" # full name in the older style format used by Profiles/CAP
+        if name[:first_name].present?
+          name[:first_name].gsub!(/\s[[:upper:]]\.?\z/) do |s|
+            name[:middle_name] = s.strip.chomp('.') # remove trailing spaces and periods
+            ''
+          end # block returns empty, removing match
+        end
+        name[:name] = "#{name[:last_name] || name[:display_name] || name[:full_name]},#{name[:first_name]},#{name[:middle_name]}" # full name in the older style format used by Profiles/CAP
         name
       end
   end

--- a/spec/lib/web_of_science/map_names_spec.rb
+++ b/spec/lib/web_of_science/map_names_spec.rb
@@ -80,6 +80,14 @@ describe WebOfScience::MapNames do
       name = { first_name: 'John Quincy', middle_name: '', last_name: 'Public' }
       expect(pub_hash_class.send(:wos_name, name)).to eq(first_name: 'John Quincy', middle_name: '', last_name: 'Public', name: 'Public,John Quincy,')
     end
+    it 'works when the first_name is missing' do
+      name = { last_name: 'Public' }
+      expect(pub_hash_class.send(:wos_name, name)).to eq(last_name: 'Public', name: 'Public,,')
+    end
+    it 'parses and returns the correct name for anonymous records' do
+      name = { display_name: '[Anonymous]', full_name: '[Anonymous]' }
+      expect(pub_hash_class.send(:wos_name, name)).to eq(name: '[Anonymous],,', full_name: '[Anonymous]', display_name: '[Anonymous]')
+    end
     it_behaves_like 'pub_hash'
     it_behaves_like 'contains_author_data'
   end
@@ -121,6 +129,10 @@ describe WebOfScience::MapNames do
     it 'parses full_name with just two initials and adds the :name variant' do
       name = { full_name: 'Public, J Q' }
       expect(pub_hash_class.send(:medline_name, name)).to eq(first_name: 'J', middle_name: 'Q', last_name: 'Public', name: 'Public,J,Q', full_name: 'Public, J Q', given_name: 'J Q')
+    end
+    it 'parses and returns the correct name for anonymous records' do
+      name = { display_name: '[Anonymous]', full_name: '[Anonymous]' }
+      expect(pub_hash_class.send(:medline_name, name)).to eq(last_name: '[Anonymous]', name: '[Anonymous],,', full_name: '[Anonymous]', display_name: '[Anonymous]', given_name: nil)
     end
     it_behaves_like 'pub_hash'
     it_behaves_like 'contains_author_data'


### PR DESCRIPTION
found a couple more issues after deploying the new WOS name parsing code:

* anonymous records only have a display_name / full_name attribute and no last_name attribute; to match what is happening with medline records; let's just use one of those if we can't find the last_name

* anonymous records don't have a first_name attribute which was blowing up on the gsub!; guard against this