### PR TITLE
Remove double-hyphen composition of log message

### DIFF
--- a/lib/web_of_science/harvester.rb
+++ b/lib/web_of_science/harvester.rb
@@ -110,8 +110,8 @@ module WebOfScience
       # @param [String] message
       # @return [void]
       def log_info(author, message)
-        prefix = "#{self.class} - "
-        prefix += "author #{author.id} - " if author.is_a?(Author)
+        prefix = self.class.to_s
+        prefix += " - author #{author.id}" if author.is_a?(Author)
         logger.info "#{prefix} - #{message}"
       end
 


### PR DESCRIPTION
Example output was:
```
I, [2018-03-06T16:45:40.230009 #10247]  INFO -- : WebOfScience::Harvester - author 17853 -  - 1 UIDs for search
```

This collapses the empty `-  -`