### PR TITLE
Unblock CiteProc upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,10 +17,9 @@ gem 'mysql2', '~> 0.4.10'
 gem 'nokogiri', '>= 1.7.1'
 
 gem 'activerecord-import'
-# To use ActiveModel has_secure_password
-# gem 'bcrypt-ruby', '~> 3.0.0'
 gem 'bibtex-ruby'
 gem 'citeproc-ruby', '~> 1.1'
+gem 'unicode' # CiteProc requires the `unicode_utils` or `unicode` Gem on Ruby 2.3
 gem 'config'
 gem 'csl-styles', '~> 1.0'
 gem 'delayed_job'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -421,6 +421,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.7)
       execjs (>= 0.3.0, < 3)
+    unicode (0.4.4.4)
     unicode-display_width (1.3.0)
     urn (2.0.2)
     vcr (4.0.0)
@@ -504,6 +505,7 @@ DEPENDENCIES
   therubyracer
   thin
   uglifier (~> 4.1)
+  unicode
   vcr
   webmock
   whenever


### PR DESCRIPTION
We need to backfill a dependency (or drop ruby 2.3)

See: https://travis-ci.org/sul-dlss/sul_pub/jobs/349199941#L980
And: https://github.com/sul-dlss/sul_pub/pull/763