### PR TITLE
Tests for matching_publication and non-wos indirect matches

### DIFF
--- a/app/api/sul_bib/authorship_api.rb
+++ b/app/api/sul_bib/authorship_api.rb
@@ -114,7 +114,8 @@ module SulBib
       # @param [String] wos_uid WebOfScience ID
       # @return [Publication]
       def get_publication_via_wos!(author, wos_uid)
-        WebOfScience.harvester.author_uid(author, wos_uid) ||
+        WebOfScience.harvester.author_uid(author, wos_uid)
+        Publication.find_by(wos_uid: wos_uid) ||
           log_and_error!("The #{wos_uid} publication was not found either locally or at WebOfScience.")
       end
 

--- a/app/models/web_of_science_source_record.rb
+++ b/app/models/web_of_science_source_record.rb
@@ -17,6 +17,15 @@ class WebOfScienceSourceRecord < ActiveRecord::Base
     @record ||= WebOfScience::Record.new(record: source_data)
   end
 
+  # @param [Publication] pub must already be persisted, like any association.create
+  def link_publication(pub)
+    transaction do
+      self.publication = pub
+      save!
+      pub.update(wos_uid: uid)
+    end
+  end
+
   private
 
     # Can initialize with either source_data String or record (WebOfScience::Record)

--- a/lib/web_of_science/identifiers.rb
+++ b/lib/web_of_science/identifiers.rb
@@ -16,7 +16,7 @@ module WebOfScience
 
     # @param rec [WebOfScience::Record]
     def initialize(rec)
-      raise(ArgumentError, 'ids must be a WebOfScience::Record') unless rec.is_a? WebOfScience::Record
+      raise(ArgumentError, 'rec must be a WebOfScience::Record') unless rec.is_a? WebOfScience::Record
       extract_ids rec.doc
       extract_uid rec.doc
       parse_medline rec.doc

--- a/lib/web_of_science/process_records.rb
+++ b/lib/web_of_science/process_records.rb
@@ -54,10 +54,12 @@ module WebOfScience
         new_uids = []
         records.each do |rec|
           pub = matching_publication(rec)
+          wssr = wssrs_hash[rec.uid]
           if pub
             author.assign_pub(pub)
+            wssr.link_publication(pub) if pub.wos_uid.nil? || wssr.publication.blank?
           else
-            create_publication(rec, wssrs_hash[rec.uid]) && new_uids << rec.uid
+            create_publication(rec, wssr) && new_uids << rec.uid
           end
         end
         new_uids.uniq


### PR DESCRIPTION
Because there are hundreds of lines of untested code and some hamstringing complexity even building fixtures, the level of confidence I have that these tests reflect our real scenario is lower than I'd like.  But they reflect it more closely than **no tests**.

My specific outstanding question is about the *timing* of pubmed additions.  The tests inject PMID ahead of time, but the actual `process_records` code only does `pubmed_additions` as the last step
(which has been true since its beginning). I suspect that is too late for the indirect matching query we need to work.