### PR TITLE
More rails like way of detecting when author is changed if identity changes

### DIFF
--- a/app/models/author_identity.rb
+++ b/app/models/author_identity.rb
@@ -1,6 +1,6 @@
 class AuthorIdentity < ActiveRecord::Base
   has_paper_trail on: [:destroy]
-  belongs_to :author, inverse_of: :author_identities
+  belongs_to :author, touch: true, inverse_of: :author_identities
 
   # required attributes will raise exceptions if nil
   validates :author, :first_name, :last_name, presence: true

--- a/spec/models/author_identity_spec.rb
+++ b/spec/models/author_identity_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe AuthorIdentity, type: :model do
       author.mirror_author_identities([new_identity1])
       expect(author.author_identities.length).to eq 1
       expect(author.harvested).to be false
-      expect(author.changed?).to be false
+      expect(author.changed?).to be true
       expect(author.should_harvest?).to be true
     end
 
@@ -121,7 +121,7 @@ RSpec.describe AuthorIdentity, type: :model do
       expect(author.mirror_author_identities([changed_middle_name])).to be true
       expect(author.author_identities.length).to eq 1
       expect(author.harvested).to be false
-      expect(author.changed?).to be false
+      expect(author.changed?).to be true
       expect(author.should_harvest?).to be true
     end
 
@@ -140,7 +140,7 @@ RSpec.describe AuthorIdentity, type: :model do
       author.mirror_author_identities([identity_same_as_primary])
       expect(author.author_identities.length).to eq 0
       expect(author.harvested).to be false
-      expect(author.changed?).to be false
+      expect(author.changed?).to be true
       expect(author.should_harvest?).to be true
     end
 

--- a/spec/models/author_identity_spec.rb
+++ b/spec/models/author_identity_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe AuthorIdentity, type: :model do
       expect(author.author_identities.length).to eq 1
       expect(author.mirror_author_identities([existing_alt_identity, new_identity1])).to be true
       expect(author.author_identities.length).to eq 2
-      expect(author.changed?).to be false
+      expect(author.changed?).to be true
       expect(author.harvested).to be false
       expect(author.should_harvest?).to be true
     end

--- a/spec/models/author_spec.rb
+++ b/spec/models/author_spec.rb
@@ -23,7 +23,7 @@ describe Author do
     it 'indicates if the primary author information changes but not the number of identities' do
       expect(subject.should_harvest?).to be false
       subject.preferred_first_name = subject.first_name + "XXX"
-      expect(subject.alt_identities_changed).to be nil
+      expect(subject.changed?).to be true
       expect(subject.harvested).to be nil
       expect(subject.should_harvest?).to be true
     end


### PR DESCRIPTION
It would be very useful to trigger author.changed? for any changes to author identities so we know when to re-harvest after a cap author update for that author...

This code will consider changes to the author_idenitity associated models as a change to the author model, thus eliminating the need to keep track of if alt identities changed in an instance variable.

This feels cleaner and more like how it should happen in a rails project.

Connected to #974