### PR TITLE
do not throw an exception when a pmid cannot be found in a search

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,7 +266,7 @@ GEM
       activerecord (>= 4.2, < 5.2)
       request_store (~> 1.1)
     parallel (1.12.1)
-    parser (2.5.0.4)
+    parser (2.5.0.5)
       ast (~> 2.4.0)
     polyamorous (1.3.3)
       activerecord (>= 3.0)

--- a/lib/pubmed_harvester.rb
+++ b/lib/pubmed_harvester.rb
@@ -8,7 +8,7 @@ class PubmedHarvester
     return [pub.pub_hash] if pub && pub.authoritative_pmid_source?
     result = fetch_remote_pubmed(pmid)
     return result unless result.empty?
-    [pub.pub_hash] # non-authoritative local hit
+    pub.blank? ? [] : [pub.pub_hash] # non-authoritative local hit if found
   end
 
   # @param [String] pmid Pubmed ID

--- a/spec/lib/pubmed_harvester_spec.rb
+++ b/spec/lib/pubmed_harvester_spec.rb
@@ -58,6 +58,11 @@ describe PubmedHarvester, :vcr do
         expect(h.size).to eq 1
       end
 
+      it 'returns an empty array when no pubs found anywhere' do
+        h = PubmedHarvester.search_all_sources_by_pmid('crap')
+        expect(h.size).to eq 0
+      end
+
       context 'duplicate PMIDs' do
         before do
           publication.pmid = 99_999_999 # Pubmed ID that does not exist


### PR DESCRIPTION
fixes #801 