### PR TITLE
Pubmed author parsing when ValidYN missing

### DIFF
--- a/app/models/pubmed_source_record.rb
+++ b/app/models/pubmed_source_record.rb
@@ -185,10 +185,10 @@ class PubmedSourceRecord < ActiveRecord::Base
       ##
       # Ignore an empty <Author/> element
       return if author.children.empty?
-      # Ignore an <Author> that contains only <CollectiveName>
+      # Ignore an <Author> that contains <CollectiveName>
       return if author.xpath('CollectiveName').present?
       # Ignore an <Author ValidYN="N"> or missing ValidYN attribute
-      return if author.attributes['ValidYN'].blank? || author.attributes['ValidYN'].value == 'N'
+      return if author.attributes['ValidYN'].present? && author.attributes['ValidYN'].value == 'N'
       # Extract name elements
       lastname = author.xpath('LastName').text
       forename = author.xpath('ForeName').text


### PR DESCRIPTION
Allow author entries previously filtered as "malformed".  If the entry doesn't declare itself invalid, it is valid by default. Otherwise, citations get built w/o any author data at all.

Fixes #814

Exclusion was introduced in 0c2059423336fd5dace0c8b586f39a007fe04557