### PR TITLE
timeframes for updated/new author harvests and setting that determines if authors poller runs harvests on changed authors

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -24,6 +24,7 @@ CAP:
   AUTHORSHIP_API_PATH: /cap-api/api/cap/v1/authors
   AUTHORSHIP_API_PORT: 443
   AUTHORSHIP_API_URI: https://cap-uat.stanford.edu
+  HARVEST_ON_CHANGE: true
 
 ## PubMed Auth Config
 PUBMED:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -53,6 +53,8 @@ WOS:
   AUTH_CODE: secret
   LOG: log/web_of_science.log
   LOG_LEVEL: warn
+  update_timeframe: 4week # default WoS symbolicTimeSpan for updated authors/biweekly harvests
+  new_author_timeframe: 52week # default WoS symbolicTimeSpan for new authors
 
 DOI:
   BASE_URI: https://dx.doi.org/
@@ -60,8 +62,6 @@ DOI:
 HARVESTER:
   USE_MIDDLE_NAME: true
   USE_AUTHOR_IDENTITIES: false
-  UPDATE_TIMEFRAME: 4week # default WoS symbolicTimeSpan for updated authors/biweekly harvests
-  NEW_AUTHOR_TIMEFRAME: 52week # default WoS symbolicTimeSpan for new authors
   INSTITUTION:
     name: Stanford University
     address:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -60,6 +60,8 @@ DOI:
 HARVESTER:
   USE_MIDDLE_NAME: true
   USE_AUTHOR_IDENTITIES: false
+  UPDATE_TIMEFRAME: 4week # default WoS symbolicTimeSpan for updated authors/biweekly harvests
+  NEW_AUTHOR_TIMEFRAME: 52week # default WoS symbolicTimeSpan for new authors
   INSTITUTION:
     name: Stanford University
     address:

--- a/lib/cap/authors_poller.rb
+++ b/lib/cap/authors_poller.rb
@@ -60,10 +60,10 @@ module Cap
     def do_wos_harvest
       return unless Settings.WOS.enabled
       Author.where(id: @new_authors_to_harvest_queue).find_in_batches(batch_size: 250) do |authors|
-        WebOfScience.harvester.harvest(authors, symbolicTimeSpan: Settings.HARVESTER.NEW_AUTHOR_TIMEFRAME)
+        WebOfScience.harvester.harvest(authors, symbolicTimeSpan: Settings.WOS.new_author_timeframe)
       end
       Author.where(id: @changed_authors_to_harvest_queue).find_in_batches(batch_size: 250) do |authors|
-        WebOfScience.harvester.harvest(authors, symbolicTimeSpan: Settings.HARVESTER.UPDATE_TIMEFRAME)
+        WebOfScience.harvester.harvest(authors, symbolicTimeSpan: Settings.WOS.update_timeframe)
       end
     end
 

--- a/lib/cap/authors_poller.rb
+++ b/lib/cap/authors_poller.rb
@@ -59,8 +59,11 @@ module Cap
 
     def do_wos_harvest
       return unless Settings.WOS.enabled
-      Author.where(id: @new_authors_to_harvest_queue + @changed_authors_to_harvest_queue).find_in_batches(batch_size: 250) do |authors|
-        WebOfScience.harvester.harvest(authors)
+      Author.where(id: @new_authors_to_harvest_queue).find_in_batches(batch_size: 250) do |authors|
+        WebOfScience.harvester.harvest(authors, symbolicTimeSpan: Settings.HARVESTER.NEW_AUTHOR_TIMEFRAME)
+      end
+      Author.where(id: @changed_authors_to_harvest_queue).find_in_batches(batch_size: 250) do |authors|
+        WebOfScience.harvester.harvest(authors, symbolicTimeSpan: Settings.HARVESTER.UPDATE_TIMEFRAME)
       end
     end
 

--- a/lib/tasks/wos.rake
+++ b/lib/tasks/wos.rake
@@ -22,7 +22,7 @@ namespace :wos do
   # "xyear" where x => 1 and < ?
   desc 'Update harvest from Web of Science, for all authors'
   task :harvest_authors_update, [:symbolicTimeSpan] => :environment do |_t, args|
-    options = args.with_defaults(symbolicTimeSpan: '4week')
+    options = args.with_defaults(symbolicTimeSpan: Settings.HARVESTER.UPDATE_TIMEFRAME)
     WebOfScience.harvester.harvest_all(options)
   end
 

--- a/lib/tasks/wos.rake
+++ b/lib/tasks/wos.rake
@@ -22,7 +22,7 @@ namespace :wos do
   # "xyear" where x => 1 and < ?
   desc 'Update harvest from Web of Science, for all authors'
   task :harvest_authors_update, [:symbolicTimeSpan] => :environment do |_t, args|
-    options = args.with_defaults(symbolicTimeSpan: Settings.HARVESTER.UPDATE_TIMEFRAME)
+    options = args.with_defaults(symbolicTimeSpan: Settings.WOS.update_timeframe)
     WebOfScience.harvester.harvest_all(options)
   end
 

--- a/lib/web_of_science/query_author.rb
+++ b/lib/web_of_science/query_author.rb
@@ -51,7 +51,7 @@ module WebOfScience
       #     will be inferred from the editions data.
       #
       #     - The documented values are strings: '1week', '2week', '4week' (prior to today)
-      #     - the actual values it accepts are any value of "Nweek" for 1 < N < 53
+      #     - the actual values it accepts are any value of "Nweek" for 1 < N < 53, or "Nyear" for 1 <= N < ?
       #
       # @return [Hash]
       def author_query

--- a/spec/lib/cap/authors_poller_spec.rb
+++ b/spec/lib/cap/authors_poller_spec.rb
@@ -229,6 +229,8 @@ describe Cap::AuthorsPoller, :vcr do
     it 'does nothing if sw client is disabled' do
       allow(Settings.SCIENCEWIRE).to receive(:enabled).and_return(false)
       expect(ScienceWireHarvester).not_to receive(:harvest_pubs_for_author_ids)
+      subject.instance_variable_set('@new_authors_to_harvest_queue', [123,456])
+      subject.instance_variable_set('@changed_authors_to_harvest_queue', [789,101212])
       subject.do_science_wire_harvest
     end
   end
@@ -236,8 +238,17 @@ describe Cap::AuthorsPoller, :vcr do
   describe '.do_wos_harvest' do
     it 'does nothing if WoS client is disabled' do
       allow(Settings.WOS).to receive(:enabled).and_return(false)
+      subject.instance_variable_set('@new_authors_to_harvest_queue', [author.id])
+      subject.instance_variable_set('@changed_authors_to_harvest_queue', [author.id])
       expect(Author).not_to receive(:where)
       expect(WebOfScience).not_to receive(:harvester)
+      subject.do_wos_harvest
+    end
+    it 'adds timeframes for harvests for new and updated authors' do
+      allow(Settings.WOS).to receive(:enabled).and_return(true)
+      subject.instance_variable_set('@new_authors_to_harvest_queue', [author.id])
+      subject.instance_variable_set('@changed_authors_to_harvest_queue', [author.id])
+      expect(WebOfScience).to receive(:harvester)
       subject.do_wos_harvest
     end
   end

--- a/spec/lib/cap/authors_poller_spec.rb
+++ b/spec/lib/cap/authors_poller_spec.rb
@@ -229,8 +229,8 @@ describe Cap::AuthorsPoller, :vcr do
     it 'does nothing if sw client is disabled' do
       allow(Settings.SCIENCEWIRE).to receive(:enabled).and_return(false)
       expect(ScienceWireHarvester).not_to receive(:harvest_pubs_for_author_ids)
-      subject.instance_variable_set('@new_authors_to_harvest_queue', [123,456])
-      subject.instance_variable_set('@changed_authors_to_harvest_queue', [789,101212])
+      subject.instance_variable_set('@new_authors_to_harvest_queue', [123, 456])
+      subject.instance_variable_set('@changed_authors_to_harvest_queue', [789, 112])
       subject.do_science_wire_harvest
     end
   end


### PR DESCRIPTION
also:
* cleanup some logging
* add default timeframes to settings
* use timeframes when harvesting updated or new authors in cap author poller

fixes #841
fixes #842