### PR TITLE
Fix issue with settings (nil should be null so it isn't set as a string)

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -54,7 +54,7 @@ WOS:
   LOG: log/web_of_science.log
   LOG_LEVEL: warn
   update_timeframe: 10year # default WoS symbolicTimeSpan for updated authors/biweekly harvests
-  new_author_timeframe: nil # default WoS symbolicTimeSpan for new authors (nil == for all time)
+  new_author_timeframe: null # default WoS symbolicTimeSpan for new authors (null == for all time)
   # note, see lib/web_of_science/query_author.rb#author_query
   #   or https://github.com/sul-dlss/sul_pub/wiki/Clarivate-APIs for allowed values of symbolicTimeSpan
 

--- a/script/batch_wos_harvest.rb
+++ b/script/batch_wos_harvest.rb
@@ -6,13 +6,19 @@ limit = 1000 # limit to 1000 authors
 options = { symbolicTimeSpan: '12week' } # go back 12 weeks in time
 offset = 0 # increment offset to do a different batch (note that this will have overlaps if run far apart in time if you use updated_at as a sort order, as updated at times will change)
 sort_order = 'updated_at desc' # do the people most recently updated
-
-harvester = WebOfScience.harvester
-authors = Author.where(active_in_cap: true, cap_import_enabled: true).order(sort_order).limit(limit).offset(offset)
-total = authors.count
-puts "Harvesting of #{total} authors started at #{Time.zone.now}"
-authors.each_with_index do |author, i|
-  puts "Harvesting cap_profile_id #{author.cap_profile_id} [#{i + 1} of #{total}]"
-  harvester.process_author(author, options)
+start_time = Time.zone.now
+CSV.open(Rails.root.join('log', 'batch_wos_harvest.csv'), 'wb') do |csv|
+  csv << ['cap_profile_id', 'name', 'new_publications']
+  harvester = WebOfScience.harvester
+  authors = Author.where(active_in_cap: true, cap_import_enabled: true).order(sort_order).limit(limit).offset(offset)
+  total = authors.count
+  puts "Harvesting of #{total} authors started at #{start_time}"
+  authors.each_with_index do |author, i|
+    puts "Harvesting cap_profile_id #{author.cap_profile_id} [#{i + 1} of #{total}]"
+    harvester.process_author(author, options)
+    new_pub_count = author.contributions.where(status: 'new').where('created_at >= ?', start_time).count
+    csv << [author.cap_profile_id, "#{author.first_name} #{author.last_name}", new_pub_count]
+  end
 end
 puts "Harvesting ended at #{Time.zone.now}"
+puts "#{limit} authors were processed."


### PR DESCRIPTION
If you use "nil" in settings, it gets set as a string.  On the other hand, "null" gets set correctly as the actual value nil, which we need in this case.  If you don't do this correctly, the API tries to send the string "nil" as symbolicTimeSpan to the WoS API instead of leaving off the parameter (which it does in the case of the value nil).  Sending "nil" causes an error in the API.

Also, updates to logging and add CSV output for batch harvest script for easier reporting to CAP after the run.