### PR TITLE
Remove libv8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,6 @@ gem 'identifiers', '~> 0.12'
 gem 'jbuilder'
 gem 'jquery-rails'
 gem 'kaminari'
-gem 'libv8'
 gem 'okcomputer' # for monitoring
 gem 'paper_trail'
 gem 'parallel'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,7 +232,6 @@ GEM
       kaminari-core (= 1.1.1)
     kaminari-core (1.1.1)
     latex-decode (0.3.1)
-    libv8 (3.16.14.19)
     loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -472,7 +471,6 @@ DEPENDENCIES
   jbuilder
   jquery-rails
   kaminari
-  libv8
   mysql2 (~> 0.4.10)
   nokogiri (>= 1.7.1)
   okcomputer


### PR DESCRIPTION
It's no longer needed since we aren't using therubyracer