### PR TITLE
remove sciencewire lookup when adding by pmid

### DIFF
--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -57,7 +57,7 @@ class Publication < ActiveRecord::Base
   end
 
   def self.find_or_create_by_pmid(pmid)
-    find_by_pmid(pmid) || SciencewireSourceRecord.get_pub_by_pmid(pmid) || PubmedSourceRecord.get_pub_by_pmid(pmid)
+    find_by_pmid(pmid) || PubmedSourceRecord.get_pub_by_pmid(pmid)
   end
 
   def self.find_by_doi(doi)


### PR DESCRIPTION
current production bug: https://app.honeybadger.io/projects/50046/faults/39602176#notice-summary

* sciencewire should *not* be in the path when looking up by and adding pubs by pmid
* short circuit a couple places where sw records are fetched, just in case that codepath is exercised somewhere else

we should also allocate some time time to review and merge #850 