### PR TITLE
use "all time" as the lookback window 

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -54,7 +54,7 @@ WOS:
   LOG: log/web_of_science.log
   LOG_LEVEL: warn
   regular_harvest_timeframe: 3week # default WoS symbolicTimeSpan for regular harvests
-  update_timeframe: 10year # default WoS symbolicTimeSpan for updated authors resulting from nightly cap polling
+  update_timeframe: null # default WoS symbolicTimeSpan for updated authors resulting from nightly cap polling
   new_author_timeframe: null # default WoS symbolicTimeSpan for new authors resulting from nightly cap polling (null == for all time)
   # note, see lib/web_of_science/query_author.rb#author_query
   #   or https://github.com/sul-dlss/sul_pub/wiki/Clarivate-APIs for allowed values of symbolicTimeSpan


### PR DESCRIPTION
for update harvests triggered by the cap author poller detecting changes to a user profile

this was requested by Tina based on issues with a user who updated their profile and had pubs going back more than 10 years that were being missed

as this lookback window is only triggered for users who update their profiles detected by the cap authors poller, it should not have a big impact on performance (as this is a small number each night)
