### PR TITLE
add pubmed key to api calls to relax NIH limits

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -30,6 +30,7 @@ CAP:
 PUBMED:
   LOG: log/pubmed.log
   FETCH_PATH: /entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+  API_KEY: a_fake_pubmed_key
   BASE_URI: https://eutils.ncbi.nlm.nih.gov
   ARTICLE_BASE_URI: https://www.ncbi.nlm.nih.gov/pubmed/
 

--- a/fixtures/vcr_cassettes/PubmedHarvester/_fetch_remote_pubmed/WOS_and_ScienceWire_both_disabled/searches_only_pubmed.yml
+++ b/fixtures/vcr_cassettes/PubmedHarvester/_fetch_remote_pubmed/WOS_and_ScienceWire_both_disabled/searches_only_pubmed.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
     body:
       encoding: UTF-8
       string: "&id=24930130"

--- a/fixtures/vcr_cassettes/PubmedHarvester/_search_all_sources_by_pmid/mix_of_local_plus_SW/pubmed_results/does_not_do_any_filtering_with_a_resultset_of_2_manual/batch_pubs.yml
+++ b/fixtures/vcr_cassettes/PubmedHarvester/_search_all_sources_by_pmid/mix_of_local_plus_SW/pubmed_results/does_not_do_any_filtering_with_a_resultset_of_2_manual/batch_pubs.yml
@@ -78,7 +78,7 @@ http_interactions:
   recorded_at: Mon, 13 Nov 2017 20:58:04 GMT
 - request:
     method: post
-    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
     body:
       encoding: UTF-8
       string: "&id=99999999"

--- a/fixtures/vcr_cassettes/PubmedSourceRecord/_get_pubmed_record_from_pubmed/extracts_fields_-_pmid.yml
+++ b/fixtures/vcr_cassettes/PubmedSourceRecord/_get_pubmed_record_from_pubmed/extracts_fields_-_pmid.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
     body:
       encoding: UTF-8
       string: "&id=&id=10000166"

--- a/fixtures/vcr_cassettes/PubmedSourceRecord/_get_pubmed_record_from_pubmed/returns_an_instance_of_PubmedSourceRecord.yml
+++ b/fixtures/vcr_cassettes/PubmedSourceRecord/_get_pubmed_record_from_pubmed/returns_an_instance_of_PubmedSourceRecord.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
     body:
       encoding: UTF-8
       string: "&id=&id=10000166"

--- a/fixtures/vcr_cassettes/PubmedSourceRecord/_source_as_hash/DOI_extraction/constructs_a_URL_based_on_the_DOI.yml
+++ b/fixtures/vcr_cassettes/PubmedSourceRecord/_source_as_hash/DOI_extraction/constructs_a_URL_based_on_the_DOI.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
     body:
       encoding: UTF-8
       string: "&id=&id=12529422"

--- a/fixtures/vcr_cassettes/PubmedSourceRecord/_source_as_hash/DOI_extraction/extracts_from_ArticleId/works_when_ELocationID_is_missing.yml
+++ b/fixtures/vcr_cassettes/PubmedSourceRecord/_source_as_hash/DOI_extraction/extracts_from_ArticleId/works_when_ELocationID_is_missing.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
     body:
       encoding: UTF-8
       string: "&id=&id=12529422"

--- a/fixtures/vcr_cassettes/PubmedSourceRecord/_source_as_hash/DOI_extraction/extracts_from_ArticleId/works_when_ELocationID_is_present.yml
+++ b/fixtures/vcr_cassettes/PubmedSourceRecord/_source_as_hash/DOI_extraction/extracts_from_ArticleId/works_when_ELocationID_is_present.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
     body:
       encoding: UTF-8
       string: "&id=&id=23453302"

--- a/fixtures/vcr_cassettes/PubmedSourceRecord/_source_as_hash/DOI_extraction/extracts_from_ArticleId/works_when_record_is_longer_than_64kb.yml
+++ b/fixtures/vcr_cassettes/PubmedSourceRecord/_source_as_hash/DOI_extraction/extracts_from_ArticleId/works_when_record_is_longer_than_64kb.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
     body:
       encoding: UTF-8
       string: "&id=&id=26430984"

--- a/fixtures/vcr_cassettes/PubmedSourceRecord/_source_as_hash/DOI_extraction/extracts_from_ELocationID/works_when_ArticleId_is_missing.yml
+++ b/fixtures/vcr_cassettes/PubmedSourceRecord/_source_as_hash/DOI_extraction/extracts_from_ELocationID/works_when_ArticleId_is_missing.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
     body:
       encoding: UTF-8
       string: "&id=&id=26858277"

--- a/fixtures/vcr_cassettes/ScienceWireHarvester/_harvest_pubs_for_author_ids/for_valid_author/calls_write_counts_to_log.yml
+++ b/fixtures/vcr_cassettes/ScienceWireHarvester/_harvest_pubs_for_author_ids/for_valid_author/calls_write_counts_to_log.yml
@@ -2076,7 +2076,7 @@ http_interactions:
   recorded_at: Mon, 13 Nov 2017 20:58:19 GMT
 - request:
     method: post
-    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
     body:
       encoding: UTF-8
       string: "&id=21975722&id=21134139&id=20386227&id=20046456&id=19088623&id=16517323&id=14617124&id=17377083"

--- a/fixtures/vcr_cassettes/ScienceWireHarvester/_harvest_pubs_for_author_ids/when_existing_pubmed_pub/updates_an_existing_pubmed_publication_with_sciencewire_data.yml
+++ b/fixtures/vcr_cassettes/ScienceWireHarvester/_harvest_pubs_for_author_ids/when_existing_pubmed_pub/updates_an_existing_pubmed_publication_with_sciencewire_data.yml
@@ -77,7 +77,7 @@ http_interactions:
   recorded_at: Mon, 13 Nov 2017 20:58:11 GMT
 - request:
     method: post
-    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
     body:
       encoding: UTF-8
       string: "&id=&id=10048354"

--- a/fixtures/vcr_cassettes/ScienceWireHarvester/_harvest_pubs_for_author_ids/when_no_existing_publication/adds_new_contributions.yml
+++ b/fixtures/vcr_cassettes/ScienceWireHarvester/_harvest_pubs_for_author_ids/when_no_existing_publication/adds_new_contributions.yml
@@ -132,7 +132,7 @@ http_interactions:
   recorded_at: Mon, 13 Nov 2017 20:58:24 GMT
 - request:
     method: post
-    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
     body:
       encoding: UTF-8
       string: "&id=10048354&id=1914489"

--- a/fixtures/vcr_cassettes/ScienceWireHarvester/_harvest_pubs_for_author_ids/when_no_existing_publication/adds_new_publications.yml
+++ b/fixtures/vcr_cassettes/ScienceWireHarvester/_harvest_pubs_for_author_ids/when_no_existing_publication/adds_new_publications.yml
@@ -132,7 +132,7 @@ http_interactions:
   recorded_at: Mon, 13 Nov 2017 20:58:22 GMT
 - request:
     method: post
-    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
     body:
       encoding: UTF-8
       string: "&id=10048354&id=1914489"

--- a/fixtures/vcr_cassettes/ScienceWireHarvester/_harvest_pubs_for_author_ids/when_run_consecutively/should_be_idempotent_for_contributions.yml
+++ b/fixtures/vcr_cassettes/ScienceWireHarvester/_harvest_pubs_for_author_ids/when_run_consecutively/should_be_idempotent_for_contributions.yml
@@ -132,7 +132,7 @@ http_interactions:
   recorded_at: Mon, 13 Nov 2017 20:58:12 GMT
 - request:
     method: post
-    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
     body:
       encoding: UTF-8
       string: "&id=10048354&id=1914489"

--- a/fixtures/vcr_cassettes/ScienceWireHarvester/_harvest_pubs_for_author_ids/when_run_consecutively/should_be_idempotent_for_pubs.yml
+++ b/fixtures/vcr_cassettes/ScienceWireHarvester/_harvest_pubs_for_author_ids/when_run_consecutively/should_be_idempotent_for_pubs.yml
@@ -132,7 +132,7 @@ http_interactions:
   recorded_at: Mon, 13 Nov 2017 20:58:14 GMT
 - request:
     method: post
-    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
     body:
       encoding: UTF-8
       string: "&id=10048354&id=1914489"

--- a/fixtures/vcr_cassettes/ScienceWireHarvester/_harvest_sw_pubs_by_wos_id_for_author/creates_ScienceWire_Publications_with_an_array_of_WebOfScience_IDs_for_a_given_author.yml
+++ b/fixtures/vcr_cassettes/ScienceWireHarvester/_harvest_sw_pubs_by_wos_id_for_author/creates_ScienceWire_Publications_with_an_array_of_WebOfScience_IDs_for_a_given_author.yml
@@ -244,7 +244,7 @@ http_interactions:
   recorded_at: Mon, 13 Nov 2017 20:58:07 GMT
 - request:
     method: post
-    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
     body:
       encoding: UTF-8
       string: "&id=23565139&id=23540906&id=23635172"

--- a/fixtures/vcr_cassettes/SulBib_API/GET_/publications/_id/returns_a_pub_with_valid_bibjson_for_sw_harvested_records.yml
+++ b/fixtures/vcr_cassettes/SulBib_API/GET_/publications/_id/returns_a_pub_with_valid_bibjson_for_sw_harvested_records.yml
@@ -912,7 +912,7 @@ http_interactions:
   recorded_at: Mon, 13 Nov 2017 20:57:09 GMT
 - request:
     method: post
-    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
     body:
       encoding: UTF-8
       string: "&id=21975722&id=21134139&id=20386227&id=20046456&id=19088623&id=16517323&id=14617124&id=17377083"

--- a/fixtures/vcr_cassettes/SulBib_API/POST_/authorship/success/with_cap_profile_id/behaves_like_it_creates_new_contributions_and_publications/for_a_new_PubMed_publication/adds_new_publication.yml
+++ b/fixtures/vcr_cassettes/SulBib_API/POST_/authorship/success/with_cap_profile_id/behaves_like_it_creates_new_contributions_and_publications/for_a_new_PubMed_publication/adds_new_publication.yml
@@ -186,7 +186,7 @@ http_interactions:
   recorded_at: Mon, 13 Nov 2017 20:58:37 GMT
 - request:
     method: post
-    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
     body:
       encoding: UTF-8
       string: "&id=&id=23684686"

--- a/fixtures/vcr_cassettes/SulBib_API/POST_/authorship/success/with_cap_profile_id/behaves_like_it_creates_new_contributions_and_publications/for_a_new_PubMed_publication/adds_proper_identifiers_section.yml
+++ b/fixtures/vcr_cassettes/SulBib_API/POST_/authorship/success/with_cap_profile_id/behaves_like_it_creates_new_contributions_and_publications/for_a_new_PubMed_publication/adds_proper_identifiers_section.yml
@@ -186,7 +186,7 @@ http_interactions:
   recorded_at: Mon, 13 Nov 2017 20:58:39 GMT
 - request:
     method: post
-    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
     body:
       encoding: UTF-8
       string: "&id=&id=23684686"

--- a/fixtures/vcr_cassettes/SulBib_API/POST_/authorship/success/with_cap_profile_id/behaves_like_it_creates_new_contributions_and_publications/for_a_new_ScienceWire_publication/adds_new_ScienceWire_publication.yml
+++ b/fixtures/vcr_cassettes/SulBib_API/POST_/authorship/success/with_cap_profile_id/behaves_like_it_creates_new_contributions_and_publications/for_a_new_ScienceWire_publication/adds_new_ScienceWire_publication.yml
@@ -96,7 +96,7 @@ http_interactions:
   recorded_at: Mon, 13 Nov 2017 20:58:35 GMT
 - request:
     method: post
-    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
     body:
       encoding: UTF-8
       string: "&id=&id=10490476"

--- a/fixtures/vcr_cassettes/SulBib_API/POST_/authorship/success/with_cap_profile_id/behaves_like_it_creates_new_contributions_and_publications/for_a_new_ScienceWire_publication/adds_new_ScienceWire_publication_with_proper_identifiers_section.yml
+++ b/fixtures/vcr_cassettes/SulBib_API/POST_/authorship/success/with_cap_profile_id/behaves_like_it_creates_new_contributions_and_publications/for_a_new_ScienceWire_publication/adds_new_ScienceWire_publication_with_proper_identifiers_section.yml
@@ -96,7 +96,7 @@ http_interactions:
   recorded_at: Mon, 13 Nov 2017 20:58:34 GMT
 - request:
     method: post
-    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
     body:
       encoding: UTF-8
       string: "&id=&id=10490476"

--- a/fixtures/vcr_cassettes/SulBib_API/POST_/authorship/success/with_sul_author_id/behaves_like_it_creates_new_contributions_and_publications/for_a_new_PubMed_publication/adds_new_publication.yml
+++ b/fixtures/vcr_cassettes/SulBib_API/POST_/authorship/success/with_sul_author_id/behaves_like_it_creates_new_contributions_and_publications/for_a_new_PubMed_publication/adds_new_publication.yml
@@ -186,7 +186,7 @@ http_interactions:
   recorded_at: Mon, 13 Nov 2017 20:58:44 GMT
 - request:
     method: post
-    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
     body:
       encoding: UTF-8
       string: "&id=&id=23684686"

--- a/fixtures/vcr_cassettes/SulBib_API/POST_/authorship/success/with_sul_author_id/behaves_like_it_creates_new_contributions_and_publications/for_a_new_PubMed_publication/adds_proper_identifiers_section.yml
+++ b/fixtures/vcr_cassettes/SulBib_API/POST_/authorship/success/with_sul_author_id/behaves_like_it_creates_new_contributions_and_publications/for_a_new_PubMed_publication/adds_proper_identifiers_section.yml
@@ -186,7 +186,7 @@ http_interactions:
   recorded_at: Mon, 13 Nov 2017 20:58:45 GMT
 - request:
     method: post
-    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
     body:
       encoding: UTF-8
       string: "&id=&id=23684686"

--- a/fixtures/vcr_cassettes/SulBib_API/POST_/authorship/success/with_sul_author_id/behaves_like_it_creates_new_contributions_and_publications/for_a_new_ScienceWire_publication/adds_new_ScienceWire_publication.yml
+++ b/fixtures/vcr_cassettes/SulBib_API/POST_/authorship/success/with_sul_author_id/behaves_like_it_creates_new_contributions_and_publications/for_a_new_ScienceWire_publication/adds_new_ScienceWire_publication.yml
@@ -96,7 +96,7 @@ http_interactions:
   recorded_at: Mon, 13 Nov 2017 20:58:52 GMT
 - request:
     method: post
-    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
     body:
       encoding: UTF-8
       string: "&id=&id=10490476"

--- a/fixtures/vcr_cassettes/SulBib_API/POST_/authorship/success/with_sul_author_id/behaves_like_it_creates_new_contributions_and_publications/for_a_new_ScienceWire_publication/adds_new_ScienceWire_publication_with_proper_identifiers_section.yml
+++ b/fixtures/vcr_cassettes/SulBib_API/POST_/authorship/success/with_sul_author_id/behaves_like_it_creates_new_contributions_and_publications/for_a_new_ScienceWire_publication/adds_new_ScienceWire_publication_with_proper_identifiers_section.yml
@@ -96,7 +96,7 @@ http_interactions:
   recorded_at: Mon, 13 Nov 2017 20:58:50 GMT
 - request:
     method: post
-    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
     body:
       encoding: UTF-8
       string: "&id=&id=10490476"

--- a/fixtures/vcr_cassettes/WebOfScience_ProcessRecords/with_WOS_records/behaves_like_execute/creates_Publications_with_WOS_attributes.yml
+++ b/fixtures/vcr_cassettes/WebOfScience_ProcessRecords/with_WOS_records/behaves_like_execute/creates_Publications_with_WOS_attributes.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
     body:
       encoding: UTF-8
       string: "&id=&id=21253920"

--- a/fixtures/vcr_cassettes/WebOfScience_ProcessRecords/with_WOS_records/behaves_like_execute/creates_new_WebOfScienceSourceRecords_Publications_PublicationIdentifiers_Contributions.yml
+++ b/fixtures/vcr_cassettes/WebOfScience_ProcessRecords/with_WOS_records/behaves_like_execute/creates_new_WebOfScienceSourceRecords_Publications_PublicationIdentifiers_Contributions.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
     body:
       encoding: UTF-8
       string: "&id=&id=21253920"

--- a/fixtures/vcr_cassettes/WebOfScience_ProcessRecords/with_WOS_records/behaves_like_execute/returns_Array_String_with_WosUIDs_on_success.yml
+++ b/fixtures/vcr_cassettes/WebOfScience_ProcessRecords/with_WOS_records/behaves_like_execute/returns_Array_String_with_WosUIDs_on_success.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
     body:
       encoding: UTF-8
       string: "&id=&id=21253920"

--- a/fixtures/vcr_cassettes/WebOfScience_ProcessRecords/with_WOS_records/behaves_like_pubs_with_pmid_have_mesh_headings/persists_PMID_and_publication_pub_hash_has_MESH_headings.yml
+++ b/fixtures/vcr_cassettes/WebOfScience_ProcessRecords/with_WOS_records/behaves_like_pubs_with_pmid_have_mesh_headings/persists_PMID_and_publication_pub_hash_has_MESH_headings.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
     body:
       encoding: UTF-8
       string: "&id=&id=21253920"

--- a/fixtures/vcr_cassettes/pub_med_client_spec_returns_a_list.yml
+++ b/fixtures/vcr_cassettes/pub_med_client_spec_returns_a_list.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
     body:
       encoding: UTF-8
       string: "&id=211&id=589&id=591&id=960"
@@ -812,6 +812,6 @@ http_interactions:
         </PubmedArticle>
 
         </PubmedArticleSet>
-    http_version: 
+    http_version:
   recorded_at: Mon, 13 Nov 2017 20:57:38 GMT
 recorded_with: VCR 3.0.1

--- a/fixtures/vcr_cassettes/pub_med_client_spec_returns_an_empty_array.yml
+++ b/fixtures/vcr_cassettes/pub_med_client_spec_returns_an_empty_array.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
     body:
       encoding: UTF-8
       string: "&id=233333333333333&id=45555666666666"

--- a/lib/pubmed_client.rb
+++ b/lib/pubmed_client.rb
@@ -16,7 +16,7 @@ class PubmedClient
     pmid_list = Array(pmids)
     pmidValuesForPost = pmid_list.collect { |pmid| "&id=#{pmid}" }.join
     response = conn.post do |req|
-      req.url Settings.PUBMED.FETCH_PATH
+      req.url "#{Settings.PUBMED.FETCH_PATH}&api_key=#{Settings.PUBMED.API_KEY}"
       req.body = pmidValuesForPost
     end
     response.body


### PR DESCRIPTION
1. updated vcr_cassettes to reflect new URL being sent to Pubmed (which now includes API key)
2. also needs shared config updates applied (see those referenced below)

see https://www.ncbi.nlm.nih.gov/books/NBK25497/