### PR TITLE
rake task that will remove all new contributions for a given author between specific dates

### DIFF
--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -68,4 +68,60 @@ namespace :cleanup do
     puts "Duped author set to inactive in cap\n"
     puts "Duped author #{duped_author.cap_profile_id} now has #{duped_author.contributions.size} publications (should be 0) and primary author #{primary_author.cap_profile_id} has #{primary_author.contributions.size} publications"
   end
+
+  desc 'Remove all new contributions for a given cap_profile_id, and cleanup disconnected publications'
+  # Use case: a researchers has many many new publications due to name ambiguities, because a harvest
+  #  was run using last name, first initial and this user was determined to have many publications that
+  #  do not actually belong to them.  This task will remove any publications associated with their profile
+  #  in the 'new' state, and then remove the publications too if they are no longer connected to any one else's
+  #  profile.  Should be rare in usage and then followed up with another harvest for this profile using:
+  #  RAILS_ENV=production bundle exec rake wos:harvest_author[123]
+
+  # RAILS_ENV=production bundle exec rake cleanup:remove_new_contributions[123] # will remove all contributions in the 'new' state for the given cap_profile_id, then remove any publications that have no contributions anymore
+  task :remove_new_contributions, [:cap_profile_id] => :environment do |_t, args|
+    cap_profile_id = args[:cap_profile_id]
+    raise 'Missing cap_profile_id' unless cap_profile_id
+
+    author = Author.find_by_cap_profile_id(cap_profile_id)
+    raise 'Author not found' unless author
+
+    start_timeframe = Time.parse('April 11, 2018') # start date to go back to look for new contributions (when we started WoS harvesting)
+    end_timeframe = Time.parse('May 1, 2018') # end date to go back to look for new contributions (when we stopped harvesting with first initial)
+
+    contributions = author.contributions.where(status: 'new').where('created_at > ?', start_timeframe).where('created_at < ?', end_timeframe)
+    pub_ids = contributions.map(&:publication_id) # cache the ids of the contributions we are going to remove, so we can update them later
+
+    total = contributions.size
+    deleted = 0
+    updated = 0
+
+    puts "Author cap_profile_id: #{cap_profile_id}; name: #{author.first_name} #{author.last_name}"
+    puts "This task will remove all #{total} of their new contributions. Are you sure you want to proceed? (y/n)"
+    input = STDIN.gets.strip.downcase
+    raise 'aborting' unless input == 'y'
+
+    puts 'removing contributions...'
+    contributions.each do |contribution|
+      puts "...Deleted contribution id #{contribution.id}"
+      contribution.destroy
+    end
+
+    puts 'updating publications...'
+    # either rebuild the publications that were removed from the profile, or delete them if they have no contributions left
+    pub_ids.each do |id|
+      pub = Publication.find(id)
+      if pub.contributions.empty? # no contributions left, delete this publication
+        puts "...Deleted publication id #{id}"
+        deleted += 1
+        pub.delete!
+      else # still has contributions, let's rebuid the pub hash to update the authorship to relfect this author being removed
+        puts "...Updated authorship for publication id #{id}"
+        updated += 1
+        pub.sync_publication_hash_and_db
+        pub.save
+      end
+    end
+
+    puts "Removed #{total} contributions; deleted #{deleted} publications, updated #{updated} publications."
+  end
 end


### PR DESCRIPTION
give a cap_profile_id, remove any contributions between the two dates when we started harvesting from WoS and stopped using first initial by default

will be used for cleanup of very specific authors with common last names who likely have lots of false positives on their profile (see #856)