### PR TITLE
harvest all sources for better efficiency

### DIFF
--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -5,7 +5,7 @@ class AuthorsController < ApplicationController
   # request an immediate harvest of this user's profile
   # POST /authors/:cap_profile_id/harvest.json
   def harvest
-    if AuthorHarvestJob.perform_later(author_params[:cap_profile_id], harvest_alternate_names: alt_names)
+    if AuthorHarvestJob.perform_later(author_params[:cap_profile_id])
       render json: {
         response: "Harvest for author #{params[:cap_profile_id]} was successfully created."
       }, status: :accepted
@@ -20,12 +20,7 @@ class AuthorsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def author_params
-      params.permit(:cap_profile_id, :altNames, :format)
+      params.permit(:cap_profile_id, :format)
     end
 
-    ##
-    # @return [Boolean]
-    def alt_names
-      author_params[:altNames] == 'true'
-    end
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -9,12 +9,12 @@ set :output, 'log/cron.log'
 
 # bi-weekly harvest at 5pm in qa, on the 8th and 23rd of the month
 every "0 17 7,23 * *", roles: [:harvester_qa] do
-  rake 'wos:harvest_authors_update'
+  rake 'harvester:all_authors_update'
 end
 
 # every three day harvest at 5pm in prod, don't overlap with qa
 every "0 17 1,5,9,13,17,21,25,29 * *", roles: [:harvester_prod] do
-  rake 'wos:harvest_authors_update'
+  rake 'harvester:all_authors_update'
 end
 
 # poll cap for new authorship information nightly at 4am-ish in both prod and qa

--- a/fixtures/vcr_cassettes/Cap_AuthorsPoller/_do_harvest/adds_separate_timeframes_for_harvests_for_new_and_updated_authors.yml
+++ b/fixtures/vcr_cassettes/Cap_AuthorsPoller/_do_harvest/adds_separate_timeframes_for_harvests_for_new_and_updated_authors.yml
@@ -1,0 +1,6271 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://search.webofknowledge.com/esti/wokmws/ws/WOKMWSAuthenticate?wsdl
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.5.1 (2018-03-29))
+      Accept:
+      - "*/*"
+      Date:
+      - Wed, 03 Apr 2019 23:00:31 GMT
+      Authorization:
+      - Basic Settings.WOS.AUTH_CODE
+      Soapaction:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Date:
+      - Wed, 03 Apr 2019 23:00:30 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Content-Length:
+      - '8705'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version='1.0' encoding='UTF-8'?><wsdl:definitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="http://auth.cxf.wokmws.thomsonreuters.com" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" name="WOKMWSAuthenticateService" targetNamespace="http://auth.cxf.wokmws.thomsonreuters.com">
+          <wsdl:types>
+        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://auth.cxf.wokmws.thomsonreuters.com" targetNamespace="http://auth.cxf.wokmws.thomsonreuters.com" version="1.0">
+        <xs:element name="AuthenticationException" type="tns:AuthenticationException"/>
+        <xs:element name="ESTIWSException" type="tns:ESTIWSException"/>
+        <xs:element name="InternalServerException" type="tns:InternalServerException"/>
+        <xs:element name="InvalidInputException" type="tns:InvalidInputException"/>
+        <xs:element name="QueryException" type="tns:QueryException"/>
+        <xs:element name="SessionException" type="tns:SessionException"/>
+        <xs:element name="authenticate" type="tns:authenticate"/>
+        <xs:element name="authenticateResponse" type="tns:authenticateResponse"/>
+        <xs:element name="closeSession" type="tns:closeSession"/>
+        <xs:element name="closeSessionResponse" type="tns:closeSessionResponse"/>
+        <xs:complexType name="closeSession">
+            <xs:sequence/>
+          </xs:complexType>
+        <xs:complexType name="closeSessionResponse">
+            <xs:sequence/>
+          </xs:complexType>
+        <xs:complexType name="QueryException">
+            <xs:sequence/>
+          </xs:complexType>
+        <xs:complexType name="ESTIWSException">
+            <xs:sequence/>
+          </xs:complexType>
+        <xs:complexType name="InvalidInputException">
+            <xs:sequence/>
+          </xs:complexType>
+        <xs:complexType name="InternalServerException">
+            <xs:sequence/>
+          </xs:complexType>
+        <xs:complexType name="SessionException">
+            <xs:sequence/>
+          </xs:complexType>
+        <xs:complexType name="AuthenticationException">
+            <xs:sequence/>
+          </xs:complexType>
+        <xs:complexType name="authenticate">
+            <xs:sequence/>
+          </xs:complexType>
+        <xs:complexType name="authenticateResponse">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="return" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:schema>
+          </wsdl:types>
+          <wsdl:message name="closeSession">
+            <wsdl:part element="tns:closeSession" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="QueryException_Exception">
+            <wsdl:part element="tns:QueryException" name="QueryException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="ESTIWSException_Exception">
+            <wsdl:part element="tns:ESTIWSException" name="ESTIWSException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="InvalidInputException_Exception">
+            <wsdl:part element="tns:InvalidInputException" name="InvalidInputException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="InternalServerException_Exception">
+            <wsdl:part element="tns:InternalServerException" name="InternalServerException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="SessionException_Exception">
+            <wsdl:part element="tns:SessionException" name="SessionException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="authenticate">
+            <wsdl:part element="tns:authenticate" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="closeSessionResponse">
+            <wsdl:part element="tns:closeSessionResponse" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="authenticateResponse">
+            <wsdl:part element="tns:authenticateResponse" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="AuthenticationException_Exception">
+            <wsdl:part element="tns:AuthenticationException" name="AuthenticationException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:portType name="WOKMWSAuthenticate">
+            <wsdl:operation name="closeSession">
+              <wsdl:input message="tns:closeSession" name="closeSession">
+            </wsdl:input>
+              <wsdl:output message="tns:closeSessionResponse" name="closeSessionResponse">
+            </wsdl:output>
+              <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="authenticate">
+              <wsdl:input message="tns:authenticate" name="authenticate">
+            </wsdl:input>
+              <wsdl:output message="tns:authenticateResponse" name="authenticateResponse">
+            </wsdl:output>
+              <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+            </wsdl:operation>
+          </wsdl:portType>
+          <wsdl:binding name="WOKMWSAuthenticateServiceSoapBinding" type="tns:WOKMWSAuthenticate">
+            <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+            <wsdl:operation name="closeSession">
+              <soap:operation soapAction="" style="document"/>
+              <wsdl:input name="closeSession">
+                <soap:body use="literal"/>
+              </wsdl:input>
+              <wsdl:output name="closeSessionResponse">
+                <soap:body use="literal"/>
+              </wsdl:output>
+              <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+              </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="authenticate">
+              <soap:operation soapAction="" style="document"/>
+              <wsdl:input name="authenticate">
+                <soap:body use="literal"/>
+              </wsdl:input>
+              <wsdl:output name="authenticateResponse">
+                <soap:body use="literal"/>
+              </wsdl:output>
+              <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+              </wsdl:fault>
+            </wsdl:operation>
+          </wsdl:binding>
+          <wsdl:service name="WOKMWSAuthenticateService">
+            <wsdl:port binding="tns:WOKMWSAuthenticateServiceSoapBinding" name="WOKMWSAuthenticatePort">
+              <soap:address location="http://search.webofknowledge.com/esti/wokmws/ws/WOKMWSAuthenticate"/>
+            </wsdl:port>
+          </wsdl:service>
+        </wsdl:definitions>
+    http_version: 
+  recorded_at: Wed, 03 Apr 2019 23:00:31 GMT
+- request:
+    method: post
+    uri: http://search.webofknowledge.com/esti/wokmws/ws/WOKMWSAuthenticate
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://auth.cxf.wokmws.thomsonreuters.com"
+        xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Body><tns:authenticate></tns:authenticate></soapenv:Body></soapenv:Envelope>
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.5.1 (2018-03-29))
+      Accept:
+      - "*/*"
+      Date:
+      - Wed, 03 Apr 2019 23:00:31 GMT
+      Authorization:
+      - Basic Settings.WOS.AUTH_CODE
+      Soapaction:
+      - ''
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Content-Length:
+      - '352'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Date:
+      - Wed, 03 Apr 2019 23:00:30 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Set-Cookie:
+      - SID=7BpaQrkTPsk18oNgGx1
+      Content-Length:
+      - '252'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><ns2:authenticateResponse
+        xmlns:ns2="http://auth.cxf.wokmws.thomsonreuters.com"><return>7BpaQrkTPsk18oNgGx1</return></ns2:authenticateResponse></soap:Body></soap:Envelope>
+    http_version: 
+  recorded_at: Wed, 03 Apr 2019 23:00:31 GMT
+- request:
+    method: get
+    uri: http://search.webofknowledge.com/esti/wokmws/ws/WokSearch?wsdl
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.5.1 (2018-03-29))
+      Accept:
+      - "*/*"
+      Date:
+      - Wed, 03 Apr 2019 23:00:31 GMT
+      Cookie:
+      - SID="7BpaQrkTPsk18oNgGx1"
+      Soapaction:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Date:
+      - Wed, 03 Apr 2019 23:00:31 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version='1.0' encoding='UTF-8'?><wsdl:definitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="http://woksearch.v3.wokmws.thomsonreuters.com" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" name="WokSearchService" targetNamespace="http://woksearch.v3.wokmws.thomsonreuters.com">
+          <wsdl:types>
+        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://woksearch.v3.wokmws.thomsonreuters.com" targetNamespace="http://woksearch.v3.wokmws.thomsonreuters.com" version="1.0">
+        <xs:element name="AuthenticationException" type="tns:AuthenticationException"/>
+        <xs:element name="ESTIWSException" type="tns:ESTIWSException"/>
+        <xs:element name="InternalServerException" type="tns:InternalServerException"/>
+        <xs:element name="InvalidInputException" type="tns:InvalidInputException"/>
+        <xs:element name="QueryException" type="tns:QueryException"/>
+        <xs:element name="SessionException" type="tns:SessionException"/>
+        <xs:element name="citedReferences" type="tns:citedReferences"/>
+        <xs:element name="citedReferencesResponse" type="tns:citedReferencesResponse"/>
+        <xs:element name="citedReferencesRetrieve" type="tns:citedReferencesRetrieve"/>
+        <xs:element name="citedReferencesRetrieveResponse" type="tns:citedReferencesRetrieveResponse"/>
+        <xs:element name="citingArticles" type="tns:citingArticles"/>
+        <xs:element name="citingArticlesResponse" type="tns:citingArticlesResponse"/>
+        <xs:element name="relatedRecords" type="tns:relatedRecords"/>
+        <xs:element name="relatedRecordsResponse" type="tns:relatedRecordsResponse"/>
+        <xs:element name="retrieve" type="tns:retrieve"/>
+        <xs:element name="retrieveById" type="tns:retrieveById"/>
+        <xs:element name="retrieveByIdResponse" type="tns:retrieveByIdResponse"/>
+        <xs:element name="retrieveResponse" type="tns:retrieveResponse"/>
+        <xs:element name="search" type="tns:search"/>
+        <xs:element name="searchResponse" type="tns:searchResponse"/>
+        <xs:complexType name="citedReferences">
+            <xs:sequence>
+              <xs:element name="databaseId" type="xs:string"/>
+              <xs:element name="uid" type="xs:string"/>
+              <xs:element name="queryLanguage" type="xs:string"/>
+              <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="retrieveParameters">
+            <xs:sequence>
+              <xs:element name="firstRecord" type="xs:int"/>
+              <xs:element name="count" type="xs:int"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="sortField" nillable="true" type="tns:sortField"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="viewField" nillable="true" type="tns:viewField"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="option" nillable="true" type="tns:keyValuePair"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="sortField">
+            <xs:sequence>
+              <xs:element name="name" type="xs:string"/>
+              <xs:element name="sort" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="viewField">
+            <xs:sequence>
+              <xs:element name="collectionName" type="xs:string"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="fieldName" nillable="true" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="keyValuePair">
+            <xs:sequence>
+              <xs:element name="key" type="xs:string"/>
+              <xs:element name="value" nillable="true" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="citedReferencesResponse">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="return" type="tns:citedReferencesSearchResults"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="citedReferencesSearchResults">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="queryId" type="xs:string"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="references" nillable="true" type="tns:citedReference"/>
+              <xs:element name="recordsFound" type="xs:int"/>
+              <xs:element name="recordsSearched" type="xs:long"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="citedReference">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="uid" type="xs:string"/>
+              <xs:element minOccurs="0" name="docid" type="xs:string"/>
+              <xs:element minOccurs="0" name="articleId" type="xs:string"/>
+              <xs:element minOccurs="0" name="citedAuthor" type="xs:string"/>
+              <xs:element minOccurs="0" name="timesCited" type="xs:string"/>
+              <xs:element minOccurs="0" name="year" type="xs:string"/>
+              <xs:element minOccurs="0" name="page" type="xs:string"/>
+              <xs:element minOccurs="0" name="volume" type="xs:string"/>
+              <xs:element minOccurs="0" name="citedTitle" type="xs:string"/>
+              <xs:element minOccurs="0" name="citedWork" type="xs:string"/>
+              <xs:element minOccurs="0" name="hot" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="QueryException">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
+              <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="FaultInformation">
+            <xs:sequence>
+              <xs:element name="code" type="xs:string"/>
+              <xs:element minOccurs="0" name="message" type="xs:string"/>
+              <xs:element minOccurs="0" name="reason" type="xs:string"/>
+              <xs:element minOccurs="0" name="causeType" type="xs:string"/>
+              <xs:element minOccurs="0" name="cause" type="xs:string"/>
+              <xs:element minOccurs="0" name="supportingWebServiceException" type="tns:SupportingWebServiceException"/>
+              <xs:element minOccurs="0" name="remedy" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="SupportingWebServiceException">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="remoteNamespace" type="xs:string"/>
+              <xs:element minOccurs="0" name="remoteOperation" type="xs:string"/>
+              <xs:element minOccurs="0" name="remoteCode" type="xs:string"/>
+              <xs:element minOccurs="0" name="remoteReason" type="xs:string"/>
+              <xs:element minOccurs="0" name="handshakeCauseId" type="xs:string"/>
+              <xs:element minOccurs="0" name="handshakeCause" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="RawFaultInformation">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="rawFaultstring" type="xs:string"/>
+              <xs:element minOccurs="0" name="rawMessage" type="xs:string"/>
+              <xs:element minOccurs="0" name="rawReason" type="xs:string"/>
+              <xs:element minOccurs="0" name="rawCause" type="xs:string"/>
+              <xs:element minOccurs="0" name="rawRemedy" type="xs:string"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="messageData" nillable="true" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="InvalidInputException">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
+              <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="ESTIWSException">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
+              <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="InternalServerException">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
+              <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="AuthenticationException">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
+              <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="SessionException">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
+              <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="citedReferencesRetrieve">
+            <xs:sequence>
+              <xs:element name="queryId" type="xs:string"/>
+              <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="citedReferencesRetrieveResponse">
+            <xs:sequence>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="return" type="tns:citedReference"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="relatedRecords">
+            <xs:sequence>
+              <xs:element name="databaseId" type="xs:string"/>
+              <xs:element name="uid" type="xs:string"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="editions" nillable="true" type="tns:editionDesc"/>
+              <xs:element minOccurs="0" name="timeSpan" type="tns:timeSpan"/>
+              <xs:element name="queryLanguage" type="xs:string"/>
+              <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="editionDesc">
+            <xs:sequence>
+              <xs:element name="collection" type="xs:string"/>
+              <xs:element name="edition" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="timeSpan">
+            <xs:sequence>
+              <xs:element name="begin" type="xs:string"/>
+              <xs:element name="end" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="relatedRecordsResponse">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="return" type="tns:fullRecordSearchResults"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="fullRecordSearchResults">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="queryId" type="xs:string"/>
+              <xs:element name="recordsFound" type="xs:int"/>
+              <xs:element name="recordsSearched" type="xs:long"/>
+              <xs:element minOccurs="0" name="parent" type="xs:string"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="optionValue" nillable="true" type="tns:labelValuesPair"/>
+              <xs:element minOccurs="0" name="records" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="labelValuesPair">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="label" type="xs:string"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="value" nillable="true" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="retrieveById">
+            <xs:sequence>
+              <xs:element name="databaseId" type="xs:string"/>
+              <xs:element maxOccurs="unbounded" name="uid" type="xs:string"/>
+              <xs:element name="queryLanguage" type="xs:string"/>
+              <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="retrieveByIdResponse">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="return" type="tns:fullRecordSearchResults"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="retrieve">
+            <xs:sequence>
+              <xs:element name="queryId" type="xs:string"/>
+              <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="retrieveResponse">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="return" type="tns:fullRecordData"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="fullRecordData">
+            <xs:sequence>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="optionValue" nillable="true" type="tns:labelValuesPair"/>
+              <xs:element minOccurs="0" name="records" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="search">
+            <xs:sequence>
+              <xs:element name="queryParameters" type="tns:queryParameters"/>
+              <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="queryParameters">
+            <xs:sequence>
+              <xs:element name="databaseId" type="xs:string"/>
+              <xs:element name="userQuery" type="xs:string"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="editions" nillable="true" type="tns:editionDesc"/>
+              <xs:element minOccurs="0" name="symbolicTimeSpan" type="xs:string"/>
+              <xs:element minOccurs="0" name="timeSpan" type="tns:timeSpan"/>
+              <xs:element name="queryLanguage" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="searchResponse">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="return" type="tns:fullRecordSearchResults"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="citingArticles">
+            <xs:sequence>
+              <xs:element name="databaseId" type="xs:string"/>
+              <xs:element name="uid" type="xs:string"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="editions" nillable="true" type="tns:editionDesc"/>
+              <xs:element minOccurs="0" name="timeSpan" type="tns:timeSpan"/>
+              <xs:element name="queryLanguage" type="xs:string"/>
+              <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="citingArticlesResponse">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="return" type="tns:fullRecordSearchResults"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:schema>
+          </wsdl:types>
+          <wsdl:message name="relatedRecordsResponse">
+            <wsdl:part element="tns:relatedRecordsResponse" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="relatedRecords">
+            <wsdl:part element="tns:relatedRecords" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="retrieveById">
+            <wsdl:part element="tns:retrieveById" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="retrieveResponse">
+            <wsdl:part element="tns:retrieveResponse" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="ESTIWSException_Exception">
+            <wsdl:part element="tns:ESTIWSException" name="ESTIWSException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="InternalServerException_Exception">
+            <wsdl:part element="tns:InternalServerException" name="InternalServerException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="retrieve">
+            <wsdl:part element="tns:retrieve" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="searchResponse">
+            <wsdl:part element="tns:searchResponse" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="citingArticlesResponse">
+            <wsdl:part element="tns:citingArticlesResponse" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="AuthenticationException_Exception">
+            <wsdl:part element="tns:AuthenticationException" name="AuthenticationException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="retrieveByIdResponse">
+            <wsdl:part element="tns:retrieveByIdResponse" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="search">
+            <wsdl:part element="tns:search" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="citingArticles">
+            <wsdl:part element="tns:citingArticles" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="citedReferences">
+            <wsdl:part element="tns:citedReferences" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="citedReferencesRetrieve">
+            <wsdl:part element="tns:citedReferencesRetrieve" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="citedReferencesRetrieveResponse">
+            <wsdl:part element="tns:citedReferencesRetrieveResponse" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="QueryException_Exception">
+            <wsdl:part element="tns:QueryException" name="QueryException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="InvalidInputException_Exception">
+            <wsdl:part element="tns:InvalidInputException" name="InvalidInputException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="citedReferencesResponse">
+            <wsdl:part element="tns:citedReferencesResponse" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="SessionException_Exception">
+            <wsdl:part element="tns:SessionException" name="SessionException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:portType name="WokSearch">
+            <wsdl:operation name="citedReferences">
+              <wsdl:input message="tns:citedReferences" name="citedReferences">
+            </wsdl:input>
+              <wsdl:output message="tns:citedReferencesResponse" name="citedReferencesResponse">
+            </wsdl:output>
+              <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="citedReferencesRetrieve">
+              <wsdl:input message="tns:citedReferencesRetrieve" name="citedReferencesRetrieve">
+            </wsdl:input>
+              <wsdl:output message="tns:citedReferencesRetrieveResponse" name="citedReferencesRetrieveResponse">
+            </wsdl:output>
+              <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="relatedRecords">
+              <wsdl:input message="tns:relatedRecords" name="relatedRecords">
+            </wsdl:input>
+              <wsdl:output message="tns:relatedRecordsResponse" name="relatedRecordsResponse">
+            </wsdl:output>
+              <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="retrieveById">
+              <wsdl:input message="tns:retrieveById" name="retrieveById">
+            </wsdl:input>
+              <wsdl:output message="tns:retrieveByIdResponse" name="retrieveByIdResponse">
+            </wsdl:output>
+              <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="retrieve">
+              <wsdl:input message="tns:retrieve" name="retrieve">
+            </wsdl:input>
+              <wsdl:output message="tns:retrieveResponse" name="retrieveResponse">
+            </wsdl:output>
+              <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="search">
+              <wsdl:input message="tns:search" name="search">
+            </wsdl:input>
+              <wsdl:output message="tns:searchResponse" name="searchResponse">
+            </wsdl:output>
+              <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="citingArticles">
+              <wsdl:input message="tns:citingArticles" name="citingArticles">
+            </wsdl:input>
+              <wsdl:output message="tns:citingArticlesResponse" name="citingArticlesResponse">
+            </wsdl:output>
+              <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+            </wsdl:operation>
+          </wsdl:portType>
+          <wsdl:binding name="WokSearchServiceSoapBinding" type="tns:WokSearch">
+            <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+            <wsdl:operation name="citedReferences">
+              <soap:operation soapAction="" style="document"/>
+              <wsdl:input name="citedReferences">
+                <soap:body use="literal"/>
+              </wsdl:input>
+              <wsdl:output name="citedReferencesResponse">
+                <soap:body use="literal"/>
+              </wsdl:output>
+              <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+              </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="citedReferencesRetrieve">
+              <soap:operation soapAction="" style="document"/>
+              <wsdl:input name="citedReferencesRetrieve">
+                <soap:body use="literal"/>
+              </wsdl:input>
+              <wsdl:output name="citedReferencesRetrieveResponse">
+                <soap:body use="literal"/>
+              </wsdl:output>
+              <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+              </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="relatedRecords">
+              <soap:operation soapAction="" style="document"/>
+              <wsdl:input name="relatedRecords">
+                <soap:body use="literal"/>
+              </wsdl:input>
+              <wsdl:output name="relatedRecordsResponse">
+                <soap:body use="literal"/>
+              </wsdl:output>
+              <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+              </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="retrieveById">
+              <soap:operation soapAction="" style="document"/>
+              <wsdl:input name="retrieveById">
+                <soap:body use="literal"/>
+              </wsdl:input>
+              <wsdl:output name="retrieveByIdResponse">
+                <soap:body use="literal"/>
+              </wsdl:output>
+              <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+              </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="retrieve">
+              <soap:operation soapAction="" style="document"/>
+              <wsdl:input name="retrieve">
+                <soap:body use="literal"/>
+              </wsdl:input>
+              <wsdl:output name="retrieveResponse">
+                <soap:body use="literal"/>
+              </wsdl:output>
+              <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+              </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="search">
+              <soap:operation soapAction="" style="document"/>
+              <wsdl:input name="search">
+                <soap:body use="literal"/>
+              </wsdl:input>
+              <wsdl:output name="searchResponse">
+                <soap:body use="literal"/>
+              </wsdl:output>
+              <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+              </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="citingArticles">
+              <soap:operation soapAction="" style="document"/>
+              <wsdl:input name="citingArticles">
+                <soap:body use="literal"/>
+              </wsdl:input>
+              <wsdl:output name="citingArticlesResponse">
+                <soap:body use="literal"/>
+              </wsdl:output>
+              <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+              </wsdl:fault>
+            </wsdl:operation>
+          </wsdl:binding>
+          <wsdl:service name="WokSearchService">
+            <wsdl:port binding="tns:WokSearchServiceSoapBinding" name="WokSearchPort">
+              <soap:address location="http://search.webofknowledge.com/esti/wokmws/ws/WokSearch"/>
+            </wsdl:port>
+          </wsdl:service>
+        </wsdl:definitions>
+    http_version: 
+  recorded_at: Wed, 03 Apr 2019 23:00:31 GMT
+- request:
+    method: post
+    uri: http://search.webofknowledge.com/esti/wokmws/ws/WokSearch
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://woksearch.v3.wokmws.thomsonreuters.com"
+        xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Body><tns:search><queryParameters><databaseId>WOK</databaseId><userQuery>AU=(&quot;Edler,Alice&quot;
+        OR &quot;Edler,Alice,Jim&quot; OR &quot;Edler,Alice,J&quot;) AND AD=(&quot;stanford&quot;)</userQuery><queryLanguage>en</queryLanguage></queryParameters><retrieveParameters><firstRecord>1</firstRecord><count>100</count><viewField><collectionName>WOS</collectionName><fieldName></fieldName></viewField><viewField><collectionName>MEDLINE</collectionName><fieldName></fieldName></viewField><option><key>RecordIDs</key><value>On</value></option></retrieveParameters></tns:search></soapenv:Body></soapenv:Envelope>
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.5.1 (2018-03-29))
+      Accept:
+      - "*/*"
+      Date:
+      - Wed, 03 Apr 2019 23:00:31 GMT
+      Cookie:
+      - SID="7BpaQrkTPsk18oNgGx1"
+      Soapaction:
+      - ''
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Content-Length:
+      - '890'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Date:
+      - Wed, 03 Apr 2019 23:00:30 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Content-Length:
+      - '5236'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><ns2:searchResponse
+        xmlns:ns2="http://woksearch.v3.wokmws.thomsonreuters.com"><return><queryId>1</queryId><recordsFound>18</recordsFound><recordsSearched>81062482</recordsSearched><optionValue><label>RecordIDs</label><value>WOS:000218296900007</value><value>MEDLINE:19088623</value><value>WOS:000264165900021</value><value>WOS:000252230800009</value><value>WOS:000270210100035</value><value>WOS:000212962700007</value><value>WOS:000276938400007</value><value>WOS:000249038700050</value><value>WOS:000217248400003</value><value>WOS:000236198500001</value><value>WOS:000251905400030</value><value>WOS:000250317500068</value><value>WOS:000176711100016</value><value>WOS:000212958400021</value><value>WOS:000186655000011</value><value>WOS:000256730800021</value><value>WOS:000259817100020</value><value>WOS:000245371900010</value></optionValue><records>&lt;records
+        xmlns="http://scientific.thomsonreuters.com/schema/wok5.4/public/Fields">&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000218296900007&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>MEDLINE:19088623&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000264165900021&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000252230800009&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000270210100035&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000212962700007&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000276938400007&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000249038700050&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000217248400003&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000236198500001&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000251905400030&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000250317500068&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000176711100016&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000212958400021&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000186655000011&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data&gt;&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000256730800021&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000259817100020&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000245371900010&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;/records></records></return></ns2:searchResponse></soap:Body></soap:Envelope>
+    http_version: 
+  recorded_at: Wed, 03 Apr 2019 23:00:31 GMT
+- request:
+    method: post
+    uri: http://search.webofknowledge.com/esti/wokmws/ws/WokSearch
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://woksearch.v3.wokmws.thomsonreuters.com"
+        xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Body><tns:retrieveById><databaseId>WOK</databaseId><uid>WOS:000218296900007</uid><uid>MEDLINE:19088623</uid><uid>WOS:000264165900021</uid><uid>WOS:000252230800009</uid><uid>WOS:000270210100035</uid><uid>WOS:000212962700007</uid><uid>WOS:000276938400007</uid><uid>WOS:000249038700050</uid><uid>WOS:000217248400003</uid><uid>WOS:000236198500001</uid><uid>WOS:000251905400030</uid><uid>WOS:000250317500068</uid><uid>WOS:000176711100016</uid><uid>WOS:000212958400021</uid><uid>WOS:000186655000011</uid><uid>WOS:000256730800021</uid><uid>WOS:000259817100020</uid><uid>WOS:000245371900010</uid><queryLanguage>en</queryLanguage><retrieveParameters><firstRecord>1</firstRecord><count>100</count><option><key>RecordIDs</key><value>On</value></option><option><key>targetNamespace</key><value>http://scientific.thomsonreuters.com/schema/wok5.4/public/FullRecord</value></option></retrieveParameters></tns:retrieveById></soapenv:Body></soapenv:Envelope>
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.5.1 (2018-03-29))
+      Accept:
+      - "*/*"
+      Date:
+      - Wed, 03 Apr 2019 23:00:31 GMT
+      Cookie:
+      - SID="7BpaQrkTPsk18oNgGx1"
+      Soapaction:
+      - ''
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Content-Length:
+      - '1221'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Date:
+      - Wed, 03 Apr 2019 23:00:31 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><ns2:retrieveByIdResponse
+        xmlns:ns2="http://woksearch.v3.wokmws.thomsonreuters.com"><return><queryId>2</queryId><recordsFound>18</recordsFound><recordsSearched>81062482</recordsSearched><optionValue><label>RecordIDs</label><value>WOS:000259817100020</value><value>WOS:000256730800021</value><value>WOS:000252230800009</value><value>WOS:000251905400030</value><value>WOS:000250317500068</value><value>WOS:000249038700050</value><value>WOS:000245371900010</value><value>WOS:000236198500001</value><value>WOS:000212958400021</value><value>WOS:000186655000011</value><value>WOS:000212962700007</value><value>WOS:000218296900007</value><value>WOS:000217248400003</value><value>WOS:000176711100016</value><value>MEDLINE:19088623</value><value>WOS:000276938400007</value><value>WOS:000270210100035</value><value>WOS:000264165900021</value></optionValue><records>&lt;records
+        xmlns="http://scientific.thomsonreuters.com/schema/wok5.4/public/FullRecord">&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000259817100020&lt;/UID>&lt;static_data>&lt;summary>&lt;EWUID>&lt;WUID
+        coll_id="WOS">&lt;/WUID>&lt;edition value="WOS.SCI">&lt;/edition>&lt;/EWUID>&lt;pub_info
+        sortdate="2008-11-01" pubyear="2008" has_abstract="N" coverdate="NOV 2008"
+        pubmonth="NOV" vol="18" issue="11" pubtype="Journal">&lt;page begin="1107"
+        end="1109" page_count="4">1107-1109&lt;/page>&lt;/pub_info>&lt;titles count="6">&lt;title
+        type="source">PEDIATRIC ANESTHESIA&lt;/title>&lt;title type="source_abbrev">PEDIATR
+        ANESTH&lt;/title>&lt;title type="abbrev_iso">Pediatr. Anesth.&lt;/title>&lt;title
+        type="abbrev_11">PEDIATR ANE&lt;/title>&lt;title type="abbrev_29">PEDIATR
+        ANESTH&lt;/title>&lt;title type="item">Improving electrical safety for patients
+        with Epidermolysis bullosa&lt;/title>&lt;/titles>&lt;names count="3">&lt;name
+        seq_no="1" role="author" reprint="Y" addr_no="1" daisng_id="2533299">&lt;display_name>Edler,
+        Alice A.&lt;/display_name>&lt;full_name>Edler, Alice A.&lt;/full_name>&lt;wos_standard>Edler,
+        AA&lt;/wos_standard>&lt;first_name>Alice A.&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;email_addr>edlera@stanford.edu&lt;/email_addr>&lt;/name>&lt;name
+        seq_no="2" role="author" addr_no="1" daisng_id="5791806">&lt;display_name>Ramamurthi,
+        Radhamangalam J.&lt;/display_name>&lt;full_name>Ramamurthi, Radhamangalam
+        J.&lt;/full_name>&lt;wos_standard>Ramamurthi, RJ&lt;/wos_standard>&lt;first_name>Radhamangalam
+        J.&lt;/first_name>&lt;last_name>Ramamurthi&lt;/last_name>&lt;/name>&lt;name
+        seq_no="3" role="author" addr_no="1" daisng_id="10937276">&lt;display_name>Valenzuela,
+        Glenn A.&lt;/display_name>&lt;full_name>Valenzuela, Glenn A.&lt;/full_name>&lt;wos_standard>Valenzuela,
+        GA&lt;/wos_standard>&lt;first_name>Glenn A.&lt;/first_name>&lt;last_name>Valenzuela&lt;/last_name>&lt;/name>&lt;/names>&lt;doctypes
+        count="1">&lt;doctype>Letter&lt;/doctype>&lt;/doctypes>&lt;publishers>&lt;publisher>&lt;address_spec
+        addr_no="1">&lt;full_address>9600 GARSINGTON RD, OXFORD OX4 2DQ, OXON, ENGLAND&lt;/full_address>&lt;city>OXFORD&lt;/city>&lt;/address_spec>&lt;names
+        count="1">&lt;name role="publisher" seq_no="1" addr_no="1">&lt;display_name&gt;BLACKWELL
+        PUBLISHING&lt;/display_name>&lt;full_name>BLACKWELL PUBLISHING&lt;/full_name>&lt;/name>&lt;/names>&lt;/publisher>&lt;/publishers>&lt;/summary>&lt;fullrecord_metadata>&lt;languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/languages>&lt;normalized_languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/normalized_languages>&lt;normalized_doctypes
+        count="1">&lt;doctype>Letter&lt;/doctype>&lt;/normalized_doctypes>&lt;refs
+        count="5">&lt;/refs>&lt;addresses count="1">&lt;address_name>&lt;address_spec
+        addr_no="1">&lt;full_address>Stanford Univ, Sch Med, Dept Anesthesia, Sect
+        Pediat Anesthesia, Stanford, CA 94305 USA&lt;/full_address>&lt;organizations
+        count="2">&lt;organization>Stanford Univ&lt;/organization>&lt;organization
+        pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="3">&lt;suborganization>Sch Med&lt;/suborganization>&lt;suborganization>Dept
+        Anesthesia&lt;/suborganization>&lt;suborganization>Sect Pediat Anesthesia&lt;/suborganization>&lt;/suborganizations>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;names count="3">&lt;name
+        seq_no="1" role="author" reprint="Y" addr_no="1" daisng_id="2533299">&lt;display_name>Edler,
+        Alice A.&lt;/display_name>&lt;full_name>Edler, Alice A.&lt;/full_name>&lt;wos_standard>Edler,
+        AA&lt;/wos_standard>&lt;first_name>Alice A.&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;email_addr>edlera@stanford.edu&lt;/email_addr>&lt;/name>&lt;name
+        seq_no="2" role="author" addr_no="1" daisng_id="5791806">&lt;display_name>Ramamurthi,
+        Radhamangalam J.&lt;/display_name>&lt;full_name>Ramamurthi, Radhamangalam
+        J.&lt;/full_name>&lt;wos_standard>Ramamurthi, RJ&lt;/wos_standard>&lt;first_name>Radhamangalam
+        J.&lt;/first_name>&lt;last_name>Ramamurthi&lt;/last_name>&lt;/name>&lt;name
+        seq_no="3" role="author" addr_no="1" daisng_id="10937276">&lt;display_name>Valenzuela,
+        Glenn A.&lt;/display_name>&lt;full_name>Valenzuela, Glenn A.&lt;/full_name>&lt;wos_standard>Valenzuela,
+        GA&lt;/wos_standard>&lt;first_name>Glenn A.&lt;/first_name>&lt;last_name>Valenzuela&lt;/last_name>&lt;/name>&lt;/names>&lt;/address_name>&lt;/addresses>&lt;reprint_addresses
+        count="1">&lt;address_name>&lt;address_spec addr_no="1">&lt;full_address>Stanford
+        Univ, Sch Med, Dept Anesthesia, Sect Pediat Anesthesia, Stanford, CA 94305
+        USA&lt;/full_address>&lt;organizations count="2">&lt;organization>Stanford
+        Univ&lt;/organization>&lt;organization pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="3">&lt;suborganization>Sch Med&lt;/suborganization>&lt;suborganization>Dept
+        Anesthesia&lt;/suborganization>&lt;suborganization>Sect Pediat Anesthesia&lt;/suborganization>&lt;/suborganizations>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;names count="1">&lt;name
+        seq_no="1" role="author" reprint="Y" addr_no="1">&lt;display_name>Edler, Alice
+        A.&lt;/display_name>&lt;full_name>Edler, Alice A.&lt;/full_name>&lt;wos_standard>Edler,
+        AA&lt;/wos_standard>&lt;first_name>Alice A.&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;email_addr>edlera@stanford.edu&lt;/email_addr>&lt;/name>&lt;/names>&lt;/address_name>&lt;/reprint_addresses>&lt;category_info>&lt;headings
+        count="1">&lt;heading>Science &amp;amp; Technology&lt;/heading>&lt;/headings>&lt;subheadings
+        count="1">&lt;subheading>Life Sciences &amp;amp; Biomedicine&lt;/subheading>&lt;/subheadings>&lt;subjects
+        count="4">&lt;subject ascatype="traditional" code="BA">Anesthesiology&lt;/subject>&lt;subject
+        ascatype="traditional" code="TQ">Pediatrics&lt;/subject>&lt;subject ascatype="extended">Anesthesiology&lt;/subject>&lt;subject
+        ascatype="extended">Pediatrics&lt;/subject>&lt;/subjects>&lt;/category_info>&lt;/fullrecord_metadata>&lt;item
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="itemType_wos"
+        coll_id="WOS">&lt;ids avail="Y">356ZW&lt;/ids>&lt;bib_id>18 (11): 1107-1109
+        NOV 2008&lt;/bib_id>&lt;/item>&lt;/static_data>&lt;dynamic_data>&lt;citation_related>&lt;tc_list>&lt;silo_tc
+        coll_id="WOS" local_count="0">&lt;/silo_tc>&lt;/tc_list>&lt;/citation_related>&lt;cluster_related>&lt;identifiers>&lt;identifier
+        type="issn" value="1155-5645">&lt;/identifier>&lt;identifier type="doi" value="10.1111/j.1460-9592.2008.02715.x">&lt;/identifier>&lt;identifier
+        type="xref_doi" value="10.1111/j.1460-9592.2008.02715.x">&lt;/identifier>&lt;/identifiers>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000256730800021&lt;/UID>&lt;static_data>&lt;summary>&lt;EWUID>&lt;WUID
+        coll_id="WOS">&lt;/WUID>&lt;edition value="WOS.SCI">&lt;/edition>&lt;/EWUID>&lt;pub_info
+        sortdate="2008-05-01" pubyear="2008" has_abstract="N" coverdate="MAY 2008"
+        pubmonth="MAY" vol="20" issue="3" pubtype="Journal">&lt;page begin="241" end="242"
+        page_count="2">241-242&lt;/page>&lt;/pub_info>&lt;titles count="6">&lt;title
+        type="source">JOURNAL OF CLINICAL ANESTHESIA&lt;/title>&lt;title type="source_abbrev">J
+        CLIN ANESTH&lt;/title>&lt;title type="abbrev_iso">J. Clin. Anesth.&lt;/title>&lt;title
+        type="abbrev_11">J CLIN ANES&lt;/title>&lt;title type="abbrev_29">J CLIN ANESTH&lt;/title>&lt;title
+        type="item">Training attendings to be expert teachers: the Stanford Anesthesia
+        Teaching Scholars Program&lt;/title>&lt;/titles>&lt;names count="3">&lt;name
+        seq_no="1" role="author" reprint="Y" addr_no="1" daisng_id="419444">&lt;display_name>Macario,
+        Alex&lt;/display_name>&lt;full_name>Macario, Alex&lt;/full_name>&lt;wos_standard>Macario,
+        A&lt;/wos_standard>&lt;first_name>Alex&lt;/first_name>&lt;last_name>Macario&lt;/last_name>&lt;email_addr>amaca@stanford.edu&lt;/email_addr>&lt;/name>&lt;name
+        seq_no="2" role="author" addr_no="1" daisng_id="2533299">&lt;display_name>Edler,
+        Alice&lt;/display_name>&lt;full_name>Edler, Alice&lt;/full_name>&lt;wos_standard>Edler,
+        A&lt;/wos_standard>&lt;first_name>Alice&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;/name>&lt;name
+        seq_no="3" role="author" addr_no="1" daisng_id="74994">&lt;display_name>Pearl,
+        Ronald&lt;/display_name>&lt;full_name>Pearl, Ronald&lt;/full_name>&lt;wos_standard>Pearl,
+        R&lt;/wos_standard>&lt;first_name>Ronald&lt;/first_name>&lt;last_name>Pearl&lt;/last_name>&lt;/name>&lt;/names>&lt;doctypes
+        count="1">&lt;doctype>Letter&lt;/doctype>&lt;/doctypes>&lt;publishers>&lt;publisher>&lt;address_spec
+        addr_no="1">&lt;full_address>360 PARK AVE SOUTH, NEW YORK, NY 10010-1710 USA&lt;/full_address>&lt;city>NEW
+        YORK&lt;/city>&lt;/address_spec>&lt;names count="1">&lt;name role="publisher"
+        seq_no="1" addr_no="1">&lt;display_name>ELSEVIER SCIENCE INC&lt;/display_name>&lt;full_name>ELSEVIER
+        SCIENCE INC&lt;/full_name>&lt;/name>&lt;/names>&lt;/publisher>&lt;/publishers>&lt;/summary>&lt;fullrecord_metadata>&lt;languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/languages>&lt;normalized_languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/normalized_languages>&lt;normalized_doctypes
+        count="1">&lt;doctype>Letter&lt;/doctype>&lt;/normalized_doctypes>&lt;refs
+        count="4">&lt;/refs>&lt;addresses count="1">&lt;address_name>&lt;address_spec
+        addr_no="1">&lt;full_address>Stanford Univ, Sch Med, Dept Anesthesia H3580,
+        Stanford, CA 94305 USA&lt;/full_address>&lt;organizations count="2">&lt;organization>Stanford
+        Univ&lt;/organization>&lt;organization pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="2">&lt;suborganization>Sch Med&lt;/suborganization>&lt;suborganization>Dept
+        Anesthesia H3580&lt;/suborganization>&lt;/suborganizations>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;names count="3">&lt;name
+        seq_no="1" role="author" reprint="Y" addr_no="1" daisng_id="419444">&lt;display_name>Macario,
+        Alex&lt;/display_name>&lt;full_name>Macario, Alex&lt;/full_name>&lt;wos_standard>Macario,
+        A&lt;/wos_standard>&lt;first_name>Alex&lt;/first_name>&lt;last_name>Macario&lt;/last_name>&lt;email_addr>amaca@stanford.edu&lt;/email_addr>&lt;/name>&lt;name
+        seq_no="2" role="author" addr_no="1" daisng_id="2533299">&lt;display_name>Edler,
+        Alice&lt;/display_name>&lt;full_name>Edler, Alice&lt;/full_name>&lt;wos_standard>Edler,
+        A&lt;/wos_standard>&lt;first_name>Alice&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;/name>&lt;name
+        seq_no="3" role="author" addr_no="1" daisng_id="74994">&lt;display_name>Pearl,
+        Ronald&lt;/display_name>&lt;full_name>Pearl, Ronald&lt;/full_name>&lt;wos_standard>Pearl,
+        R&lt;/wos_standard>&lt;first_name>Ronald&lt;/first_name>&lt;last_name>Pearl&lt;/last_name>&lt;/name>&lt;/names>&lt;/address_name>&lt;/addresses>&lt;reprint_addresses
+        count="1">&lt;address_name>&lt;address_spec addr_no="1">&lt;full_address>Stanford
+        Univ, Sch Med, Dept Anesthesia H3580, Stanford, CA 94305 USA&lt;/full_address>&lt;organizations
+        count="2">&lt;organization>Stanford Univ&lt;/organization>&lt;organization
+        pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="2">&lt;suborganization>Sch Med&lt;/suborganization>&lt;suborganization>Dept
+        Anesthesia H3580&lt;/suborganization>&lt;/suborganizations>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;names count="1">&lt;name
+        seq_no="1" role="author" reprint="Y" addr_no="1">&lt;display_name>Macario,
+        Alex&lt;/display_name>&lt;full_name>Macario, Alex&lt;/full_name>&lt;wos_standard>Macario,
+        A&lt;/wos_standard>&lt;first_name>Alex&lt;/first_name>&lt;last_name>Macario&lt;/last_name>&lt;email_addr>amaca@stanford.edu&lt;/email_addr>&lt;/name>&lt;/names>&lt;/address_name>&lt;/reprint_addresses>&lt;category_info>&lt;headings
+        count="1">&lt;heading>Science &amp;amp; Technology&lt;/heading>&lt;/headings>&lt;subheadings
+        count="1">&lt;subheading>Life Sciences &amp;amp; Biomedicine&lt;/subheading>&lt;/subheadings>&lt;subjects
+        count="2">&lt;subject ascatype="traditional" code="BA">Anesthesiology&lt;/subject>&lt;subject
+        ascatype="extended">Anesthesiology&lt;/subject>&lt;/subjects>&lt;/category_info>&lt;/fullrecord_metadata>&lt;item
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="itemType_wos"
+        coll_id="WOS">&lt;ids avail="N">313HD&lt;/ids>&lt;bib_id>20 (3): 241-242 MAY
+        2008&lt;/bib_id>&lt;bib_pagecount type="Journal">98&lt;/bib_pagecount&gt;&lt;keywords_plus
+        count="1">&lt;keyword>ACADEMY&lt;/keyword>&lt;/keywords_plus>&lt;/item>&lt;/static_data>&lt;dynamic_data>&lt;citation_related>&lt;tc_list>&lt;silo_tc
+        coll_id="WOS" local_count="1">&lt;/silo_tc>&lt;/tc_list>&lt;/citation_related>&lt;cluster_related>&lt;identifiers>&lt;identifier
+        type="issn" value="0952-8180">&lt;/identifier>&lt;identifier type="eissn"
+        value="1873-4529">&lt;/identifier>&lt;identifier type="doi" value="10.1016/j.jclinane.2008.01.002">&lt;/identifier>&lt;identifier
+        type="xref_doi" value="10.1016/j.jclinane.2008.01.002">&lt;/identifier>&lt;/identifiers>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000252230800009&lt;/UID>&lt;static_data>&lt;summary>&lt;EWUID>&lt;WUID
+        coll_id="WOS">&lt;/WUID>&lt;edition value="WOS.SCI">&lt;/edition>&lt;/EWUID>&lt;pub_info
+        sortdate="2007-12-01" pubyear="2007" has_abstract="Y" coverdate="DEC 2007"
+        pubmonth="DEC" vol="19" issue="8" pubtype="Journal">&lt;page begin="616" end="618"
+        page_count="3">616-618&lt;/page>&lt;/pub_info>&lt;titles count="6">&lt;title
+        type="source">JOURNAL OF CLINICAL ANESTHESIA&lt;/title>&lt;title type="source_abbrev">J
+        CLIN ANESTH&lt;/title>&lt;title type="abbrev_iso">J. Clin. Anesth.&lt;/title>&lt;title
+        type="abbrev_11">J CLIN ANES&lt;/title>&lt;title type="abbrev_29">J CLIN ANESTH&lt;/title>&lt;title
+        type="item">Special anesthetic considerations for stereotactic radiosurgery
+        in children&lt;/title>&lt;/titles>&lt;names count="1">&lt;name seq_no="1"
+        role="author" reprint="Y" daisng_id="2533299">&lt;display_name>Edler, Alice&lt;/display_name>&lt;full_name>Edler,
+        Alice&lt;/full_name>&lt;wos_standard>Edler, A&lt;/wos_standard>&lt;first_name>Alice&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;email_addr>edlera@stanford.edu&lt;/email_addr>&lt;/name>&lt;/names>&lt;doctypes
+        count="1">&lt;doctype>Editorial Material&lt;/doctype>&lt;/doctypes>&lt;publishers>&lt;publisher>&lt;address_spec
+        addr_no="1">&lt;full_address>360 PARK AVE SOUTH, NEW YORK, NY 10010-1710 USA&lt;/full_address>&lt;city>NEW
+        YORK&lt;/city>&lt;/address_spec>&lt;names count="1">&lt;name role="publisher"
+        seq_no="1" addr_no="1">&lt;display_name>ELSEVIER SCIENCE INC&lt;/display_name>&lt;full_name>ELSEVIER
+        SCIENCE INC&lt;/full_name>&lt;/name>&lt;/names>&lt;/publisher>&lt;/publishers>&lt;/summary>&lt;fullrecord_metadata>&lt;languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/languages>&lt;normalized_languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/normalized_languages>&lt;normalized_doctypes
+        count="1">&lt;doctype>Editorial&lt;/doctype>&lt;/normalized_doctypes>&lt;refs
+        count="8">&lt;/refs>&lt;addresses count="1">&lt;address_name>&lt;address_spec
+        addr_no="1">&lt;full_address>Stanford Univ, Sch Med, Dept Anesthesia, Stanford,
+        CA 94305 USA&lt;/full_address>&lt;organizations count="2">&lt;organization>Stanford
+        Univ&lt;/organization>&lt;organization pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="2">&lt;suborganization>Sch Med&lt;/suborganization>&lt;suborganization>Dept
+        Anesthesia&lt;/suborganization>&lt;/suborganizations>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;/address_name>&lt;/addresses>&lt;reprint_addresses
+        count="1">&lt;address_name>&lt;address_spec addr_no="1">&lt;full_address>Stanford
+        Univ, Sch Med, Dept Anesthesia, Stanford, CA 94305 USA&lt;/full_address>&lt;organizations
+        count="2">&lt;organization>Stanford Univ&lt;/organization>&lt;organization
+        pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="2">&lt;suborganization>Sch Med&lt;/suborganization>&lt;suborganization>Dept
+        Anesthesia&lt;/suborganization>&lt;/suborganizations>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;names count="1">&lt;name
+        seq_no="1" role="author" reprint="Y" addr_no="1">&lt;display_name>Edler, Alice&lt;/display_name>&lt;full_name>Edler,
+        Alice&lt;/full_name>&lt;wos_standard>Edler, A&lt;/wos_standard>&lt;first_name>Alice&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;email_addr>edlera@stanford.edu&lt;/email_addr>&lt;/name>&lt;/names>&lt;/address_name>&lt;/reprint_addresses>&lt;category_info>&lt;headings
+        count="1">&lt;heading>Science &amp;amp; Technology&lt;/heading>&lt;/headings>&lt;subheadings
+        count="1">&lt;subheading>Life Sciences &amp;amp; Biomedicine&lt;/subheading>&lt;/subheadings>&lt;subjects
+        count="2">&lt;subject ascatype="traditional" code="BA">Anesthesiology&lt;/subject>&lt;subject
+        ascatype="extended">Anesthesiology&lt;/subject>&lt;/subjects>&lt;/category_info>&lt;keywords
+        count="3">&lt;keyword>anesthesia, pediatric&lt;/keyword>&lt;keyword>neurosurgery&lt;/keyword>&lt;keyword>stereotactic
+        surgery&lt;/keyword>&lt;/keywords>&lt;abstracts count="1">&lt;abstract>&lt;abstract_text
+        count="1">&lt;p>Children present special anesthetic considerations, not only
+        in their unique pharmacologic and physiologic attributes but also in the types
+        of anesthetic care they require. A new neurosurgical technique, the gamma
+        knife, is particularly challenging for pediatric anesthesia providers because
+        of its extended duration, multiple site procedures, and anesthetic requirements
+        associated with the use of a stereotactic frame. (c) 2007 Elsevier Inc. All
+        rights reserved.&lt;/p>&lt;/abstract_text>&lt;/abstract>&lt;/abstracts>&lt;/fullrecord_metadata>&lt;item
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="itemType_wos"
+        coll_id="WOS">&lt;ids avail="Y">249LV&lt;/ids>&lt;bib_id>19 (8): 616-618 DEC
+        2007&lt;/bib_id>&lt;/item>&lt;/static_data>&lt;dynamic_data>&lt;citation_related>&lt;tc_list>&lt;silo_tc
+        coll_id="WOS" local_count="4">&lt;/silo_tc>&lt;/tc_list>&lt;/citation_related>&lt;cluster_related>&lt;identifiers>&lt;identifier
+        type="issn" value="0952-8180">&lt;/identifier>&lt;identifier type="doi" value="10.1016/j.jclinane.2007.03.009">&lt;/identifier>&lt;identifier
+        type="xref_doi" value="10.1016/j.jclinane.2007.03.009">&lt;/identifier>&lt;/identifiers>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000251905400030&lt;/UID>&lt;static_data>&lt;summary>&lt;EWUID>&lt;WUID
+        coll_id="WOS">&lt;/WUID>&lt;edition value="WOS.SCI">&lt;/edition>&lt;/EWUID>&lt;pub_info
+        sortdate="2008-01-01" pubyear="2008" has_abstract="N" coverdate="JAN 2008"
+        pubmonth="JAN" vol="108" issue="1" pubtype="Journal">&lt;page begin="167"
+        end="167" page_count="1">167-167&lt;/page>&lt;/pub_info>&lt;titles count="6">&lt;title
+        type="source">ANESTHESIOLOGY&lt;/title>&lt;title type="source_abbrev">ANESTHESIOLOGY&lt;/title>&lt;title
+        type="abbrev_iso">Anesthesiology&lt;/title>&lt;title type="abbrev_11">ANESTHESIOL&lt;/title>&lt;title
+        type="abbrev_29">ANESTHESIOLOGY&lt;/title>&lt;title type="item">The use of
+        simulation education in competency assessment: More questions than answers&lt;/title>&lt;/titles>&lt;names
+        count="1">&lt;name seq_no="1" role="author" reprint="Y" addr_no="1" daisng_id="2533299">&lt;display_name>Edler,
+        Alice A.&lt;/display_name>&lt;full_name>Edler, Alice A.&lt;/full_name>&lt;wos_standard>Edler,
+        AA&lt;/wos_standard>&lt;first_name>Alice A.&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;email_addr>edlera@stanford.edu&lt;/email_addr>&lt;/name>&lt;/names>&lt;doctypes
+        count="1">&lt;doctype>Letter&lt;/doctype>&lt;/doctypes>&lt;publishers>&lt;publisher>&lt;address_spec
+        addr_no="1">&lt;full_address>530 WALNUT ST, PHILADELPHIA, PA 19106-3621 USA&lt;/full_address>&lt;city>PHILADELPHIA&lt;/city>&lt;/address_spec>&lt;names
+        count="1">&lt;name role="publisher" seq_no="1" addr_no="1">&lt;display_name>LIPPINCOTT
+        WILLIAMS &amp;amp; WILKINS&lt;/display_name>&lt;full_name>LIPPINCOTT WILLIAMS
+        &amp;amp; WILKINS&lt;/full_name>&lt;/name>&lt;/names>&lt;/publisher>&lt;/publishers>&lt;/summary>&lt;fullrecord_metadata>&lt;languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/languages>&lt;normalized_languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/normalized_languages>&lt;normalized_doctypes
+        count="1">&lt;doctype>Letter&lt;/doctype>&lt;/normalized_doctypes>&lt;refs
+        count="8">&lt;/refs>&lt;addresses count="1">&lt;address_name>&lt;address_spec
+        addr_no="1">&lt;full_address>Stanford Univ, Sch Med, Stanford, CA 94305 USA&lt;/full_address>&lt;organizations
+        count="2">&lt;organization>Stanford Univ&lt;/organization>&lt;organization
+        pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="1">&lt;suborganization>Sch Med&lt;/suborganization>&lt;/suborganizations>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;names count="1">&lt;name
+        seq_no="1" role="author" reprint="Y" addr_no="1" daisng_id="2533299">&lt;display_name>Edler,
+        Alice A.&lt;/display_name>&lt;full_name>Edler, Alice A.&lt;/full_name>&lt;wos_standard>Edler,
+        AA&lt;/wos_standard>&lt;first_name>Alice A.&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;email_addr>edlera@stanford.edu&lt;/email_addr>&lt;/name>&lt;/names>&lt;/address_name>&lt;/addresses>&lt;reprint_addresses
+        count="1">&lt;address_name>&lt;address_spec addr_no="1">&lt;full_address>Stanford
+        Univ, Sch Med, Stanford, CA 94305 USA&lt;/full_address>&lt;organizations count="2">&lt;organization>Stanford
+        Univ&lt;/organization>&lt;organization pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="1">&lt;suborganization>Sch Med&lt;/suborganization>&lt;/suborganizations>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;names count="1">&lt;name
+        seq_no="1" role="author" reprint="Y" addr_no="1">&lt;display_name>Edler, Alice
+        A.&lt;/display_name>&lt;full_name>Edler, Alice A.&lt;/full_name>&lt;wos_standard>Edler,
+        AA&lt;/wos_standard>&lt;first_name>Alice A.&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;email_addr>edlera@stanford.edu&lt;/email_addr>&lt;/name>&lt;/names>&lt;/address_name>&lt;/reprint_addresses>&lt;category_info>&lt;headings
+        count="1">&lt;heading>Science &amp;amp; Technology&lt;/heading>&lt;/headings>&lt;subheadings
+        count="1">&lt;subheading>Life Sciences &amp;amp; Biomedicine&lt;/subheading>&lt;/subheadings>&lt;subjects
+        count="2">&lt;subject ascatype="traditional" code="BA">Anesthesiology&lt;/subject>&lt;subject
+        ascatype="extended">Anesthesiology&lt;/subject>&lt;/subjects>&lt;/category_info>&lt;/fullrecord_metadata>&lt;item
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="itemType_wos"
+        coll_id="WOS">&lt;ids avail="Y">245AA&lt;/ids>&lt;bib_id>108 (1): 167-167
+        JAN 2008&lt;/bib_id>&lt;keywords_plus count="1">&lt;keyword>TEAMWORK&lt;/keyword>&lt;/keywords_plus>&lt;/item>&lt;/static_data>&lt;dynamic_data>&lt;citation_related>&lt;tc_list>&lt;silo_tc
+        coll_id="WOS" local_count="5">&lt;/silo_tc>&lt;/tc_list>&lt;/citation_related>&lt;cluster_related>&lt;identifiers>&lt;identifier
+        type="issn" value="0003-3022">&lt;/identifier>&lt;identifier type="xref_doi"
+        value="10.1097/01.anes.0000296648.16232.28">&lt;/identifier>&lt;/identifiers>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000250317500068&lt;/UID>&lt;static_data>&lt;summary>&lt;EWUID>&lt;WUID
+        coll_id="WOS">&lt;/WUID>&lt;edition value="WOS.SCI">&lt;/edition>&lt;/EWUID>&lt;pub_info
+        sortdate="2007-11-01" pubyear="2007" has_abstract="N" coverdate="NOV 2007"
+        pubmonth="NOV" vol="105" issue="5" pubtype="Journal">&lt;page begin="1513"
+        end="1513" page_count="1">1513-1513&lt;/page>&lt;/pub_info>&lt;titles count="6">&lt;title
+        type="source">ANESTHESIA AND ANALGESIA&lt;/title>&lt;title type="source_abbrev">ANESTH
+        ANALG&lt;/title>&lt;title type="abbrev_iso">Anesth. Analg.&lt;/title>&lt;title
+        type="abbrev_11">ANESTH ANAL&lt;/title>&lt;title type="abbrev_29">ANESTH ANALG&lt;/title>&lt;title
+        type="item">Factors influencing Postanesthesia recovery after pediatric ambulatory
+        tonsillectomy and adenoidectomy - In response&lt;/title>&lt;/titles>&lt;names
+        count="2">&lt;name seq_no="1" role="author" reprint="Y" daisng_id="2533299">&lt;display_name>Edler,
+        Alice&lt;/display_name>&lt;full_name>Edler, Alice&lt;/full_name>&lt;wos_standard>Edler,
+        A&lt;/wos_standard>&lt;first_name>Alice&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;/name>&lt;name
+        seq_no="2" role="author" daisng_id="1371640">&lt;display_name>Golianu, Brenda&lt;/display_name>&lt;full_name>Golianu,
+        Brenda&lt;/full_name>&lt;wos_standard>Golianu, B&lt;/wos_standard>&lt;first_name>Brenda&lt;/first_name>&lt;last_name>Golianu&lt;/last_name>&lt;/name>&lt;/names>&lt;doctypes
+        count="1">&lt;doctype>Letter&lt;/doctype>&lt;/doctypes>&lt;publishers>&lt;publisher>&lt;address_spec
+        addr_no="1">&lt;full_address>530 WALNUT ST, PHILADELPHIA, PA 19106-3621 USA&lt;/full_address>&lt;city>PHILADELPHIA&lt;/city>&lt;/address_spec>&lt;names
+        count="1">&lt;name role="publisher" seq_no="1" addr_no="1">&lt;display_name>LIPPINCOTT
+        WILLIAMS &amp;amp; WILKINS&lt;/display_name>&lt;full_name>LIPPINCOTT WILLIAMS
+        &amp;amp; WILKINS&lt;/full_name>&lt;/name>&lt;/names>&lt;/publisher>&lt;/publishers>&lt;/summary>&lt;fullrecord_metadata>&lt;languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/languages>&lt;normalized_languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/normalized_languages>&lt;normalized_doctypes
+        count="1">&lt;doctype>Letter&lt;/doctype>&lt;/normalized_doctypes>&lt;refs
+        count="3">&lt;/refs>&lt;addresses count="1">&lt;address_name>&lt;address_spec
+        addr_no="1">&lt;full_address>Stanford Univ, Sch Med, Stanford, CA 94305 USA&lt;/full_address>&lt;organizations
+        count="2">&lt;organization>Stanford Univ&lt;/organization>&lt;organization
+        pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="1">&lt;suborganization>Sch Med&lt;/suborganization>&lt;/suborganizations>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;/address_name>&lt;/addresses>&lt;reprint_addresses
+        count="1">&lt;address_name>&lt;address_spec addr_no="1">&lt;full_address>Stanford
+        Univ, Sch Med, Stanford, CA 94305 USA&lt;/full_address>&lt;organizations count="2">&lt;organization>Stanford
+        Univ&lt;/organization>&lt;organization pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="1">&lt;suborganization>Sch Med&lt;/suborganization>&lt;/suborganizations>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;names count="1">&lt;name
+        seq_no="1" role="author" reprint="Y" addr_no="1">&lt;display_name>Edler, Alice&lt;/display_name>&lt;full_name>Edler,
+        Alice&lt;/full_name>&lt;wos_standard>Edler, A&lt;/wos_standard>&lt;first_name>Alice&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;/name>&lt;/names>&lt;/address_name>&lt;/reprint_addresses>&lt;category_info>&lt;headings
+        count="1">&lt;heading>Science &amp;amp; Technology&lt;/heading>&lt;/headings>&lt;subheadings
+        count="1">&lt;subheading>Life Sciences &amp;amp; Biomedicine&lt;/subheading>&lt;/subheadings>&lt;subjects
+        count="2">&lt;subject ascatype="traditional" code="BA">Anesthesiology&lt;/subject>&lt;subject
+        ascatype="extended">Anesthesiology&lt;/subject>&lt;/subjects>&lt;/category_info>&lt;/fullrecord_metadata>&lt;item
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="itemType_wos"
+        coll_id="WOS">&lt;ids avail="Y">222SN&lt;/ids>&lt;bib_id>105 (5): 1513-1513
+        NOV 2007&lt;/bib_id>&lt;/item>&lt;/static_data>&lt;dynamic_data>&lt;citation_related>&lt;tc_list>&lt;silo_tc
+        coll_id="WOS" local_count="0">&lt;/silo_tc>&lt;/tc_list>&lt;/citation_related>&lt;cluster_related>&lt;identifiers>&lt;identifier
+        type="issn" value="0003-2999">&lt;/identifier>&lt;identifier type="doi" value="10.1213/01.ane.0000287015.05692.04">&lt;/identifier>&lt;/identifiers>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000249038700050&lt;/UID>&lt;static_data>&lt;summary>&lt;EWUID>&lt;WUID
+        coll_id="WOS">&lt;/WUID>&lt;edition value="WOS.SCI">&lt;/edition>&lt;/EWUID>&lt;pub_info
+        sortdate="2007-09-01" pubyear="2007" has_abstract="N" coverdate="SEP 2007"
+        pubmonth="SEP" vol="35" issue="9" pubtype="Journal">&lt;page begin="2237"
+        end="2238" page_count="2">2237-2238&lt;/page>&lt;/pub_info>&lt;titles count="6">&lt;title
+        type="source">CRITICAL CARE MEDICINE&lt;/title>&lt;title type="source_abbrev">CRIT
+        CARE MED&lt;/title>&lt;title type="abbrev_iso">Crit. Care Med.&lt;/title>&lt;title
+        type="abbrev_11">CRIT CARE M&lt;/title>&lt;title type="abbrev_29">CRIT CARE
+        MED&lt;/title>&lt;title type="item">&amp;quot;A rose by any other name&amp;quot;?
+        Toward a common terminology in simulation education and assessment&lt;/title>&lt;/titles>&lt;names
+        count="2">&lt;name seq_no="1" role="author" reprint="Y" daisng_id="2533299">&lt;display_name>Edler,
+        Alice A.&lt;/display_name>&lt;full_name>Edler, Alice A.&lt;/full_name>&lt;wos_standard>Edler,
+        AA&lt;/wos_standard>&lt;first_name>Alice A.&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;/name>&lt;name
+        seq_no="2" role="author" daisng_id="8436819">&lt;display_name>Fanning, Ruth
+        M.&lt;/display_name>&lt;full_name>Fanning, Ruth M.&lt;/full_name>&lt;wos_standard>Fanning,
+        RM&lt;/wos_standard>&lt;first_name>Ruth M.&lt;/first_name>&lt;last_name>Fanning&lt;/last_name>&lt;/name>&lt;/names>&lt;doctypes
+        count="1">&lt;doctype>Letter&lt;/doctype>&lt;/doctypes>&lt;publishers>&lt;publisher>&lt;address_spec
+        addr_no="1">&lt;full_address>530 WALNUT ST, PHILADELPHIA, PA 19106-3621 USA&lt;/full_address>&lt;city>PHILADELPHIA&lt;/city>&lt;/address_spec>&lt;names
+        count="1">&lt;name role="publisher" seq_no="1" addr_no="1">&lt;display_name>LIPPINCOTT
+        WILLIAMS &amp;amp; WILKINS&lt;/display_name>&lt;full_name>LIPPINCOTT WILLIAMS
+        &amp;amp; WILKINS&lt;/full_name>&lt;/name>&lt;/names>&lt;/publisher>&lt;/publishers>&lt;/summary>&lt;fullrecord_metadata>&lt;languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/languages>&lt;normalized_languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/normalized_languages>&lt;normalized_doctypes
+        count="1">&lt;doctype>Letter&lt;/doctype>&lt;/normalized_doctypes>&lt;refs
+        count="3">&lt;/refs>&lt;addresses count="1">&lt;address_name>&lt;address_spec
+        addr_no="1">&lt;full_address>Stanford Univ, Stanford, CA 94305 USA&lt;/full_address>&lt;organizations
+        count="2">&lt;organization>Stanford Univ&lt;/organization>&lt;organization
+        pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;/address_name>&lt;/addresses>&lt;reprint_addresses
+        count="1">&lt;address_name>&lt;address_spec addr_no="1">&lt;full_address>Stanford
+        Univ, Stanford, CA 94305 USA&lt;/full_address>&lt;organizations count="2">&lt;organization>Stanford
+        Univ&lt;/organization>&lt;organization pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;names count="1">&lt;name
+        seq_no="1" role="author" reprint="Y" addr_no="1">&lt;display_name>Edler, Alice
+        A.&lt;/display_name>&lt;full_name>Edler, Alice A.&lt;/full_name>&lt;wos_standard>Edler,
+        AA&lt;/wos_standard>&lt;first_name>Alice A.&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;/name>&lt;/names>&lt;/address_name>&lt;/reprint_addresses>&lt;category_info>&lt;headings
+        count="1">&lt;heading&gt;Science &amp;amp; Technology&lt;/heading>&lt;/headings>&lt;subheadings
+        count="1">&lt;subheading>Life Sciences &amp;amp; Biomedicine&lt;/subheading>&lt;/subheadings>&lt;subjects
+        count="2">&lt;subject ascatype="traditional" code="DS">Critical Care Medicine&lt;/subject>&lt;subject
+        ascatype="extended">General &amp;amp; Internal Medicine&lt;/subject>&lt;/subjects>&lt;/category_info>&lt;/fullrecord_metadata>&lt;item
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="itemType_wos"
+        coll_id="WOS">&lt;ids avail="Y">204JB&lt;/ids>&lt;bib_id>35 (9): 2237-2238
+        SEP 2007&lt;/bib_id>&lt;keywords_plus count="1">&lt;keyword>FEEDBACK&lt;/keyword>&lt;/keywords_plus>&lt;/item>&lt;/static_data>&lt;dynamic_data>&lt;citation_related>&lt;tc_list>&lt;silo_tc
+        coll_id="WOS" local_count="0">&lt;/silo_tc>&lt;/tc_list>&lt;/citation_related>&lt;cluster_related>&lt;identifiers>&lt;identifier
+        type="issn" value="0090-3493">&lt;/identifier>&lt;identifier type="doi" value="10.1097/01.CCM.0000281643.88046.DC">&lt;/identifier>&lt;identifier
+        type="xref_doi" value="10.1097/01.CCM.0000281643.88046.DC">&lt;/identifier>&lt;/identifiers>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000245371900010&lt;/UID>&lt;static_data>&lt;summary>&lt;EWUID>&lt;WUID
+        coll_id="WOS">&lt;/WUID>&lt;edition value="WOS.SCI">&lt;/edition>&lt;/EWUID>&lt;pub_info
+        sortdate="2007-04-01" pubyear="2007" has_abstract="Y" coverdate="APR 2007"
+        pubmonth="APR" vol="104" issue="4" pubtype="Journal">&lt;page begin="784"
+        end="789" page_count="6">784-789&lt;/page>&lt;/pub_info>&lt;titles count="6">&lt;title
+        type="source">ANESTHESIA AND ANALGESIA&lt;/title>&lt;title type="source_abbrev">ANESTH
+        ANALG&lt;/title>&lt;title type="abbrev_iso">Anesth. Analg.&lt;/title>&lt;title
+        type="abbrev_11">ANESTH ANAL&lt;/title>&lt;title type="abbrev_29">ANESTH ANALG&lt;/title>&lt;title
+        type="item">An analysis of factors influencing postanesthesia recovery after
+        pediatric ambulatory tonsillectomy and adenoidectomy&lt;/title>&lt;/titles>&lt;names
+        count="5">&lt;name seq_no="1" role="author" reprint="Y" daisng_id="2533299">&lt;display_name>Edler,
+        Alice A.&lt;/display_name>&lt;full_name>Edler, Alice A.&lt;/full_name>&lt;wos_standard>Edler,
+        AA&lt;/wos_standard>&lt;first_name>Alice A.&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;email_addr>edlera@aol.com&lt;/email_addr>&lt;/name>&lt;name
+        seq_no="2" role="author" daisng_id="187937">&lt;display_name>Mariano, Edward
+        R.&lt;/display_name>&lt;full_name>Mariano, Edward R.&lt;/full_name>&lt;wos_standard>Mariano,
+        ER&lt;/wos_standard>&lt;first_name>Edward R.&lt;/first_name>&lt;last_name>Mariano&lt;/last_name>&lt;/name>&lt;name
+        seq_no="3" role="author" daisng_id="1371640">&lt;display_name>Golianu, Brenda&lt;/display_name>&lt;full_name>Golianu,
+        Brenda&lt;/full_name>&lt;wos_standard>Golianu, B&lt;/wos_standard>&lt;first_name>Brenda&lt;/first_name>&lt;last_name>Golianu&lt;/last_name>&lt;/name>&lt;name
+        seq_no="4" role="author" daisng_id="5988843">&lt;display_name>Kuan, Calvin&lt;/display_name>&lt;full_name>Kuan,
+        Calvin&lt;/full_name>&lt;wos_standard>Kuan, C&lt;/wos_standard>&lt;first_name>Calvin&lt;/first_name>&lt;last_name>Kuan&lt;/last_name>&lt;/name>&lt;name
+        seq_no="5" role="author" daisng_id="9338718">&lt;display_name>Pentcheva, Krassimira&lt;/display_name>&lt;full_name>Pentcheva,
+        Krassimira&lt;/full_name>&lt;wos_standard>Pentcheva, K&lt;/wos_standard>&lt;first_name>Krassimira&lt;/first_name>&lt;last_name>Pentcheva&lt;/last_name>&lt;/name>&lt;/names>&lt;doctypes
+        count="1">&lt;doctype>Article&lt;/doctype>&lt;/doctypes>&lt;publishers>&lt;publisher>&lt;address_spec
+        addr_no="1">&lt;full_address>530 WALNUT ST, PHILADELPHIA, PA 19106-3621 USA&lt;/full_address>&lt;city>PHILADELPHIA&lt;/city>&lt;/address_spec>&lt;names
+        count="1">&lt;name role="publisher" seq_no="1" addr_no="1">&lt;display_name>LIPPINCOTT
+        WILLIAMS &amp;amp; WILKINS&lt;/display_name>&lt;full_name>LIPPINCOTT WILLIAMS
+        &amp;amp; WILKINS&lt;/full_name>&lt;/name>&lt;/names>&lt;/publisher>&lt;/publishers>&lt;/summary>&lt;fullrecord_metadata>&lt;languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/languages>&lt;normalized_languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/normalized_languages>&lt;normalized_doctypes
+        count="1">&lt;doctype>Article&lt;/doctype>&lt;/normalized_doctypes>&lt;refs
+        count="21">&lt;/refs>&lt;addresses count="2">&lt;address_name>&lt;address_spec
+        addr_no="1">&lt;full_address>Stanford Univ, Sch Med, Dept Anesthesia, Lucile
+        Packard Childrens Hosp, Stanford, CA 94305 USA&lt;/full_address>&lt;organizations
+        count="3">&lt;organization>Stanford Univ&lt;/organization>&lt;organization
+        pref="Y">Lucile Packard Children&amp;apos;s Hospital (LPCH)&lt;/organization>&lt;organization
+        pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="3">&lt;suborganization>Sch Med&lt;/suborganization>&lt;suborganization>Dept
+        Anesthesia&lt;/suborganization>&lt;suborganization>Lucile Packard Childrens
+        Hosp&lt;/suborganization>&lt;/suborganizations>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;/address_name>&lt;address_name>&lt;address_spec
+        addr_no="2">&lt;full_address>Univ Calif San Diego, Dept Anesthesia, San Diego
+        Sch Med, San Diego, CA 92103 USA&lt;/full_address>&lt;organizations count="3">&lt;organization>Univ
+        Calif San Diego&lt;/organization>&lt;organization pref="Y">University of California
+        San Diego&lt;/organization>&lt;organization pref="Y">University of California
+        System&lt;/organization>&lt;/organizations>&lt;suborganizations count="2">&lt;suborganization>Dept
+        Anesthesia&lt;/suborganization>&lt;suborganization>San Diego Sch Med&lt;/suborganization>&lt;/suborganizations>&lt;city>San
+        Diego&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">92103&lt;/zip>&lt;/address_spec>&lt;/address_name>&lt;/addresses>&lt;reprint_addresses
+        count="1">&lt;address_name>&lt;address_spec addr_no="1">&lt;full_address>Stanford
+        Univ, Sch Med, Dept Anesthesia, 300 pasteur Dr H3580, Stanford, CA 94305 USA&lt;/full_address>&lt;organizations
+        count="2">&lt;organization>Stanford Univ&lt;/organization>&lt;organization
+        pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="2">&lt;suborganization>Sch Med&lt;/suborganization>&lt;suborganization>Dept
+        Anesthesia&lt;/suborganization>&lt;/suborganizations>&lt;street>300 pasteur
+        Dr H3580&lt;/street>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;names count="1">&lt;name
+        seq_no="1" role="author" reprint="Y" addr_no="1">&lt;display_name>Edler, Alice
+        A.&lt;/display_name>&lt;full_name>Edler, Alice A.&lt;/full_name>&lt;wos_standard>Edler,
+        AA&lt;/wos_standard>&lt;first_name>Alice A.&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;email_addr>edlera@aol.com&lt;/email_addr>&lt;/name>&lt;/names>&lt;/address_name>&lt;/reprint_addresses>&lt;category_info>&lt;headings
+        count="1">&lt;heading>Science &amp;amp; Technology&lt;/heading>&lt;/headings>&lt;subheadings
+        count="1">&lt;subheading>Life Sciences &amp;amp; Biomedicine&lt;/subheading>&lt;/subheadings>&lt;subjects
+        count="2">&lt;subject ascatype="traditional" code="BA">Anesthesiology&lt;/subject>&lt;subject
+        ascatype="extended">Anesthesiology&lt;/subject>&lt;/subjects>&lt;/category_info>&lt;abstracts
+        count="1">&lt;abstract>&lt;abstract_text count="4">&lt;p>BACKGROUND: Many
+        factors contribute to prolonged length of stay (LOS) for pediatric patients
+        in the postanesthesia care unit (PACU). We designed this prospective study
+        to identify the pre- and postoperative factors that prolong LOS.&lt;/p>&lt;p>METHODS:
+        We studied 166 children, aged 1-18 yr, who underwent tonsillectomy and adenoidectomy
+        or tonsillectomy and adenoidectomy, and bilateral myringotomy with tube insertion
+        under general anesthesia. The primary outcome measure was the time spent in
+        the PACU until predetermined discharge criteria were met.&lt;/p>&lt;p>RESULTS:
+        The number of episodes of postoperative nausea and vomiting, patient age,
+        and number of oxygen desaturations contributed significantly (P &amp;lt; 0.05)
+        to prolonged LOS. Each episode of postoperative nausea and vomiting (P &amp;lt;
+        0.05) or oxygen desaturation to &amp;lt; 95% (P &amp;lt; 0.05) increased the
+        patient&amp;apos;s LOS by 0.5 h. History of upper respiratory tract infection,
+        emergence agitation, and parental anxiety did not significantly predict increased
+        LOS.&lt;/p>&lt;p>CONCLUSION: This investigation is the first composite view
+        of LOS in pediatric patients. The significance of identifying patients at
+        risk of prolonged LOS prior to anesthesia is of use not only in allocating
+        PACU resource and staffing needs, but also for improving quality of care and
+        ensuring a minimally traumatic anesthetic experience for our pediatric patients
+        and their families.&lt;/p>&lt;/abstract_text>&lt;/abstract>&lt;/abstracts>&lt;/fullrecord_metadata>&lt;item
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="itemType_wos"
+        coll_id="WOS">&lt;ids avail="Y">152OS&lt;/ids>&lt;bib_id>104 (4): 784-789
+        APR 2007&lt;/bib_id>&lt;keywords_plus count="10">&lt;keyword>RISK-FACTORS&lt;/keyword>&lt;keyword>CHILDREN&lt;/keyword>&lt;keyword>ADENOTONSILLECTOMY&lt;/keyword>&lt;keyword>SURGERY&lt;/keyword>&lt;keyword>STAY&lt;/keyword>&lt;keyword>CARE&lt;/keyword>&lt;keyword>COMPLICATIONS&lt;/keyword>&lt;keyword>DEXAMETHASONE&lt;/keyword>&lt;keyword>ANESTHESIA&lt;/keyword>&lt;keyword>ADMISSION&lt;/keyword>&lt;/keywords_plus>&lt;/item>&lt;contributors
+        count="1">&lt;contributor>&lt;name seq_no="1" role="researcher_id" orcid_id="0000-0003-2735-248X">&lt;display_name>Mariano,
+        Edward&lt;/display_name>&lt;full_name>Mariano, Edward&lt;/full_name>&lt;first_name>Edward&lt;/first_name>&lt;last_name>Mariano&lt;/last_name>&lt;/name>&lt;/contributor>&lt;/contributors>&lt;/static_data>&lt;dynamic_data>&lt;citation_related>&lt;tc_list>&lt;silo_tc
+        coll_id="WOS" local_count="29">&lt;/silo_tc>&lt;/tc_list>&lt;/citation_related>&lt;cluster_related>&lt;identifiers>&lt;identifier
+        type="issn" value="0003-2999">&lt;/identifier>&lt;identifier type="doi" value="10.1213/01.ane.0000258771.53068.09">&lt;/identifier>&lt;identifier
+        type="xref_doi" value="10.1213/01.ane.0000258771.53068.09">&lt;/identifier>&lt;/identifiers>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000236198500001&lt;/UID>&lt;static_data>&lt;summary>&lt;EWUID>&lt;WUID
+        coll_id="WOS">&lt;/WUID>&lt;edition value="WOS.SCI">&lt;/edition>&lt;/EWUID>&lt;pub_info
+        sortdate="2006-02-01" pubyear="2006" has_abstract="Y" coverdate="FEB 2006"
+        pubmonth="FEB" vol="18" issue="1" pubtype="Journal">&lt;page begin="1" end="4"
+        page_count="4">1-4&lt;/page>&lt;/pub_info>&lt;titles count="6">&lt;title type="source">JOURNAL
+        OF CLINICAL ANESTHESIA&lt;/title>&lt;title type="source_abbrev">J CLIN ANESTH&lt;/title>&lt;title
+        type="abbrev_iso">J. Clin. Anesth.&lt;/title>&lt;title type="abbrev_11">J
+        CLIN ANES&lt;/title>&lt;title type="abbrev_29">J CLIN ANESTH&lt;/title>&lt;title
+        type="item">Avian flu (H5N1): its epidemiology, prevention, and implications
+        for anesthesiology&lt;/title>&lt;/titles>&lt;names count="1">&lt;name seq_no="1"
+        role="author" reprint="Y" daisng_id="2533299">&lt;display_name>Edler, AA&lt;/display_name>&lt;full_name>Edler,
+        AA&lt;/full_name>&lt;wos_standard>Edler, AA&lt;/wos_standard>&lt;first_name>AA&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;email_addr>edlera@aol.com&lt;/email_addr>&lt;/name>&lt;/names>&lt;doctypes
+        count="1">&lt;doctype>Article&lt;/doctype>&lt;/doctypes>&lt;publishers>&lt;publisher>&lt;address_spec
+        addr_no="1">&lt;full_address>360 PARK AVE SOUTH, NEW YORK, NY 10010-1710 USA&lt;/full_address>&lt;city>NEW
+        YORK&lt;/city>&lt;/address_spec>&lt;names count="1">&lt;name role="publisher"
+        seq_no="1" addr_no="1">&lt;display_name>ELSEVIER SCIENCE INC&lt;/display_name>&lt;full_name>ELSEVIER
+        SCIENCE INC&lt;/full_name>&lt;/name>&lt;/names>&lt;/publisher>&lt;/publishers>&lt;/summary>&lt;fullrecord_metadata>&lt;languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/languages>&lt;normalized_languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/normalized_languages>&lt;normalized_doctypes
+        count="1">&lt;doctype>Article&lt;/doctype>&lt;/normalized_doctypes>&lt;refs
+        count="12">&lt;/refs>&lt;addresses count="1">&lt;address_name>&lt;address_spec
+        addr_no="1">&lt;full_address>Stanford Univ, Ctr Med, Dept Anesthesia, Stanford,
+        CA 94305 USA&lt;/full_address>&lt;organizations count="2">&lt;organization>Stanford
+        Univ&lt;/organization>&lt;organization pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="2">&lt;suborganization>Ctr Med&lt;/suborganization>&lt;suborganization>Dept
+        Anesthesia&lt;/suborganization>&lt;/suborganizations>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;/address_name>&lt;/addresses>&lt;reprint_addresses
+        count="1">&lt;address_name>&lt;address_spec addr_no="1">&lt;full_address>Stanford
+        Univ, Ctr Med, Dept Anesthesia, Stanford, CA 94305 USA&lt;/full_address>&lt;organizations
+        count="2">&lt;organization>Stanford Univ&lt;/organization>&lt;organization
+        pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="2">&lt;suborganization>Ctr Med&lt;/suborganization>&lt;suborganization>Dept
+        Anesthesia&lt;/suborganization>&lt;/suborganizations>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;names count="1">&lt;name
+        seq_no="1" role="author" reprint="Y">&lt;display_name>Edler, AA&lt;/display_name>&lt;full_name>Edler,
+        AA&lt;/full_name>&lt;wos_standard>Edler, AA&lt;/wos_standard>&lt;first_name>AA&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;/name>&lt;/names>&lt;/address_name>&lt;/reprint_addresses>&lt;category_info>&lt;headings
+        count="1">&lt;heading>Science &amp;amp; Technology&lt;/heading>&lt;/headings>&lt;subheadings
+        count="1">&lt;subheading>Life Sciences &amp;amp; Biomedicine&lt;/subheading>&lt;/subheadings>&lt;subjects
+        count="2">&lt;subject ascatype="traditional" code="BA">Anesthesiology&lt;/subject>&lt;subject
+        ascatype="extended">Anesthesiology&lt;/subject>&lt;/subjects>&lt;/category_info>&lt;keywords
+        count="5">&lt;keyword>communicable diseases, emerging&lt;/keyword>&lt;keyword>disease
+        notification&lt;/keyword>&lt;keyword>disease outbreaks&lt;/keyword>&lt;keyword>disease
+        transmission&lt;/keyword>&lt;keyword>influenza, avian&lt;/keyword>&lt;/keywords>&lt;abstracts
+        count="1">&lt;abstract>&lt;abstract_text count="1">&lt;p>Avian flu, influenza
+        A subtype H5N1, is an emergent and virulent disease that poses a threat to,
+        Emerging; the health and safety of the world community. Avian flu is I of
+        more than 25 influenza A viruses that reside Disease notification; primarily
+        in birds but also infect humans and other mammals. Avian flu is responsible
+        for the current Disease outbreaks; outbreak in Asia; H5N1 has now displayed
+        probable human-to-human transmission; it could be a Disease transmission;
+        harbinger of a global epidemic. Anesthesiologists are exposed to a risk for
+        infection when they are influenza involved in airway instrurnentation of infected
+        patients. Given tile evidence of emerging resistance to, Avian common antiviral
+        agents used to treat H5N1 influenza virus and limited supply of H5N1 vaccine,
+        prevention is our best protection. The following article will detail the virology
+        and preventive public health practices for H5N1. This knowledge can also be
+        used to define and prevent other yet unidentified infectious threats. (c)
+        2006 Elsevier Inc. All rights reserved.&lt;/p>&lt;/abstract_text>&lt;/abstract>&lt;/abstracts>&lt;/fullrecord_metadata>&lt;item
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="itemType_wos"
+        coll_id="WOS">&lt;ids avail="N">024MG&lt;/ids>&lt;bib_id>18 (1): 1-4 FEB 2006&lt;/bib_id>&lt;bib_pagecount
+        type="Journal">92&lt;/bib_pagecount>&lt;keywords_plus count="4">&lt;keyword>INFLUENZA-A
+        H5N1&lt;/keyword>&lt;keyword>TRANSMISSION&lt;/keyword>&lt;keyword>OUTBREAK&lt;/keyword>&lt;keyword>TORONTO&lt;/keyword>&lt;/keywords_plus>&lt;/item>&lt;/static_data>&lt;dynamic_data>&lt;citation_related>&lt;tc_list>&lt;silo_tc
+        coll_id="WOS" local_count="4">&lt;/silo_tc>&lt;/tc_list>&lt;/citation_related>&lt;cluster_related>&lt;identifiers>&lt;identifier
+        type="issn" value="0952-8180">&lt;/identifier>&lt;identifier type="eissn"
+        value="1873-4529">&lt;/identifier>&lt;identifier type="doi" value="10.1016/j.jclinane.2005.12.004">&lt;/identifier>&lt;identifier
+        type="xref_doi" value="10.1016/j.jclinane.2005.12.004">&lt;/identifier>&lt;/identifiers>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000212958400021&lt;/UID>&lt;static_data>&lt;summary>&lt;EWUID>&lt;WUID
+        coll_id="WOS">&lt;/WUID>&lt;edition value="WOS.ESCI">&lt;/edition>&lt;/EWUID>&lt;pub_info
+        sortdate="2009-06-01" pubyear="2009" has_abstract="N" coverdate="JUN 2009"
+        pubmonth="JUN" vol="6" issue="2" pubtype="Journal">&lt;page begin="139" end="140"
+        page_count="2">139-140&lt;/page>&lt;/pub_info>&lt;titles count="6">&lt;title
+        type="source">CLINICAL TEACHER&lt;/title>&lt;title type="source_abbrev">CLIN
+        TEACH&lt;/title>&lt;title type="abbrev_iso">Clin. Teach.&lt;/title>&lt;title
+        type="abbrev_11">CLIN TEACH&lt;/title>&lt;title type="abbrev_29">CLIN TEACH&lt;/title>&lt;title
+        type="item">Action research in medical education: a shifting paradigm or old
+        wine in new skins?&lt;/title>&lt;/titles>&lt;names count="1">&lt;name seq_no="1"
+        role="author" reprint="Y" addr_no="1" daisng_id="2533299">&lt;display_name>Edler,
+        Alice&lt;/display_name>&lt;full_name>Edler, Alice&lt;/full_name>&lt;wos_standard>Edler,
+        A&lt;/wos_standard>&lt;first_name>Alice&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;/name>&lt;/names>&lt;doctypes
+        count="1">&lt;doctype>Letter&lt;/doctype>&lt;/doctypes>&lt;publishers>&lt;publisher>&lt;address_spec
+        addr_no="1">&lt;full_address>111 RIVER ST, HOBOKEN 07030-5774, NJ USA&lt;/full_address>&lt;city>HOBOKEN&lt;/city>&lt;/address_spec>&lt;names
+        count="1">&lt;name role="publisher" seq_no="1" addr_no="1">&lt;display_name>WILEY&lt;/display_name>&lt;full_name>WILEY&lt;/full_name>&lt;/name>&lt;/names>&lt;/publisher>&lt;/publishers>&lt;/summary>&lt;fullrecord_metadata>&lt;languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/languages>&lt;normalized_languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/normalized_languages>&lt;normalized_doctypes
+        count="1">&lt;doctype>Letter&lt;/doctype>&lt;/normalized_doctypes>&lt;refs
+        count="6">&lt;/refs>&lt;addresses count="1">&lt;address_name>&lt;address_spec
+        addr_no="1">&lt;full_address>Stanford Univ, Dept Grad Med Educ, Stanford,
+        CA 94305 USA&lt;/full_address>&lt;organizations count="2">&lt;organization>Stanford
+        Univ&lt;/organization>&lt;organization pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="1">&lt;suborganization>Dept Grad Med Educ&lt;/suborganization>&lt;/suborganizations>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;names count="1">&lt;name
+        seq_no="1" role="author" reprint="Y" addr_no="1" daisng_id="2533299">&lt;display_name>Edler,
+        Alice&lt;/display_name>&lt;full_name>Edler, Alice&lt;/full_name>&lt;wos_standard>Edler,
+        A&lt;/wos_standard>&lt;first_name>Alice&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;/name>&lt;/names>&lt;/address_name>&lt;/addresses>&lt;reprint_addresses
+        count="1">&lt;address_name>&lt;address_spec addr_no="1">&lt;full_address>Stanford
+        Univ, Dept Grad Med Educ, Stanford, CA 94305 USA&lt;/full_address>&lt;organizations
+        count="2">&lt;organization>Stanford Univ&lt;/organization>&lt;organization
+        pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="1">&lt;suborganization>Dept Grad Med Educ&lt;/suborganization>&lt;/suborganizations>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;names count="1">&lt;name
+        seq_no="1" role="author" reprint="Y" addr_no="1">&lt;display_name>Edler, Alice&lt;/display_name>&lt;full_name>Edler,
+        Alice&lt;/full_name>&lt;wos_standard>Edler, A&lt;/wos_standard>&lt;first_name>Alice&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;/name>&lt;/names>&lt;/address_name>&lt;/reprint_addresses>&lt;category_info>&lt;headings
+        count="1">&lt;heading>Science &amp;amp; Technology&lt;/heading>&lt;/headings>&lt;subheadings
+        count="1">&lt;subheading>Life Sciences &amp;amp; Biomedicine&lt;/subheading>&lt;/subheadings>&lt;subjects
+        count="2">&lt;subject ascatype="traditional" code="QA">Medicine, Research
+        &amp;amp; Experimental&lt;/subject>&lt;subject ascatype="extended">Research
+        &amp;amp; Experimental Medicine&lt;/subject>&lt;/subjects>&lt;/category_info>&lt;/fullrecord_metadata>&lt;item
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="itemType_wos"
+        coll_id="WOS">&lt;ids avail="Y">V91XH&lt;/ids>&lt;bib_id>6 (2): 139-140 JUN
+        2009&lt;/bib_id>&lt;bib_pagecount type="Journal">84&lt;/bib_pagecount>&lt;/item>&lt;/static_data>&lt;dynamic_data>&lt;citation_related>&lt;tc_list>&lt;silo_tc
+        coll_id="WOS" local_count="1">&lt;/silo_tc>&lt;/tc_list>&lt;/citation_related>&lt;cluster_related>&lt;identifiers>&lt;identifier
+        type="issn" value="1743-4971">&lt;/identifier>&lt;identifier type="eissn"
+        value="1743-498X">&lt;/identifier>&lt;identifier type="doi" value="10.1111/j.1743-498X.2009.00271.x">&lt;/identifier>&lt;/identifiers>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000186655000011&lt;/UID>&lt;static_data>&lt;summary>&lt;EWUID>&lt;WUID
+        coll_id="WOS">&lt;/WUID>&lt;edition value="WOS.SCI">&lt;/edition>&lt;/EWUID>&lt;pub_info
+        sortdate="2003-11-01" pubyear="2003" has_abstract="Y" coverdate="NOV 2003"
+        pubmonth="NOV" vol="13" issue="9" pubtype="Journal">&lt;page begin="818" end="822"
+        page_count="5">818-822&lt;/page>&lt;/pub_info>&lt;titles count="6">&lt;title
+        type="source">PAEDIATRIC ANAESTHESIA&lt;/title>&lt;title type="source_abbrev">PAEDIATR
+        ANAESTH&lt;/title>&lt;title type="abbrev_iso">Paediatr. Anaesth.&lt;/title>&lt;title
+        type="abbrev_11">PAEDIATR AN&lt;/title>&lt;title type="abbrev_29">PAEDIATR
+        ANAESTH&lt;/title>&lt;title type="item">Blood loss during posterior spinal
+        fusion surgery in patients with neuromuscular disease: is there an increased
+        risk?&lt;/title>&lt;/titles>&lt;names count="3">&lt;name seq_no="1" role="author"
+        reprint="Y" daisng_id="468355">&lt;display_name>Edler, A&lt;/display_name>&lt;full_name>Edler,
+        A&lt;/full_name>&lt;wos_standard>Edler, A&lt;/wos_standard>&lt;first_name>A&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;/name>&lt;name
+        seq_no="2" role="author" daisng_id="202348">&lt;display_name>Murray, DJ&lt;/display_name>&lt;full_name>Murray,
+        DJ&lt;/full_name>&lt;wos_standard>Murray, DJ&lt;/wos_standard>&lt;first_name>DJ&lt;/first_name>&lt;last_name>Murray&lt;/last_name>&lt;/name>&lt;name
+        seq_no="3" role="author" daisng_id="131889">&lt;display_name>Forbes, RB&lt;/display_name>&lt;full_name>Forbes,
+        RB&lt;/full_name>&lt;wos_standard>Forbes, RB&lt;/wos_standard>&lt;first_name>RB&lt;/first_name>&lt;last_name>Forbes&lt;/last_name>&lt;/name>&lt;/names>&lt;doctypes
+        count="1">&lt;doctype>Article&lt;/doctype>&lt;/doctypes>&lt;publishers>&lt;publisher>&lt;address_spec
+        addr_no="1">&lt;full_address>9600 GARSINGTON RD, OXFORD OX4 2DG, OXON, ENGLAND&lt;/full_address>&lt;city>OXFORD&lt;/city>&lt;/address_spec>&lt;names
+        count="1">&lt;name role="publisher" seq_no="1" addr_no="1">&lt;display_name>BLACKWELL
+        PUBLISHING LTD&lt;/display_name>&lt;full_name>BLACKWELL PUBLISHING LTD&lt;/full_name>&lt;/name>&lt;/names>&lt;/publisher>&lt;/publishers>&lt;/summary>&lt;fullrecord_metadata>&lt;languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/languages>&lt;normalized_languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/normalized_languages>&lt;normalized_doctypes
+        count="1">&lt;doctype>Article&lt;/doctype>&lt;/normalized_doctypes>&lt;refs
+        count="10">&lt;/refs>&lt;addresses count="3">&lt;address_name>&lt;address_spec
+        addr_no="1">&lt;full_address>Stanford Univ, Sch Med, Dept Anesthesiol, Stanford,
+        CA 94305 USA&lt;/full_address>&lt;organizations count="2">&lt;organization>Stanford
+        Univ&lt;/organization>&lt;organization pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="2">&lt;suborganization>Sch Med&lt;/suborganization>&lt;suborganization>Dept
+        Anesthesiol&lt;/suborganization>&lt;/suborganizations>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;/address_name>&lt;address_name>&lt;address_spec
+        addr_no="2">&lt;full_address>Washington Univ, St Louis Childrens Hosp, Sch
+        Med, St Louis, MO 63110 USA&lt;/full_address>&lt;organizations count="3">&lt;organization>Washington
+        Univ&lt;/organization>&lt;organization pref="Y">St. Louis Children&amp;apos;s
+        Hospital&lt;/organization>&lt;organization pref="Y">Washington University
+        (WUSTL)&lt;/organization>&lt;/organizations>&lt;suborganizations count="2">&lt;suborganization>St
+        Louis Childrens Hosp&lt;/suborganization>&lt;suborganization>Sch Med&lt;/suborganization>&lt;/suborganizations>&lt;city>St
+        Louis&lt;/city>&lt;state>MO&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">63110&lt;/zip>&lt;/address_spec>&lt;/address_name>&lt;address_name>&lt;address_spec
+        addr_no="3">&lt;full_address>Univ Iowa, Coll Med, Dept Anesthesiol, Iowa City,
+        IA 52242 USA&lt;/full_address>&lt;organizations count="2">&lt;organization>Univ
+        Iowa&lt;/organization>&lt;organization pref="Y">University of Iowa&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="2">&lt;suborganization>Coll Med&lt;/suborganization>&lt;suborganization>Dept
+        Anesthesiol&lt;/suborganization>&lt;/suborganizations>&lt;city>Iowa City&lt;/city>&lt;state>IA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">52242&lt;/zip>&lt;/address_spec>&lt;/address_name>&lt;/addresses>&lt;reprint_addresses
+        count="1">&lt;address_name>&lt;address_spec addr_no="1">&lt;full_address>Stanford
+        Univ, Sch Med, Dept Anesthesiol, 300 Pasteur Dr,Room 3580, Stanford, CA 94305
+        USA&lt;/full_address>&lt;organizations count="2">&lt;organization>Stanford
+        Univ&lt;/organization>&lt;organization pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="2">&lt;suborganization>Sch Med&lt;/suborganization>&lt;suborganization>Dept
+        Anesthesiol&lt;/suborganization>&lt;/suborganizations>&lt;street>300 Pasteur
+        Dr,Room 3580&lt;/street>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;names count="1">&lt;name
+        seq_no="1" role="author" reprint="Y" addr_no="1" display="N">&lt;display_name>Edler,
+        A&lt;/display_name>&lt;full_name>Edler, A&lt;/full_name>&lt;wos_standard>Edler,
+        A&lt;/wos_standard>&lt;first_name>A&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;/name>&lt;/names>&lt;/address_name>&lt;/reprint_addresses>&lt;category_info>&lt;headings
+        count="1">&lt;heading>Science &amp;amp; Technology&lt;/heading>&lt;/headings>&lt;subheadings
+        count="1">&lt;subheading>Life Sciences &amp;amp; Biomedicine&lt;/subheading>&lt;/subheadings>&lt;subjects
+        count="4">&lt;subject ascatype="traditional" code="BA">Anesthesiology&lt;/subject>&lt;subject
+        ascatype="traditional" code="TQ">Pediatrics&lt;/subject>&lt;subject ascatype="extended">Anesthesiology&lt;/subject>&lt;subject
+        ascatype="extended">Pediatrics&lt;/subject>&lt;/subjects>&lt;/category_info>&lt;keywords
+        count="4">&lt;keyword>scoliosis surgery&lt;/keyword>&lt;keyword>spinal fusion&lt;/keyword>&lt;keyword>blood
+        loss&lt;/keyword>&lt;keyword>neuromuscular disease&lt;/keyword>&lt;/keywords>&lt;abstracts
+        count="1">&lt;abstract>&lt;abstract_text count="4">&lt;p>Background: Scoliosis
+        surgery in paediatric patients can carry significant morbidity associated
+        with intraoperative blood loss and the resultant transfusion therapy. Patients
+        with neuromuscular disease may be at an increased risk for this intraoperative
+        blood loss, but it is unclear if this is because of direct vascular pathophysiological
+        changes or the fact that neuromuscular patients typically have more extensive
+        orthopaedic disease and more vertebral segments involved. This study examined
+        the risk of extensive blood loss (&amp;gt;50% of total blood volume) in patients
+        with neuromuscular disease compared with patients who did not have neuromuscular
+        disease when the extent of the surgery (number of segments fused), age and
+        preoperative coagulation profile where taken into consideration.&lt;/p>&lt;p>Methods:
+        Retrospective chart review of 163 paediatric patients was preformed. Patients
+        who carried a diagnosis of preexisting neuromuscular disease were classified
+        as such. Idiopathic, traumatic and iatrogenic scoliosis were classified as
+        nonneuromuscular. Extensive blood loss was defined as &amp;gt;50% of estimated
+        total blood volume. Logistic regression was used to predict the risk of extensive
+        blood loss between the two groups when age, weight, extent of surgery was
+        controlled for and anaesthetic and surgical techniques remained similar.&lt;/p>&lt;p>Results:
+        Patients with neuromuscular disease did not vary significantly in age, weight,
+        or preoperative haematocrit and platelet count from patients without neuromuscular
+        disease. Neuromuscular patients did have significantly more vertebral segments
+        fused. When this difference was controlled for statistically, neuromuscular
+        patients had an almost seven times higher risk (adjusted odds ration 6.9,
+        P &amp;lt; 0.05) of losing &amp;gt;50% of their estimated total blood volume
+        during scoliosis surgery.&lt;/p>&lt;p>Conclusions: Patients with neuromuscular
+        disease can present various anaesthetic challenges during scoliosis surgery,
+        among these is the inherent risk of extensive blood loss. Recognizing this
+        may help anaesthesiologists and surgeons more accurately prepare for and treat
+        intraoperative blood loss during scoliosis surgery in patients with neuromuscular
+        disease.&lt;/p>&lt;/abstract_text>&lt;/abstract>&lt;/abstracts>&lt;/fullrecord_metadata>&lt;item
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="itemType_wos"
+        coll_id="WOS">&lt;ids avail="Y">744WC&lt;/ids>&lt;bib_id>13 (9): 818-822 NOV
+        2003&lt;/bib_id>&lt;keywords_plus count="2">&lt;keyword>DUCHENNE MUSCULAR-DYSTROPHY&lt;/keyword>&lt;keyword>DYSFUNCTION&lt;/keyword>&lt;/keywords_plus>&lt;/item>&lt;contributors
+        count="2">&lt;contributor>&lt;name seq_no="1" role="researcher_id" orcid_id="0000-0001-6264-3210">&lt;display_name>Murray,
+        David&lt;/display_name>&lt;full_name>Murray, David&lt;/full_name>&lt;first_name>David&lt;/first_name>&lt;last_name>Murray&lt;/last_name>&lt;/name>&lt;/contributor>&lt;contributor>&lt;name
+        seq_no="2" role="researcher_id" orcid_id="0000-0002-1444-7909">&lt;display_name>Forbes,
+        Raeburn&lt;/display_name>&lt;full_name>Forbes, Raeburn&lt;/full_name>&lt;first_name>Raeburn&lt;/first_name>&lt;last_name>Forbes&lt;/last_name>&lt;/name>&lt;/contributor>&lt;/contributors>&lt;/static_data>&lt;dynamic_data>&lt;citation_related>&lt;tc_list>&lt;silo_tc
+        coll_id="WOS" local_count="51">&lt;/silo_tc>&lt;/tc_list>&lt;/citation_related>&lt;cluster_related>&lt;identifiers>&lt;identifier
+        type="issn" value="1155-5645">&lt;/identifier>&lt;identifier type="xref_doi"
+        value="10.1046/j.1460-9592.2003.01171.x">&lt;/identifier>&lt;/identifiers>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000212962700007&lt;/UID>&lt;static_data>&lt;summary>&lt;EWUID>&lt;WUID
+        coll_id="WOS">&lt;/WUID>&lt;edition value="WOS.ESCI">&lt;/edition>&lt;/EWUID>&lt;pub_info
+        sortdate="2010-03-01" pubyear="2010" has_abstract="Y" coverdate="MAR 2010"
+        pubmonth="MAR" vol="7" issue="1" pubtype="Journal">&lt;page begin="26" end="31"
+        page_count="6">26-31&lt;/page>&lt;/pub_info>&lt;titles count="6">&lt;title
+        type="source">CLINICAL TEACHER&lt;/title>&lt;title type="source_abbrev">CLIN
+        TEACH&lt;/title>&lt;title type="abbrev_iso">Clin. Teach.&lt;/title>&lt;title
+        type="abbrev_11">CLIN TEACH&lt;/title>&lt;title type="abbrev_29">CLIN TEACH&lt;/title>&lt;title
+        type="item">Leadership lessons from military education for postgraduate medical
+        curricular improvement&lt;/title>&lt;/titles>&lt;names count="4">&lt;name
+        seq_no="1" role="author" reprint="Y" addr_no="1" daisng_id="2533299">&lt;display_name>Edler,
+        Alice&lt;/display_name>&lt;full_name>Edler, Alice&lt;/full_name>&lt;wos_standard>Edler,
+        A&lt;/wos_standard>&lt;first_name>Alice&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;email_addr>edlera@aaol.com&lt;/email_addr>&lt;/name>&lt;name
+        seq_no="2" role="author" addr_no="1" daisng_id="25896451">&lt;display_name>Adamshick,
+        Mark&lt;/display_name>&lt;full_name>Adamshick, Mark&lt;/full_name>&lt;wos_standard>Adamshick,
+        M&lt;/wos_standard>&lt;first_name>Mark&lt;/first_name>&lt;last_name>Adamshick&lt;/last_name>&lt;/name>&lt;name
+        seq_no="3" role="author" addr_no="1" daisng_id="5648207">&lt;display_name>Fanning,
+        Ruth&lt;/display_name>&lt;full_name>Fanning, Ruth&lt;/full_name>&lt;wos_standard>Fanning,
+        R&lt;/wos_standard>&lt;first_name>Ruth&lt;/first_name>&lt;last_name>Fanning&lt;/last_name>&lt;/name>&lt;name
+        seq_no="4" role="author" addr_no="1" daisng_id="10229781">&lt;display_name>Piro,
+        Nancy&lt;/display_name>&lt;full_name>Piro, Nancy&lt;/full_name>&lt;wos_standard>Piro,
+        N&lt;/wos_standard>&lt;first_name>Nancy&lt;/first_name>&lt;last_name>Piro&lt;/last_name>&lt;/name>&lt;/names>&lt;doctypes
+        count="1">&lt;doctype>Article&lt;/doctype>&lt;/doctypes>&lt;publishers>&lt;publisher>&lt;address_spec
+        addr_no="1">&lt;full_address>111 RIVER ST, HOBOKEN 07030-5774, NJ USA&lt;/full_address>&lt;city>HOBOKEN&lt;/city>&lt;/address_spec>&lt;names
+        count="1">&lt;name role="publisher" seq_no="1" addr_no="1">&lt;display_name>WILEY&lt;/display_name>&lt;full_name>WILEY&lt;/full_name>&lt;/name>&lt;/names>&lt;/publisher>&lt;/publishers>&lt;/summary>&lt;fullrecord_metadata>&lt;languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/languages>&lt;normalized_languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/normalized_languages>&lt;normalized_doctypes
+        count="1">&lt;doctype>Article&lt;/doctype>&lt;/normalized_doctypes>&lt;refs
+        count="26">&lt;/refs>&lt;addresses count="1">&lt;address_name>&lt;address_spec
+        addr_no="1">&lt;full_address>Stanford Univ, Stanford Hosp &amp;amp; Clin,
+        Sch Med, US Naval Acad, Stanford, CA 94305 USA&lt;/full_address>&lt;organizations
+        count="5">&lt;organization>Stanford Univ&lt;/organization>&lt;organization
+        pref="Y">Stanford University&lt;/organization>&lt;organization pref="Y">United
+        States Naval Academy&lt;/organization>&lt;organization pref="Y">United States
+        Department of Defense&lt;/organization>&lt;organization pref="Y">United States
+        Navy&lt;/organization>&lt;/organizations>&lt;suborganizations count="3">&lt;suborganization>Stanford
+        Hosp &amp;amp; Clin&lt;/suborganization>&lt;suborganization>Sch Med&lt;/suborganization>&lt;suborganization>US
+        Naval Acad&lt;/suborganization>&lt;/suborganizations>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;names count="4">&lt;name
+        seq_no="1" role="author" reprint="Y" addr_no="1" daisng_id="2533299">&lt;display_name>Edler,
+        Alice&lt;/display_name>&lt;full_name>Edler, Alice&lt;/full_name>&lt;wos_standard>Edler,
+        A&lt;/wos_standard>&lt;first_name>Alice&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;email_addr>edlera@aaol.com&lt;/email_addr>&lt;/name>&lt;name
+        seq_no="2" role="author" addr_no="1" daisng_id="25896451">&lt;display_name>Adamshick,
+        Mark&lt;/display_name>&lt;full_name>Adamshick, Mark&lt;/full_name>&lt;wos_standard>Adamshick,
+        M&lt;/wos_standard>&lt;first_name>Mark&lt;/first_name>&lt;last_name>Adamshick&lt;/last_name>&lt;/name>&lt;name
+        seq_no="3" role="author" addr_no="1" daisng_id="5648207">&lt;display_name>Fanning,
+        Ruth&lt;/display_name>&lt;full_name>Fanning, Ruth&lt;/full_name>&lt;wos_standard>Fanning,
+        R&lt;/wos_standard>&lt;first_name>Ruth&lt;/first_name>&lt;last_name>Fanning&lt;/last_name>&lt;/name>&lt;name
+        seq_no="4" role="author" addr_no="1" daisng_id="10229781">&lt;display_name>Piro,
+        Nancy&lt;/display_name>&lt;full_name>Piro, Nancy&lt;/full_name>&lt;wos_standard>Piro,
+        N&lt;/wos_standard>&lt;first_name>Nancy&lt;/first_name>&lt;last_name>Piro&lt;/last_name>&lt;/name>&lt;/names>&lt;/address_name>&lt;/addresses>&lt;reprint_addresses
+        count="1">&lt;address_name>&lt;address_spec addr_no="1">&lt;full_address>Dept
+        Grad Med Educ, 300 Pasteur Rm HC435, Stanford, CA 94305 USA&lt;/full_address>&lt;organizations
+        count="1">&lt;organization>Dept Grad Med Educ&lt;/organization>&lt;/organizations>&lt;street>300
+        Pasteur Rm HC435&lt;/street>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;names count="1">&lt;name
+        seq_no="1" role="author" reprint="Y" addr_no="1">&lt;display_name>Edler, Alice&lt;/display_name>&lt;full_name>Edler,
+        Alice&lt;/full_name>&lt;wos_standard>Edler, A&lt;/wos_standard>&lt;first_name>Alice&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;email_addr>edlera@aaol.com&lt;/email_addr>&lt;/name>&lt;/names>&lt;/address_name>&lt;/reprint_addresses>&lt;category_info>&lt;headings
+        count="1">&lt;heading>Science &amp;amp; Technology&lt;/heading>&lt;/headings>&lt;subheadings
+        count="1">&lt;subheading>Life Sciences &amp;amp; Biomedicine&lt;/subheading>&lt;/subheadings>&lt;subjects
+        count="2">&lt;subject ascatype="traditional" code="QA">Medicine, Research
+        &amp;amp; Experimental&lt;/subject>&lt;subject ascatype="extended">Research
+        &amp;amp; Experimental Medicine&lt;/subject>&lt;/subjects>&lt;/category_info>&lt;abstracts
+        count="1">&lt;abstract>&lt;abstract_text count="4">&lt;p>Background: Quality
+        medical education includes both teaching and learning of data-driven knowledge,
+        and appropriate technical skills and tacit behaviours, such as effective communication
+        and professional leadership. But these implicit behaviours are not readily
+        adaptable to traditional medical curriculum models. This manuscript explores
+        a medical leadership curriculum informed by military education.&lt;/p>&lt;p>Context:
+        Our paediatric anaesthesia residents expressed a strong desire for more leadership
+        opportunity within the training programme. Upon exploration, current health
+        care models for leadership training were limited to short didactic presentations
+        or lengthy certificate programmes. We could not find an appropriate model
+        for our 1-year fellowship.&lt;/p>&lt;p>Innovation: In collaboration with the
+        US Naval Academy, we modified the &amp;apos;Leadership Education and Development
+        Program&amp;apos; curriculum to introduce daily and graduated leadership opportunities:
+        starting with low-risk decision-making tasks and progressing to independent
+        professional decision making and leadership. Each resident who opted into
+        the programme had a 3-month role as team leader and spent 9 months as a team
+        member. At the end of the first year of this curriculum both quantitative
+        assessment and qualitative reflection from residents and faculty members noted
+        significantly improved clinical and administrative decision making. The second-year
+        residents&amp;apos; performance showed further improvement.&lt;/p>&lt;p>Implications:
+        Medical education has long emphasised subjectmatter knowledge as a prime focus.
+        However, in competencybased medical education, new curriculum models are needed.
+        Many helpful models can be found in other professional fields. Collaborations
+        between professional educators benefit the students, who are learning these
+        new skills, the medical educators, who work jointly with other professionals,
+        and the original curriculum designer, who has an opportunity to reflect on
+        the strengths and weaknesses of his or her model.&lt;/p>&lt;/abstract_text>&lt;/abstract>&lt;/abstracts>&lt;/fullrecord_metadata>&lt;item
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="itemType_wos"
+        coll_id="WOS">&lt;ids avail="Y">V91YY&lt;/ids>&lt;bib_id>7 (1): 26-31 MAR
+        2010&lt;/bib_id>&lt;bib_pagecount type="Journal">79&lt;/bib_pagecount>&lt;/item>&lt;/static_data>&lt;dynamic_data>&lt;citation_related>&lt;tc_list>&lt;silo_tc
+        coll_id="WOS" local_count="8">&lt;/silo_tc>&lt;/tc_list>&lt;/citation_related>&lt;cluster_related>&lt;identifiers>&lt;identifier
+        type="issn" value="1743-4971">&lt;/identifier>&lt;identifier type="eissn"
+        value="1743-498X">&lt;/identifier>&lt;identifier type="doi" value="10.1111/j.1743-498X.2009.00336.x/full">&lt;/identifier>&lt;/identifiers>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics"&gt;&lt;UID>WOS:000218296900007&lt;/UID>&lt;static_data>&lt;summary>&lt;EWUID>&lt;WUID
+        coll_id="WOS">&lt;/WUID>&lt;edition value="WOS.ESCI">&lt;/edition>&lt;/EWUID>&lt;pub_info
+        sortdate="2010-03-01" pubyear="2010" has_abstract="N" coverdate="SPR 2010"
+        pubmonth="SPR" vol="48" issue="2" pubtype="Journal">&lt;page begin="59" end="69"
+        page_count="11">59-69&lt;/page>&lt;/pub_info>&lt;titles count="6">&lt;title
+        type="source">INTERNATIONAL ANESTHESIOLOGY CLINICS&lt;/title>&lt;title type="source_abbrev">INT
+        ANESTHESIOL CLIN&lt;/title>&lt;title type="abbrev_iso">Int. Anesthesiol. Clin.&lt;/title>&lt;title
+        type="abbrev_11">INT ANESTH&lt;/title>&lt;title type="abbrev_29">INT ANESTHESIOL
+        CLIN&lt;/title>&lt;title type="item">Teaching NonPhysician Anesthesia Providers
+        in Tanzania: A Movement Toward Sustainable Healthcare Development&lt;/title>&lt;/titles>&lt;names
+        count="2">&lt;name seq_no="1" role="author" reprint="Y" addr_no="1" daisng_id="2533299">&lt;display_name>Edler,
+        Alice A.&lt;/display_name>&lt;full_name>Edler, Alice A.&lt;/full_name>&lt;wos_standard>Edler,
+        AA&lt;/wos_standard>&lt;first_name>Alice A.&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;email_addr>Edlera@stanford.edu&lt;/email_addr>&lt;/name>&lt;name
+        seq_no="2" role="author" addr_no="2" daisng_id="9001344">&lt;display_name>Gipp,
+        Melanie S.&lt;/display_name>&lt;full_name>Gipp, Melanie S.&lt;/full_name>&lt;wos_standard>Gipp,
+        MS&lt;/wos_standard>&lt;first_name>Melanie S.&lt;/first_name>&lt;last_name>Gipp&lt;/last_name>&lt;/name>&lt;/names>&lt;doctypes
+        count="1">&lt;doctype>Article&lt;/doctype>&lt;/doctypes>&lt;publishers>&lt;publisher>&lt;address_spec
+        addr_no="1">&lt;full_address>TWO COMMERCE SQ, 2001 MARKET ST, PHILADELPHIA,
+        PA 19103 USA&lt;/full_address>&lt;city>PHILADELPHIA&lt;/city>&lt;/address_spec>&lt;names
+        count="1">&lt;name role="publisher" seq_no="1" addr_no="1">&lt;display_name>LIPPINCOTT
+        WILLIAMS &amp;amp; WILKINS&lt;/display_name>&lt;full_name>LIPPINCOTT WILLIAMS
+        &amp;amp; WILKINS&lt;/full_name>&lt;/name>&lt;/names>&lt;/publisher>&lt;/publishers>&lt;/summary>&lt;fullrecord_metadata>&lt;languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/languages>&lt;normalized_languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/normalized_languages>&lt;normalized_doctypes
+        count="1">&lt;doctype>Article&lt;/doctype>&lt;/normalized_doctypes>&lt;refs
+        count="28">&lt;/refs>&lt;addresses count="2">&lt;address_name>&lt;address_spec
+        addr_no="1">&lt;full_address>Stanford Univ Hosp, Stanford, CA 94305 USA&lt;/full_address>&lt;organizations
+        count="2">&lt;organization>Stanford Univ Hosp&lt;/organization>&lt;organization
+        pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;names count="1">&lt;name
+        seq_no="1" role="author" reprint="Y" addr_no="1" daisng_id="2533299">&lt;display_name>Edler,
+        Alice A.&lt;/display_name>&lt;full_name>Edler, Alice A.&lt;/full_name>&lt;wos_standard>Edler,
+        AA&lt;/wos_standard>&lt;first_name>Alice A.&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;email_addr>Edlera@stanford.edu&lt;/email_addr>&lt;/name>&lt;/names>&lt;/address_name>&lt;address_name>&lt;address_spec
+        addr_no="2">&lt;full_address>Stanford Univ, Sch Med, Stanford, CA 94305 USA&lt;/full_address>&lt;organizations
+        count="2">&lt;organization>Stanford Univ&lt;/organization>&lt;organization
+        pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="1">&lt;suborganization>Sch Med&lt;/suborganization>&lt;/suborganizations>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;names count="1">&lt;name
+        seq_no="2" role="author" addr_no="2" daisng_id="9001344">&lt;display_name>Gipp,
+        Melanie S.&lt;/display_name>&lt;full_name>Gipp, Melanie S.&lt;/full_name>&lt;wos_standard>Gipp,
+        MS&lt;/wos_standard>&lt;first_name>Melanie S.&lt;/first_name>&lt;last_name>Gipp&lt;/last_name>&lt;/name>&lt;/names>&lt;/address_name&gt;&lt;/addresses>&lt;reprint_addresses
+        count="1">&lt;address_name>&lt;address_spec addr_no="1">&lt;full_address>Stanford
+        Univ Hosp &amp;amp; Clin, Dept Grad Med Educ, 300 Pasteur Dr,Room HC4335,
+        Stanford, CA 94305 USA&lt;/full_address>&lt;organizations count="2">&lt;organization>Stanford
+        Univ Hosp &amp;amp; Clin&lt;/organization>&lt;organization pref="Y">Stanford
+        University&lt;/organization>&lt;/organizations>&lt;suborganizations count="1">&lt;suborganization>Dept
+        Grad Med Educ&lt;/suborganization>&lt;/suborganizations>&lt;street>300 Pasteur
+        Dr,Room HC4335&lt;/street>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;names count="1">&lt;name
+        seq_no="1" role="author" reprint="Y" addr_no="1">&lt;display_name>Edler, Alice
+        A.&lt;/display_name>&lt;full_name>Edler, Alice A.&lt;/full_name>&lt;wos_standard>Edler,
+        AA&lt;/wos_standard>&lt;first_name>Alice A.&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;email_addr>Edlera@stanford.edu&lt;/email_addr>&lt;/name>&lt;/names>&lt;/address_name>&lt;/reprint_addresses>&lt;category_info>&lt;headings
+        count="1">&lt;heading>Science &amp;amp; Technology&lt;/heading>&lt;/headings>&lt;subheadings
+        count="1">&lt;subheading>Life Sciences &amp;amp; Biomedicine&lt;/subheading>&lt;/subheadings>&lt;subjects
+        count="2">&lt;subject ascatype="traditional" code="BA">Anesthesiology&lt;/subject>&lt;subject
+        ascatype="extended">Anesthesiology&lt;/subject>&lt;/subjects>&lt;/category_info>&lt;/fullrecord_metadata>&lt;item
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="itemType_wos"
+        coll_id="WOS">&lt;ids avail="N">V3I9A&lt;/ids>&lt;bib_id>48 (2): 59-69 SPR
+        2010&lt;/bib_id>&lt;bib_pagecount type="Journal">177&lt;/bib_pagecount>&lt;/item>&lt;/static_data>&lt;dynamic_data>&lt;citation_related>&lt;tc_list>&lt;silo_tc
+        coll_id="WOS" local_count="3">&lt;/silo_tc>&lt;/tc_list>&lt;/citation_related>&lt;cluster_related>&lt;identifiers>&lt;identifier
+        type="issn" value="0020-5907">&lt;/identifier>&lt;identifier type="eissn"
+        value="1537-1913">&lt;/identifier>&lt;identifier type="doi" value="10.1097/AIA.0b013e3181cd15ef">&lt;/identifier>&lt;/identifiers>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000217248400003&lt;/UID>&lt;static_data>&lt;summary>&lt;EWUID>&lt;WUID
+        coll_id="WOS">&lt;/WUID>&lt;edition value="WOS.ESCI">&lt;/edition>&lt;/EWUID>&lt;pub_info
+        sortdate="2009-01-01" pubyear="2009" has_abstract="Y" coverdate="2009" vol="6"
+        pubtype="Journal" journal_oas_gold="Y">&lt;page page_count="9">&lt;/page>&lt;/pub_info>&lt;titles
+        count="6">&lt;title type="source">JOURNAL OF EDUCATIONAL EVALUATION FOR HEALTH
+        PROFESSIONS&lt;/title>&lt;title type="source_abbrev">J EDUC EVAL HEALTH P&lt;/title>&lt;title
+        type="abbrev_iso">J. Educ. Eval. Health Prof.&lt;/title>&lt;title type="abbrev_11">J
+        ED EV HEA&lt;/title>&lt;title type="abbrev_29">J EDUC EVAL HEALTH PROF&lt;/title>&lt;title
+        type="item">Patient Simulation: A Literary Synthesis of Assessment Tools in
+        Anesthesiology&lt;/title>&lt;/titles>&lt;names count="7">&lt;name seq_no="1"
+        role="author" reprint="Y" addr_no="1" daisng_id="2533299">&lt;display_name>Edler,
+        Alice A.&lt;/display_name>&lt;full_name>Edler, Alice A.&lt;/full_name>&lt;wos_standard>Edler,
+        AA&lt;/wos_standard>&lt;first_name>Alice A.&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;email_addr>edlera@aol.com&lt;/email_addr>&lt;/name>&lt;name
+        seq_no="2" role="author" addr_no="2" daisng_id="5648207">&lt;display_name>Fanning,
+        Ruth G.&lt;/display_name>&lt;full_name>Fanning, Ruth G.&lt;/full_name>&lt;wos_standard>Fanning,
+        RG&lt;/wos_standard>&lt;first_name>Ruth G.&lt;/first_name>&lt;last_name>Fanning&lt;/last_name>&lt;/name>&lt;name
+        seq_no="3" role="author" addr_no="2" daisng_id="6107585">&lt;display_name>Chen,
+        Michael. I.&lt;/display_name>&lt;full_name>Chen, Michael. I.&lt;/full_name>&lt;wos_standard>Chen,
+        MI&lt;/wos_standard>&lt;first_name>Michael. I.&lt;/first_name>&lt;last_name>Chen&lt;/last_name>&lt;/name>&lt;name
+        seq_no="4" role="author" addr_no="2" daisng_id="4440236">&lt;display_name>Claure,
+        Rebecca&lt;/display_name>&lt;full_name>Claure, Rebecca&lt;/full_name>&lt;wos_standard>Claure,
+        R&lt;/wos_standard>&lt;first_name>Rebecca&lt;/first_name>&lt;last_name>Claure&lt;/last_name>&lt;/name>&lt;name
+        seq_no="5" role="author" addr_no="2" daisng_id="13567425">&lt;display_name>Almazan,
+        Dondee&lt;/display_name>&lt;full_name>Almazan, Dondee&lt;/full_name>&lt;wos_standard>Almazan,
+        D&lt;/wos_standard>&lt;first_name>Dondee&lt;/first_name>&lt;last_name>Almazan&lt;/last_name>&lt;/name>&lt;name
+        seq_no="6" role="author" addr_no="3" daisng_id="18501128">&lt;display_name>Struyk,
+        Brain&lt;/display_name>&lt;full_name>Struyk, Brain&lt;/full_name>&lt;wos_standard>Struyk,
+        B&lt;/wos_standard>&lt;first_name>Brain&lt;/first_name>&lt;last_name>Struyk&lt;/last_name>&lt;/name>&lt;name
+        seq_no="7" role="author" addr_no="2" daisng_id="4151185">&lt;display_name>Seiden,
+        Samuel C.&lt;/display_name>&lt;full_name>Seiden, Samuel C.&lt;/full_name>&lt;wos_standard>Seiden,
+        SC&lt;/wos_standard>&lt;first_name>Samuel C.&lt;/first_name>&lt;last_name>Seiden&lt;/last_name>&lt;/name>&lt;/names>&lt;doctypes
+        count="1">&lt;doctype>Article&lt;/doctype>&lt;/doctypes>&lt;publishers>&lt;publisher>&lt;address_spec
+        addr_no="1">&lt;full_address>JAYANG-ROLLANDMENT, KWAJONG, KU103, SOUTH KOREA&lt;/full_address>&lt;city>KWAJONG&lt;/city>&lt;/address_spec>&lt;names
+        count="1">&lt;name role="publisher" seq_no="1" addr_no="1">&lt;display_name>KOREA
+        HEALTH INSURANCE LICENSING EXAMINATION INST&lt;/display_name>&lt;full_name>KOREA
+        HEALTH INSURANCE LICENSING EXAMINATION INST&lt;/full_name>&lt;/name>&lt;/names>&lt;/publisher>&lt;/publishers>&lt;/summary>&lt;fullrecord_metadata>&lt;languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/languages>&lt;normalized_languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/normalized_languages>&lt;normalized_doctypes
+        count="1">&lt;doctype>Article&lt;/doctype>&lt;/normalized_doctypes>&lt;refs
+        count="67">&lt;/refs>&lt;addresses count="3">&lt;address_name>&lt;address_spec
+        addr_no="1">&lt;full_address>Stanford Hosp &amp;amp; Clin, Dept Grad Med Educ,
+        Stanford, CA 94305 USA&lt;/full_address>&lt;organizations count="2">&lt;organization>Stanford
+        Hosp &amp;amp; Clin&lt;/organization>&lt;organization pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="1">&lt;suborganization>Dept Grad Med Educ&lt;/suborganization>&lt;/suborganizations>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;names count="1">&lt;name
+        seq_no="1" role="author" reprint="Y" addr_no="1" daisng_id="2533299">&lt;display_name>Edler,
+        Alice A.&lt;/display_name>&lt;full_name>Edler, Alice A.&lt;/full_name>&lt;wos_standard>Edler,
+        AA&lt;/wos_standard>&lt;first_name>Alice A.&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;email_addr>edlera@aol.com&lt;/email_addr>&lt;/name>&lt;/names>&lt;/address_name>&lt;address_name>&lt;address_spec
+        addr_no="2">&lt;full_address>Stanford Univ, Sch Med, Dept Anaesthesia, Stanford,
+        CA 94305 USA&lt;/full_address>&lt;organizations count="2">&lt;organization>Stanford
+        Univ&lt;/organization>&lt;organization pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="2">&lt;suborganization>Sch Med&lt;/suborganization>&lt;suborganization>Dept
+        Anaesthesia&lt;/suborganization>&lt;/suborganizations>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;names count="5">&lt;name
+        seq_no="2" role="author" addr_no="2" daisng_id="5648207">&lt;display_name>Fanning,
+        Ruth G.&lt;/display_name>&lt;full_name>Fanning, Ruth G.&lt;/full_name>&lt;wos_standard>Fanning,
+        RG&lt;/wos_standard>&lt;first_name>Ruth G.&lt;/first_name>&lt;last_name>Fanning&lt;/last_name>&lt;/name>&lt;name
+        seq_no="3" role="author" addr_no="2" daisng_id="6107585">&lt;display_name>Chen,
+        Michael. I.&lt;/display_name>&lt;full_name>Chen, Michael. I.&lt;/full_name>&lt;wos_standard>Chen,
+        MI&lt;/wos_standard>&lt;first_name>Michael. I.&lt;/first_name>&lt;last_name>Chen&lt;/last_name>&lt;/name>&lt;name
+        seq_no="4" role="author" addr_no="2" daisng_id="4440236">&lt;display_name>Claure,
+        Rebecca&lt;/display_name>&lt;full_name>Claure, Rebecca&lt;/full_name>&lt;wos_standard>Claure,
+        R&lt;/wos_standard>&lt;first_name>Rebecca&lt;/first_name>&lt;last_name>Claure&lt;/last_name>&lt;/name>&lt;name
+        seq_no="5" role="author" addr_no="2" daisng_id="13567425">&lt;display_name>Almazan,
+        Dondee&lt;/display_name>&lt;full_name>Almazan, Dondee&lt;/full_name>&lt;wos_standard>Almazan,
+        D&lt;/wos_standard>&lt;first_name>Dondee&lt;/first_name>&lt;last_name>Almazan&lt;/last_name>&lt;/name>&lt;name
+        seq_no="7" role="author" addr_no="2" daisng_id="4151185">&lt;display_name>Seiden,
+        Samuel C.&lt;/display_name>&lt;full_name>Seiden, Samuel C.&lt;/full_name>&lt;wos_standard>Seiden,
+        SC&lt;/wos_standard>&lt;first_name>Samuel C.&lt;/first_name>&lt;last_name>Seiden&lt;/last_name>&lt;/name>&lt;/names>&lt;/address_name>&lt;address_name>&lt;address_spec
+        addr_no="3">&lt;full_address>Childrens Hosp Philadelphia, Dept Anaesthesia,
+        Philadelphia, PA 19104 USA&lt;/full_address>&lt;organizations count="3">&lt;organization>Childrens
+        Hosp Philadelphia&lt;/organization>&lt;organization pref="Y">Childrens Hospital
+        of Philadelphia&lt;/organization>&lt;organization pref="Y">University of Pennsylvania&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="1">&lt;suborganization>Dept Anaesthesia&lt;/suborganization>&lt;/suborganizations>&lt;city>Philadelphia&lt;/city>&lt;state>PA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">19104&lt;/zip>&lt;/address_spec>&lt;names count="1">&lt;name
+        seq_no="6" role="author" addr_no="3" daisng_id="18501128">&lt;display_name>Struyk,
+        Brain&lt;/display_name>&lt;full_name>Struyk, Brain&lt;/full_name>&lt;wos_standard>Struyk,
+        B&lt;/wos_standard>&lt;first_name>Brain&lt;/first_name>&lt;last_name>Struyk&lt;/last_name>&lt;/name>&lt;/names>&lt;/address_name>&lt;/addresses>&lt;reprint_addresses
+        count="1">&lt;address_name>&lt;address_spec addr_no="1">&lt;full_address>Stanford
+        Hosp &amp;amp; Clin, Dept Grad Med Educ, Stanford, CA 94305 USA&lt;/full_address>&lt;organizations
+        count="2">&lt;organization>Stanford Hosp &amp;amp; Clin&lt;/organization>&lt;organization
+        pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="1">&lt;suborganization>Dept Grad Med Educ&lt;/suborganization>&lt;/suborganizations>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;names count="1">&lt;name
+        seq_no="1" role="author" reprint="Y" addr_no="1">&lt;display_name>Edler, Alice
+        A.&lt;/display_name>&lt;full_name>Edler, Alice A.&lt;/full_name>&lt;wos_standard>Edler,
+        AA&lt;/wos_standard>&lt;first_name>Alice A.&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;email_addr>edlera@aol.com&lt;/email_addr>&lt;/name>&lt;/names>&lt;/address_name>&lt;/reprint_addresses>&lt;category_info>&lt;headings
+        count="1">&lt;heading>Social Sciences&lt;/heading>&lt;/headings>&lt;subjects
+        count="2">&lt;subject ascatype="traditional" code="HA">Education &amp;amp;
+        Educational Research&lt;/subject>&lt;subject ascatype="extended">Education
+        &amp;amp; Educational Research&lt;/subject>&lt;/subjects>&lt;/category_info>&lt;keywords
+        count="6">&lt;keyword>High-Fidelity Patient Simulation&lt;/keyword>&lt;keyword>Anesthesiology&lt;/keyword>&lt;keyword>Patient
+        Simulation&lt;/keyword&gt;&lt;keyword>Performance Assessment&lt;/keyword>&lt;keyword>Systemic
+        Review&lt;/keyword>&lt;keyword>Test Theory&lt;/keyword>&lt;/keywords>&lt;abstracts
+        count="1">&lt;abstract>&lt;abstract_text count="1">&lt;p>High-fidelity patient
+        simulation (HFPS) has been hypothesized as a modality for assessing competency
+        of knowledge and skill in patient simulation, but uniform methods for HFPS
+        performance assessment (PA) have not yet been completely achieved. Anesthesiology
+        as a field founded the HFPS discipline and also leads in its PA. This project
+        reviews the types, quality, and designated purpose of HFPS PA tools in anesthesiology.
+        We used the systematic review method and systematically reviewed anesthesiology
+        literature referenced in PubMed to assess the quality and reliability of available
+        PA tools in HFPS. Of 412 articles identified, 50 met our inclusion criteria.
+        Seventy seven percent of studies have been published since 2000; more recent
+        studies demonstrated higher quality. Investigators reported a variety of test
+        construction and validation methods. The most commonly reported test construction
+        methods included &amp;quot;modified Delphi Techniques&amp;quot; for item selection,
+        reliability measurement using inter-rater agreement, and intra-class correlations
+        between test items or subtests. Modern test theory, in particular generalizability
+        theory, was used in nine (18%) of studies. Test score validity has been addressed
+        in multiple investigations and shown a significant improvement in reporting
+        accuracy. However the assessment of predicative has been low across the majority
+        of studies. Usability and practicality of testing occasions and tools was
+        only anecdotally reported. To more completely comply with the gold standards
+        for PA design, both shared experience of experts and recognition of test construction
+        standards, including reliability and validity measurements, instrument piloting,
+        rater training, and explicit identification of the purpose and proposed use
+        of the assessment tool, are required.&lt;/p>&lt;/abstract_text>&lt;/abstract>&lt;/abstracts>&lt;/fullrecord_metadata>&lt;item
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="itemType_wos"
+        coll_id="WOS">&lt;ids avail="N">V1U5T&lt;/ids>&lt;bib_id>6: - 2009&lt;/bib_id>&lt;bib_pagecount
+        type="Journal">25&lt;/bib_pagecount>&lt;/item>&lt;/static_data>&lt;dynamic_data>&lt;citation_related>&lt;tc_list>&lt;silo_tc
+        coll_id="WOS" local_count="11">&lt;/silo_tc>&lt;/tc_list>&lt;/citation_related>&lt;cluster_related>&lt;identifiers>&lt;identifier
+        type="issn" value="1975-5937">&lt;/identifier>&lt;identifier type="art_no"
+        value="ARTN 3">&lt;/identifier>&lt;identifier type="doi" value="10.3352/jeehp.2009.6.3">&lt;/identifier>&lt;/identifiers>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000176711100016&lt;/UID>&lt;static_data>&lt;summary>&lt;EWUID>&lt;WUID
+        coll_id="WOS">&lt;/WUID>&lt;edition value="WOS.SCI">&lt;/edition>&lt;/EWUID>&lt;pub_info
+        sortdate="2002-07-10" pubyear="2002" has_abstract="N" coverdate="JUL 10 2002"
+        pubmonth="JUL 10" vol="288" issue="2" pubtype="Journal">&lt;page begin="166"
+        end="166" page_count="1">166-166&lt;/page>&lt;/pub_info>&lt;titles count="6">&lt;title
+        type="source">JAMA-JOURNAL OF THE AMERICAN MEDICAL ASSOCIATION&lt;/title>&lt;title
+        type="source_abbrev">JAMA-J AM MED ASSOC&lt;/title>&lt;title type="abbrev_iso">JAMA-J.
+        Am. Med. Assoc.&lt;/title>&lt;title type="abbrev_11">J AM MED A&lt;/title>&lt;title
+        type="abbrev_29">JAMA-J AM MED ASSN&lt;/title>&lt;title type="item">Policies
+        for exposure to bloodborne pathogens among US-based international voluntary
+        medical organizations&lt;/title>&lt;/titles>&lt;names count="3">&lt;name seq_no="1"
+        role="author" reprint="Y" daisng_id="468355">&lt;display_name>Edler, A&lt;/display_name>&lt;full_name>Edler,
+        A&lt;/full_name>&lt;wos_standard>Edler, A&lt;/wos_standard>&lt;first_name>A&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;/name>&lt;name
+        seq_no="2" role="author" daisng_id="166532">&lt;display_name>Olsen, MA&lt;/display_name>&lt;full_name>Olsen,
+        MA&lt;/full_name>&lt;wos_standard>Olsen, MA&lt;/wos_standard>&lt;first_name>MA&lt;/first_name>&lt;last_name>Olsen&lt;/last_name>&lt;/name>&lt;name
+        seq_no="3" role="author" daisng_id="22303164">&lt;display_name>Mbwille, MCE&lt;/display_name>&lt;full_name>Mbwille,
+        MCE&lt;/full_name&gt;&lt;wos_standard>Mbwille, MCE&lt;/wos_standard>&lt;first_name>MCE&lt;/first_name>&lt;last_name>Mbwille&lt;/last_name>&lt;/name>&lt;/names>&lt;doctypes
+        count="1">&lt;doctype>Letter&lt;/doctype>&lt;/doctypes>&lt;publishers>&lt;publisher>&lt;address_spec
+        addr_no="1">&lt;full_address>515 N STATE ST, CHICAGO, IL 60610 USA&lt;/full_address>&lt;city>CHICAGO&lt;/city>&lt;/address_spec>&lt;names
+        count="1">&lt;name role="publisher" seq_no="1" addr_no="1">&lt;display_name>AMER
+        MEDICAL ASSOC&lt;/display_name>&lt;full_name>AMER MEDICAL ASSOC&lt;/full_name>&lt;/name>&lt;/names>&lt;/publisher>&lt;/publishers>&lt;/summary>&lt;fullrecord_metadata>&lt;languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/languages>&lt;normalized_languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/normalized_languages>&lt;normalized_doctypes
+        count="1">&lt;doctype>Letter&lt;/doctype>&lt;/normalized_doctypes>&lt;refs
+        count="3">&lt;/refs>&lt;addresses count="3">&lt;address_name>&lt;address_spec
+        addr_no="1">&lt;full_address>Stanford Univ, Dept Anesthesiol, Sch Med, Stanford,
+        CA 94305 USA&lt;/full_address>&lt;organizations count="2">&lt;organization>Stanford
+        Univ&lt;/organization>&lt;organization pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="2">&lt;suborganization>Dept Anesthesiol&lt;/suborganization>&lt;suborganization>Sch
+        Med&lt;/suborganization>&lt;/suborganizations>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;/address_name>&lt;address_name>&lt;address_spec
+        addr_no="2">&lt;full_address>Washington Univ, Sch Med, Div Infect Dis, St
+        Louis, MO 63110 USA&lt;/full_address>&lt;organizations count="2">&lt;organization>Washington
+        Univ&lt;/organization>&lt;organization pref="Y">Washington University (WUSTL)&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="2">&lt;suborganization>Sch Med&lt;/suborganization>&lt;suborganization>Div
+        Infect Dis&lt;/suborganization>&lt;/suborganizations>&lt;city>St Louis&lt;/city>&lt;state>MO&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">63110&lt;/zip>&lt;/address_spec>&lt;/address_name>&lt;address_name>&lt;address_spec
+        addr_no="3">&lt;full_address>Mbeya Consultant Hosp, Mbeya, Tanzania&lt;/full_address>&lt;organizations
+        count="1">&lt;organization>Mbeya Consultant Hosp&lt;/organization>&lt;/organizations>&lt;city>Mbeya&lt;/city>&lt;country>Tanzania&lt;/country>&lt;/address_spec>&lt;/address_name>&lt;/addresses>&lt;reprint_addresses
+        count="1">&lt;address_name>&lt;address_spec addr_no="1">&lt;full_address>Stanford
+        Univ, Dept Anesthesiol, Sch Med, Stanford, CA 94305 USA&lt;/full_address>&lt;organizations
+        count="2">&lt;organization>Stanford Univ&lt;/organization>&lt;organization
+        pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="2">&lt;suborganization>Dept Anesthesiol&lt;/suborganization>&lt;suborganization>Sch
+        Med&lt;/suborganization>&lt;/suborganizations>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;names count="1">&lt;name
+        seq_no="1" role="author" reprint="Y" addr_no="1" display="N">&lt;display_name>Edler,
+        A&lt;/display_name>&lt;full_name>Edler, A&lt;/full_name>&lt;wos_standard>Edler,
+        A&lt;/wos_standard>&lt;first_name>A&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;/name>&lt;/names>&lt;/address_name>&lt;/reprint_addresses>&lt;category_info>&lt;headings
+        count="1">&lt;heading>Science &amp;amp; Technology&lt;/heading>&lt;/headings>&lt;subheadings
+        count="1">&lt;subheading>Life Sciences &amp;amp; Biomedicine&lt;/subheading>&lt;/subheadings>&lt;subjects
+        count="2">&lt;subject ascatype="traditional" code="PY">Medicine, General &amp;amp;
+        Internal&lt;/subject>&lt;subject ascatype="extended">General &amp;amp; Internal
+        Medicine&lt;/subject>&lt;/subjects>&lt;/category_info>&lt;/fullrecord_metadata>&lt;item
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="itemType_wos"
+        coll_id="WOS">&lt;ids avail="Y">571HC&lt;/ids>&lt;bib_id>288 (2): 166-166
+        JUL 10 2002&lt;/bib_id>&lt;/item>&lt;/static_data>&lt;dynamic_data>&lt;citation_related>&lt;tc_list>&lt;silo_tc
+        coll_id="WOS" local_count="2">&lt;/silo_tc>&lt;/tc_list>&lt;/citation_related>&lt;cluster_related>&lt;identifiers>&lt;identifier
+        type="issn" value="0098-7484">&lt;/identifier>&lt;identifier type="xref_doi"
+        value="10.1001/jama.288.2.166">&lt;/identifier>&lt;/identifiers>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>MEDLINE:19088623&lt;/UID>&lt;static_data>&lt;summary>&lt;EWUID>&lt;WUID
+        coll_id="MEDLINE">&lt;/WUID>&lt;edition value="MEDLINE.MEDLINE">&lt;/edition>&lt;/EWUID>&lt;pub_info
+        sortdate="2007-01-01" pubyear="2007" season="Fall" coverdate="2007" vol="2"
+        issue="3" pubtype="Journal" medium="Print" model="Print" has_abstract="N">&lt;page
+        begin="194" end="8">194-8&lt;/page>&lt;/pub_info>&lt;titles count="4">&lt;title
+        type="item">Scenario and checklist for airway rescue during pediatric sedation.&lt;/title>&lt;title
+        type="source">Simulation in healthcare : journal of the Society for Simulation
+        in Healthcare&lt;/title>&lt;title type="abbrev_iso">Simul Healthc&lt;/title>&lt;title
+        type="source_abbrev">Simul Healthc&lt;/title>&lt;/titles>&lt;names count="5">&lt;name
+        seq_no="1" role="author" display="Y">&lt;display_name>Chen, Michael I&lt;/display_name>&lt;full_name>Chen,
+        Michael I&lt;/full_name>&lt;initials>MI&lt;/initials>&lt;/name>&lt;name seq_no="2"
+        role="author" display="Y">&lt;display_name>Edler, Alice&lt;/display_name>&lt;full_name>Edler,
+        Alice&lt;/full_name>&lt;initials>A&lt;/initials>&lt;/name>&lt;name seq_no="3"
+        role="author" display="Y">&lt;display_name>Wald, Samuel&lt;/display_name>&lt;full_name>Wald,
+        Samuel&lt;/full_name>&lt;initials>S&lt;/initials>&lt;/name>&lt;name seq_no="4"
+        role="author" display="Y">&lt;display_name>DuBois, Joshua&lt;/display_name>&lt;full_name>DuBois,
+        Joshua&lt;/full_name>&lt;initials>J&lt;/initials>&lt;/name>&lt;name seq_no="5"
+        role="author" display="Y">&lt;display_name>Huang, Yue Ming&lt;/display_name>&lt;full_name>Huang,
+        Yue Ming&lt;/full_name>&lt;initials>YM&lt;/initials>&lt;/name>&lt;/names>&lt;doctypes
+        count="1">&lt;doctype>Journal Article&lt;/doctype>&lt;/doctypes>&lt;/summary>&lt;fullrecord_metadata>&lt;languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/languages>&lt;normalized_languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/normalized_languages>&lt;normalized_doctypes
+        count="1">&lt;doctype>Article&lt;/doctype>&lt;/normalized_doctypes>&lt;addresses
+        count="1">&lt;address_name>&lt;address_spec addr_no="1">&lt;full_address>Stanford
+        University Medical Center Stanford, CA, USA. michael1@stanford.edu&lt;/full_address>&lt;/address_spec>&lt;/address_name>&lt;/addresses>&lt;category_info>&lt;headings
+        count="2">&lt;heading>Science &amp;amp; Technology&lt;/heading>&lt;heading>Social
+        Sciences&lt;/heading>&lt;/headings>&lt;subheadings count="1">&lt;subheading>Life
+        Sciences &amp;amp; Biomedicine&lt;/subheading>&lt;/subheadings>&lt;subjects
+        count="10">&lt;subject ascatype="traditional" code="TQ">PEDIATRICS&lt;/subject>&lt;subject
+        ascatype="traditional" code="FF">EMERGENCY MEDICINE&lt;/subject>&lt;subject
+        ascatype="traditional">CARDIAC CARDIOVASCULAR SYSTEMS&lt;/subject>&lt;subject
+        ascatype="traditional" code="XA">SOCIOLOGY&lt;/subject>&lt;subject ascatype="traditional">EDUCATION
+        EDUCATIONAL RESEARCH&lt;/subject>&lt;subject ascatype="extended">Pediatrics&lt;/subject>&lt;subject
+        ascatype="extended">Emergency Medicine&lt;/subject>&lt;subject ascatype="extended">Cardiovascular
+        System &amp;amp; Cardiology&lt;/subject>&lt;subject ascatype="extended">Sociology&lt;/subject>&lt;subject
+        ascatype="extended">Education &amp;amp; Educational Research&lt;/subject>&lt;/subjects>&lt;/category_info>&lt;/fullrecord_metadata>&lt;item
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Owner="NLM" Status="MEDLINE"
+        xsi:type="itemType_medline" coll_id="MEDLINE">&lt;MedlineJournalInfo>&lt;Country>United
+        States&lt;/Country>&lt;NlmUniqueID>101264408&lt;/NlmUniqueID>&lt;ISSNLinking>1559-2332&lt;/ISSNLinking>&lt;/MedlineJournalInfo>&lt;DateCompleted>2009-01-28&lt;/DateCompleted>&lt;DateRevised>2008-12-17&lt;/DateRevised>&lt;Affiliation>Stanford
+        University Medical Center Stanford, CA, USA. michael1@stanford.edu&lt;/Affiliation>&lt;CitationSubset>IM&lt;/CitationSubset>&lt;MeshHeadingList>&lt;MeshHeading>&lt;DescriptorName
+        MajorTopicYN="N" UI="D000293">Adolescent&lt;/DescriptorName>&lt;TreeCodeList>&lt;TreeCode
+        MajorTopicYN="N">M01.060.057&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;MeshHeading>&lt;DescriptorName
+        MajorTopicYN="Y" UI="D016887">Cardiopulmonary Resuscitation&lt;/DescriptorName>&lt;TreeCodeList>&lt;TreeCode
+        MajorTopicYN="Y">E02.365.647.110&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;MeshHeading>&lt;DescriptorName
+        MajorTopicYN="N" UI="D002648">Child&lt;/DescriptorName>&lt;TreeCodeList>&lt;TreeCode
+        MajorTopicYN="N">M01.060.406&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;MeshHeading>&lt;DescriptorName
+        MajorTopicYN="N" UI="D002669">Child Welfare&lt;/DescriptorName>&lt;TreeCodeList>&lt;TreeCode
+        MajorTopicYN="N">I01.880.787.293&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;MeshHeading>&lt;DescriptorName
+        MajorTopicYN="N" UI="D002675">Child, Preschool&lt;/DescriptorName>&lt;TreeCodeList>&lt;TreeCode
+        MajorTopicYN="N">M01.060.406.448&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;MeshHeading>&lt;DescriptorName
+        MajorTopicYN="Y" UI="D002983">Clinical Competence&lt;/DescriptorName>&lt;TreeCodeList>&lt;TreeCode
+        MajorTopicYN="Y">I02.399.630.210&lt;/TreeCode>&lt;TreeCode MajorTopicYN="Y">N04.761.210&lt;/TreeCode>&lt;TreeCode
+        MajorTopicYN="Y">N05.715.175&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;MeshHeading>&lt;DescriptorName
+        MajorTopicYN="N" UI="D003479">Curriculum&lt;/DescriptorName>&lt;TreeCodeList>&lt;TreeCode
+        MajorTopicYN="N">I02.158&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;MeshHeading>&lt;DescriptorName
+        MajorTopicYN="N" UI="D006801">Humans&lt;/DescriptorName>&lt;TreeCodeList>&lt;TreeCode
+        MajorTopicYN="N">B01.050.150.900.649.801.400.112.400.400&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;MeshHeading>&lt;DescriptorName
+        MajorTopicYN="N" UI="D007223">Infant&lt;/DescriptorName>&lt;TreeCodeList>&lt;TreeCode
+        MajorTopicYN="N">M01.060.703&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;MeshHeading>&lt;DescriptorName
+        MajorTopicYN="N" UI="D007231">Infant, Newborn&lt;/DescriptorName>&lt;TreeCodeList>&lt;TreeCode
+        MajorTopicYN="N">M01.060.703.520&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;MeshHeading>&lt;DescriptorName
+        MajorTopicYN="Y" UI="D016544">Patient Simulation&lt;/DescriptorName>&lt;TreeCodeList>&lt;TreeCode
+        MajorTopicYN="Y">I02.903.847.500&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;MeshHeading>&lt;DescriptorName
+        MajorTopicYN="Y" UI="D010372">Pediatrics&lt;/DescriptorName>&lt;TreeCodeList>&lt;TreeCode
+        MajorTopicYN="Y">H02.403.670&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;MeshHeading>&lt;DescriptorName
+        MajorTopicYN="N" UI="D012121">Respiration, Artificial&lt;/DescriptorName>&lt;QualifierName
+        MajorTopicYN="N" UI="Q000295">instrumentation&lt;/QualifierName>&lt;TreeCodeList>&lt;TreeCode
+        MajorTopicYN="N">E02.041.625&lt;/TreeCode>&lt;TreeCode MajorTopicYN="N">E02.365.647.729&lt;/TreeCode>&lt;TreeCode
+        MajorTopicYN="N">E02.880.820&lt;/TreeCode>&lt;TreeCode MajorTopicYN="N">Y31&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;/MeshHeadingList>&lt;/item&gt;&lt;/static_data>&lt;dynamic_data>&lt;citation_related>&lt;tc_list>&lt;silo_tc
+        coll_id="MEDLINE" local_count="0">&lt;/silo_tc>&lt;/tc_list>&lt;/citation_related>&lt;cluster_related>&lt;identifiers>&lt;identifier
+        type="doi" value="10.1097/SIH.0b013e3181461b60">&lt;/identifier>&lt;identifier
+        type="issn" value="1559-2332">&lt;/identifier>&lt;identifier type="xref_doi"
+        value="10.1097/SIH.0b013e3181461b60">&lt;/identifier>&lt;identifier type="pmid"
+        value="MEDLINE:19088623">&lt;/identifier>&lt;/identifiers>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000276938400007&lt;/UID>&lt;static_data>&lt;summary>&lt;EWUID>&lt;WUID
+        coll_id="WOS">&lt;/WUID>&lt;edition value="WOS.SCI">&lt;/edition>&lt;/EWUID>&lt;pub_info
+        sortdate="2010-04-01" pubyear="2010" has_abstract="Y" coverdate="APR 2010"
+        pubmonth="APR" vol="5" issue="2" pubtype="Journal">&lt;page begin="112" end="115"
+        page_count="4">112-115&lt;/page>&lt;/pub_info>&lt;titles count="6">&lt;title
+        type="source">SIMULATION IN HEALTHCARE-JOURNAL OF THE SOCIETY FOR SIMULATION
+        IN HEALTHCARE&lt;/title>&lt;title type="source_abbrev">SIMUL HEALTHC&lt;/title>&lt;title
+        type="abbrev_iso">Simul. Healthc.&lt;/title>&lt;title type="abbrev_11">SIMUL
+        HEALT&lt;/title>&lt;title type="abbrev_29">SIMUL HEALTHC&lt;/title>&lt;title
+        type="item">Affordable Simulation for Small-Scale Training and Assessment&lt;/title>&lt;/titles>&lt;names
+        count="5">&lt;name seq_no="1" role="author" addr_no="1" daisng_id="2533299">&lt;display_name>Edler,
+        Alice A.&lt;/display_name>&lt;full_name>Edler, Alice A.&lt;/full_name>&lt;wos_standard>Edler,
+        AA&lt;/wos_standard>&lt;first_name>Alice A.&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;/name>&lt;name
+        seq_no="2" role="author" addr_no="1" daisng_id="6107585">&lt;display_name>Chen,
+        Michael&lt;/display_name>&lt;full_name>Chen, Michael&lt;/full_name>&lt;wos_standard>Chen,
+        M&lt;/wos_standard>&lt;first_name>Michael&lt;/first_name>&lt;last_name>Chen&lt;/last_name>&lt;/name>&lt;name
+        seq_no="3" role="author" addr_no="1" daisng_id="3538816">&lt;display_name>Honkanen,
+        Anita&lt;/display_name>&lt;full_name>Honkanen, Anita&lt;/full_name>&lt;wos_standard>Honkanen,
+        A&lt;/wos_standard>&lt;first_name>Anita&lt;/first_name>&lt;last_name>Honkanen&lt;/last_name>&lt;/name>&lt;name
+        seq_no="4" role="author" addr_no="1" daisng_id="5873384">&lt;display_name>Hackel,
+        Al&lt;/display_name>&lt;full_name>Hackel, Al&lt;/full_name>&lt;wos_standard>Hackel,
+        A&lt;/wos_standard>&lt;first_name>Al&lt;/first_name>&lt;last_name>Hackel&lt;/last_name>&lt;/name>&lt;name
+        seq_no="5" role="author" reprint="Y" addr_no="1" daisng_id="1371640">&lt;display_name>Golianu,
+        Brenda&lt;/display_name>&lt;full_name>Golianu, Brenda&lt;/full_name>&lt;wos_standard>Golianu,
+        B&lt;/wos_standard>&lt;first_name>Brenda&lt;/first_name>&lt;last_name>Golianu&lt;/last_name>&lt;email_addr>bgolianu@stanford.edu&lt;/email_addr>&lt;/name>&lt;/names>&lt;doctypes
+        count="1">&lt;doctype>Editorial Material&lt;/doctype>&lt;/doctypes>&lt;publishers>&lt;publisher>&lt;address_spec
+        addr_no="1">&lt;full_address>TWO COMMERCE SQ, 2001 MARKET ST, PHILADELPHIA,
+        PA 19103 USA&lt;/full_address>&lt;city>PHILADELPHIA&lt;/city>&lt;/address_spec>&lt;names
+        count="1">&lt;name role="publisher" seq_no="1" addr_no="1">&lt;display_name>LIPPINCOTT
+        WILLIAMS &amp;amp; WILKINS&lt;/display_name>&lt;full_name>LIPPINCOTT WILLIAMS
+        &amp;amp; WILKINS&lt;/full_name>&lt;/name>&lt;/names>&lt;/publisher>&lt;/publishers>&lt;/summary>&lt;fullrecord_metadata>&lt;languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/languages>&lt;normalized_languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/normalized_languages>&lt;normalized_doctypes
+        count="1">&lt;doctype>Editorial&lt;/doctype>&lt;/normalized_doctypes>&lt;refs
+        count="12">&lt;/refs>&lt;addresses count="1">&lt;address_name>&lt;address_spec
+        addr_no="1">&lt;full_address>Stanford Univ, Sch Med, Dept Anesthesia, Stanford,
+        CA 94305 USA&lt;/full_address>&lt;organizations count="2">&lt;organization>Stanford
+        Univ&lt;/organization>&lt;organization pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="2">&lt;suborganization>Sch Med&lt;/suborganization>&lt;suborganization>Dept
+        Anesthesia&lt;/suborganization>&lt;/suborganizations>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;names count="5">&lt;name
+        seq_no="1" role="author" addr_no="1" daisng_id="2533299">&lt;display_name>Edler,
+        Alice A.&lt;/display_name>&lt;full_name>Edler, Alice A.&lt;/full_name>&lt;wos_standard>Edler,
+        AA&lt;/wos_standard>&lt;first_name>Alice A.&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;/name>&lt;name
+        seq_no="2" role="author" addr_no="1" daisng_id="6107585">&lt;display_name>Chen,
+        Michael&lt;/display_name>&lt;full_name>Chen, Michael&lt;/full_name>&lt;wos_standard>Chen,
+        M&lt;/wos_standard>&lt;first_name>Michael&lt;/first_name>&lt;last_name>Chen&lt;/last_name>&lt;/name>&lt;name
+        seq_no="3" role="author" addr_no="1" daisng_id="3538816">&lt;display_name>Honkanen,
+        Anita&lt;/display_name>&lt;full_name>Honkanen, Anita&lt;/full_name>&lt;wos_standard>Honkanen,
+        A&lt;/wos_standard>&lt;first_name>Anita&lt;/first_name>&lt;last_name>Honkanen&lt;/last_name>&lt;/name>&lt;name
+        seq_no="4" role="author" addr_no="1" daisng_id="5873384">&lt;display_name>Hackel,
+        Al&lt;/display_name>&lt;full_name>Hackel, Al&lt;/full_name>&lt;wos_standard>Hackel,
+        A&lt;/wos_standard>&lt;first_name>Al&lt;/first_name>&lt;last_name>Hackel&lt;/last_name>&lt;/name>&lt;name
+        seq_no="5" role="author" reprint="Y" addr_no="1" daisng_id="1371640">&lt;display_name>Golianu,
+        Brenda&lt;/display_name>&lt;full_name>Golianu, Brenda&lt;/full_name>&lt;wos_standard>Golianu,
+        B&lt;/wos_standard>&lt;first_name>Brenda&lt;/first_name>&lt;last_name>Golianu&lt;/last_name>&lt;email_addr>bgolianu@stanford.edu&lt;/email_addr>&lt;/name>&lt;/names>&lt;/address_name>&lt;/addresses>&lt;reprint_addresses
+        count="1">&lt;address_name>&lt;address_spec addr_no="1">&lt;full_address>Stanford
+        Univ, Sch Med, Dept Anesthesia, 300 Pasteur Dr,Rm H3580, Stanford, CA 94305
+        USA&lt;/full_address>&lt;organizations count="2">&lt;organization>Stanford
+        Univ&lt;/organization>&lt;organization pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="2">&lt;suborganization>Sch Med&lt;/suborganization>&lt;suborganization>Dept
+        Anesthesia&lt;/suborganization>&lt;/suborganizations>&lt;street>300 Pasteur
+        Dr,Rm H3580&lt;/street>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;names count="1">&lt;name
+        seq_no="1" role="author" reprint="Y" addr_no="1">&lt;display_name>Golianu,
+        Brenda&lt;/display_name>&lt;full_name>Golianu, Brenda&lt;/full_name>&lt;wos_standard>Golianu,
+        B&lt;/wos_standard>&lt;first_name>Brenda&lt;/first_name>&lt;last_name>Golianu&lt;/last_name>&lt;email_addr>bgolianu@stanford.edu&lt;/email_addr>&lt;/name>&lt;/names>&lt;/address_name>&lt;/reprint_addresses>&lt;category_info>&lt;headings
+        count="1">&lt;heading>Science &amp;amp; Technology&lt;/heading>&lt;/headings>&lt;subheadings
+        count="1">&lt;subheading>Life Sciences &amp;amp; Biomedicine&lt;/subheading>&lt;/subheadings>&lt;subjects
+        count="2">&lt;subject ascatype="traditional" code="HL">Health Care Sciences
+        &amp;amp; Services&lt;/subject>&lt;subject ascatype="extended">Health Care
+        Sciences &amp;amp; Services&lt;/subject>&lt;/subjects>&lt;/category_info>&lt;keywords
+        count="4">&lt;keyword>Medical education&lt;/keyword>&lt;keyword>Patient simulation&lt;/keyword>&lt;keyword>Performance
+        assessment&lt;/keyword>&lt;keyword>Economics&lt;/keyword>&lt;/keywords>&lt;abstracts
+        count="1">&lt;abstract>&lt;abstract_text count="4">&lt;p>Introduction: High-fidelity
+        patient simulation is increasingly recognized as an effective means of team
+        training, acquisition and maintenance of technical and professional skills,
+        and reliable performance assessment; however, finding a cost effective solution
+        to providing such instruction can be difficult. This report describes the
+        rationale, design, and appropriateness of a portable simulation model and
+        example of its successful use at national meetings.&lt;/p>&lt;p>Methods: The
+        Stanford Simulation Group, in association with several other centers, developed
+        a portable Pediatric Simulation Training and Assessment Program (Pediatric
+        Anesthesia in-Situ Simulation) and presented it at two national meetings.
+        The technical challenges and costs of development are outlined, and a satisfaction
+        survey was conducted at the completion of the program.&lt;/p>&lt;p>Results:
+        All respondents (100%) either agreed or strongly agreed that the course was
+        useful, met expectations, was enjoyable, and that the scenarios were realistic.&lt;/p>&lt;p>Conclusions:
+        The Portable Simulation Training and Assessment Program (Pediatric Anesthesia
+        in-Situ Simulation) presents innovative educational and financial opportunities
+        to assist in both training and assessment of critical emergency response skills
+        at smaller institutions and allows specialized instruction in an in situ setting.
+        (Sim Healthcare 5:112-115, 2010)&lt;/p>&lt;/abstract_text>&lt;/abstract>&lt;/abstracts>&lt;/fullrecord_metadata>&lt;item
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="itemType_wos"
+        coll_id="WOS">&lt;ids avail="N">586UG&lt;/ids>&lt;bib_id>5 (2): 112-115 APR
+        2010&lt;/bib_id>&lt;bib_pagecount type="Journal">84&lt;/bib_pagecount>&lt;keywords_plus
+        count="1">&lt;keyword>EDUCATION&lt;/keyword>&lt;/keywords_plus>&lt;/item>&lt;/static_data>&lt;dynamic_data>&lt;citation_related>&lt;tc_list>&lt;silo_tc
+        coll_id="WOS" local_count="8">&lt;/silo_tc>&lt;/tc_list>&lt;/citation_related>&lt;cluster_related>&lt;identifiers>&lt;identifier
+        type="issn" value="1559-2332">&lt;/identifier>&lt;identifier type="eissn"
+        value="1559-713X">&lt;/identifier>&lt;identifier type="doi" value="10.1097/SIH.0b013e3181c76332">&lt;/identifier>&lt;identifier
+        type="xref_doi" value="10.1097/SIH.0b013e3181c76332">&lt;/identifier>&lt;/identifiers>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000270210100035&lt;/UID>&lt;static_data>&lt;summary>&lt;EWUID>&lt;WUID
+        coll_id="WOS">&lt;/WUID>&lt;edition value="WOS.SCI">&lt;/edition>&lt;/EWUID>&lt;pub_info
+        sortdate="2009-10-01" pubyear="2009" has_abstract="N" coverdate="OCT 2009"
+        pubmonth="OCT" vol="111" issue="4" pubtype="Journal">&lt;page begin="920"
+        end="920" page_count="1">920-920&lt;/page>&lt;/pub_info>&lt;titles count="6">&lt;title
+        type="source">ANESTHESIOLOGY&lt;/title>&lt;title type="source_abbrev">ANESTHESIOLOGY&lt;/title>&lt;title
+        type="abbrev_iso">Anesthesiology&lt;/title>&lt;title type="abbrev_11">ANESTHESIOL&lt;/title>&lt;title
+        type="abbrev_29">ANESTHESIOLOGY&lt;/title>&lt;title type="item">Paradigm Consciousness:
+        A New Approach to Understanding Anesthesia Knowledge and Education&lt;/title>&lt;/titles>&lt;names
+        count="1">&lt;name seq_no="1" role="author" reprint="Y" daisng_id="2533299">&lt;display_name>Edler,
+        Alice A.&lt;/display_name>&lt;full_name>Edler, Alice A.&lt;/full_name>&lt;wos_standard>Edler,
+        AA&lt;/wos_standard>&lt;first_name>Alice A.&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;email_addr>edlera@aol.com&lt;/email_addr>&lt;/name>&lt;/names>&lt;doctypes
+        count="1">&lt;doctype>Letter&lt;/doctype>&lt;/doctypes>&lt;publishers&gt;&lt;publisher>&lt;address_spec
+        addr_no="1">&lt;full_address>530 WALNUT ST, PHILADELPHIA, PA 19106-3621 USA&lt;/full_address>&lt;city>PHILADELPHIA&lt;/city>&lt;/address_spec>&lt;names
+        count="1">&lt;name role="publisher" seq_no="1" addr_no="1">&lt;display_name>LIPPINCOTT
+        WILLIAMS &amp;amp; WILKINS&lt;/display_name>&lt;full_name>LIPPINCOTT WILLIAMS
+        &amp;amp; WILKINS&lt;/full_name>&lt;/name>&lt;/names>&lt;/publisher>&lt;/publishers>&lt;/summary>&lt;fullrecord_metadata>&lt;languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/languages>&lt;normalized_languages
+        count="1"&gt;&lt;language type="primary">English&lt;/language>&lt;/normalized_languages>&lt;normalized_doctypes
+        count="1">&lt;doctype>Letter&lt;/doctype>&lt;/normalized_doctypes>&lt;refs
+        count="4">&lt;/refs>&lt;addresses count="1">&lt;address_name>&lt;address_spec
+        addr_no="1">&lt;full_address>Stanford Hosp &amp;amp; Clin, Dept Grad Med Educ,
+        Stanford, CA USA&lt;/full_address>&lt;organizations count="2">&lt;organization>Stanford
+        Hosp &amp;amp; Clin&lt;/organization>&lt;organization pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="1">&lt;suborganization>Dept Grad Med Educ&lt;/suborganization>&lt;/suborganizations>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;/address_spec>&lt;/address_name>&lt;/addresses>&lt;reprint_addresses
+        count="1">&lt;address_name>&lt;address_spec addr_no="1">&lt;full_address>Stanford
+        Hosp &amp;amp; Clin, Dept Grad Med Educ, Stanford, CA USA&lt;/full_address>&lt;organizations
+        count="2">&lt;organization>Stanford Hosp &amp;amp; Clin&lt;/organization>&lt;organization
+        pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="1">&lt;suborganization>Dept Grad Med Educ&lt;/suborganization>&lt;/suborganizations>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;/address_spec>&lt;names
+        count="1">&lt;name seq_no="1" role="author" reprint="Y" addr_no="1">&lt;display_name>Edler,
+        Alice A.&lt;/display_name>&lt;full_name>Edler, Alice A.&lt;/full_name>&lt;wos_standard>Edler,
+        AA&lt;/wos_standard>&lt;first_name>Alice A.&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;email_addr>edlera@aol.com&lt;/email_addr>&lt;/name>&lt;/names>&lt;/address_name>&lt;/reprint_addresses>&lt;category_info>&lt;headings
+        count="1">&lt;heading>Science &amp;amp; Technology&lt;/heading>&lt;/headings>&lt;subheadings
+        count="1">&lt;subheading>Life Sciences &amp;amp; Biomedicine&lt;/subheading>&lt;/subheadings>&lt;subjects
+        count="2">&lt;subject ascatype="traditional" code="BA">Anesthesiology&lt;/subject>&lt;subject
+        ascatype="extended">Anesthesiology&lt;/subject>&lt;/subjects>&lt;/category_info>&lt;/fullrecord_metadata>&lt;item
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="itemType_wos"
+        coll_id="WOS">&lt;ids avail="Y">499HS&lt;/ids>&lt;bib_id>111 (4): 920-920
+        OCT 2009&lt;/bib_id>&lt;bib_pagecount type="Journal">304&lt;/bib_pagecount>&lt;/item>&lt;/static_data>&lt;dynamic_data>&lt;citation_related>&lt;tc_list>&lt;silo_tc
+        coll_id="WOS" local_count="0">&lt;/silo_tc>&lt;/tc_list>&lt;/citation_related>&lt;cluster_related>&lt;identifiers>&lt;identifier
+        type="issn" value="0003-3022">&lt;/identifier>&lt;identifier type="xref_doi"
+        value="10.1097/ALN.0b013e3181b43948">&lt;/identifier>&lt;/identifiers>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000264165900021&lt;/UID>&lt;static_data>&lt;summary>&lt;EWUID>&lt;WUID
+        coll_id="WOS">&lt;/WUID>&lt;edition value="WOS.SCI">&lt;/edition>&lt;/EWUID>&lt;pub_info
+        sortdate="2009-04-01" pubyear="2009" has_abstract="N" coverdate="APR 2009"
+        pubmonth="APR" vol="19" issue="4" pubtype="Journal">&lt;page begin="406" end="407"
+        page_count="2">406-407&lt;/page>&lt;/pub_info>&lt;titles count="6">&lt;title
+        type="source">PEDIATRIC ANESTHESIA&lt;/title>&lt;title type="source_abbrev">PEDIATR
+        ANESTH&lt;/title>&lt;title type="abbrev_iso">Pediatr. Anesth.&lt;/title>&lt;title
+        type="abbrev_11">PEDIATR ANE&lt;/title>&lt;title type="abbrev_29">PEDIATR
+        ANESTH&lt;/title>&lt;title type="item">A case series of airway management
+        for wireless capsule endoscopy in pediatric patients&lt;/title>&lt;/titles>&lt;names
+        count="2">&lt;name seq_no="1" role="author" reprint="Y" addr_no="1" daisng_id="2533299">&lt;display_name>Edler,
+        Alice&lt;/display_name>&lt;full_name>Edler, Alice&lt;/full_name>&lt;wos_standard>Edler,
+        A&lt;/wos_standard>&lt;first_name>Alice&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;email_addr>edlera@aol.com&lt;/email_addr>&lt;/name>&lt;name
+        seq_no="2" role="author" addr_no="1" daisng_id="4440236">&lt;display_name>Claure,
+        Rebecca&lt;/display_name>&lt;full_name>Claure, Rebecca&lt;/full_name>&lt;wos_standard>Claure,
+        R&lt;/wos_standard>&lt;first_name>Rebecca&lt;/first_name>&lt;last_name>Claure&lt;/last_name>&lt;/name>&lt;/names>&lt;doctypes
+        count="1">&lt;doctype>Letter&lt;/doctype>&lt;/doctypes>&lt;publishers>&lt;publisher>&lt;address_spec
+        addr_no="1">&lt;full_address>COMMERCE PLACE, 350 MAIN ST, MALDEN 02148, MA
+        USA&lt;/full_address>&lt;city>MALDEN&lt;/city>&lt;/address_spec>&lt;names
+        count="1">&lt;name role="publisher" seq_no="1" addr_no="1">&lt;display_name>WILEY-BLACKWELL
+        PUBLISHING, INC&lt;/display_name>&lt;full_name>WILEY-BLACKWELL PUBLISHING,
+        INC&lt;/full_name>&lt;/name>&lt;/names>&lt;/publisher>&lt;/publishers>&lt;/summary>&lt;fullrecord_metadata>&lt;languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/languages>&lt;normalized_languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/normalized_languages>&lt;normalized_doctypes
+        count="1">&lt;doctype>Letter&lt;/doctype>&lt;/normalized_doctypes>&lt;refs
+        count="0">&lt;/refs>&lt;addresses count="1">&lt;address_name>&lt;address_spec
+        addr_no="1">&lt;full_address>Stanford Univ, Sch Med, Stanford, CA 94305 USA&lt;/full_address>&lt;organizations
+        count="2">&lt;organization>Stanford Univ&lt;/organization>&lt;organization
+        pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="1">&lt;suborganization>Sch Med&lt;/suborganization>&lt;/suborganizations>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;names count="2">&lt;name
+        seq_no="1" role="author" reprint="Y" addr_no="1" daisng_id="2533299">&lt;display_name>Edler,
+        Alice&lt;/display_name>&lt;full_name>Edler, Alice&lt;/full_name>&lt;wos_standard>Edler,
+        A&lt;/wos_standard>&lt;first_name>Alice&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;email_addr>edlera@aol.com&lt;/email_addr>&lt;/name>&lt;name
+        seq_no="2" role="author" addr_no="1" daisng_id="4440236">&lt;display_name>Claure,
+        Rebecca&lt;/display_name>&lt;full_name>Claure, Rebecca&lt;/full_name>&lt;wos_standard>Claure,
+        R&lt;/wos_standard>&lt;first_name>Rebecca&lt;/first_name>&lt;last_name>Claure&lt;/last_name>&lt;/name>&lt;/names>&lt;/address_name>&lt;/addresses>&lt;reprint_addresses
+        count="1">&lt;address_name>&lt;address_spec addr_no="1">&lt;full_address>Stanford
+        Univ, Sch Med, 300 Pasteur, Stanford, CA 94305 USA&lt;/full_address>&lt;organizations
+        count="2">&lt;organization>Stanford Univ&lt;/organization>&lt;organization
+        pref="Y">Stanford University&lt;/organization>&lt;/organizations>&lt;suborganizations
+        count="1">&lt;suborganization>Sch Med&lt;/suborganization>&lt;/suborganizations>&lt;street>300
+        Pasteur&lt;/street>&lt;city>Stanford&lt;/city>&lt;state>CA&lt;/state>&lt;country>USA&lt;/country>&lt;zip
+        location="AP">94305&lt;/zip>&lt;/address_spec>&lt;names count="1">&lt;name
+        seq_no="1" role="author" reprint="Y" addr_no="1">&lt;display_name>Edler, Alice&lt;/display_name>&lt;full_name>Edler,
+        Alice&lt;/full_name>&lt;wos_standard>Edler, A&lt;/wos_standard>&lt;first_name>Alice&lt;/first_name>&lt;last_name>Edler&lt;/last_name>&lt;email_addr>edlera@aol.com&lt;/email_addr>&lt;/name>&lt;/names>&lt;/address_name>&lt;/reprint_addresses>&lt;category_info>&lt;headings
+        count="1">&lt;heading>Science &amp;amp; Technology&lt;/heading>&lt;/headings>&lt;subheadings
+        count="1">&lt;subheading>Life Sciences &amp;amp; Biomedicine&lt;/subheading>&lt;/subheadings>&lt;subjects
+        count="4">&lt;subject ascatype="traditional" code="BA">Anesthesiology&lt;/subject>&lt;subject
+        ascatype="traditional" code="TQ">Pediatrics&lt;/subject>&lt;subject ascatype="extended">Anesthesiology&lt;/subject>&lt;subject
+        ascatype="extended">Pediatrics&lt;/subject>&lt;/subjects>&lt;/category_info>&lt;/fullrecord_metadata>&lt;item
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="itemType_wos"
+        coll_id="WOS">&lt;ids avail="Y">418RK&lt;/ids>&lt;bib_id>19 (4): 406-407 APR
+        2009&lt;/bib_id>&lt;bib_pagecount type="Journal">137&lt;/bib_pagecount>&lt;/item>&lt;/static_data>&lt;dynamic_data>&lt;citation_related>&lt;tc_list>&lt;silo_tc
+        coll_id="WOS" local_count="0">&lt;/silo_tc>&lt;/tc_list>&lt;/citation_related>&lt;cluster_related>&lt;identifiers>&lt;identifier
+        type="issn" value="1155-5645">&lt;/identifier>&lt;identifier type="doi" value="10.1111/j.1460-9592.2009.02945.x">&lt;/identifier>&lt;/identifiers>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;/records></records></return></ns2:retrieveByIdResponse></soap:Body></soap:Envelope>'
+    http_version: 
+  recorded_at: Wed, 03 Apr 2019 23:00:31 GMT
+- request:
+    method: post
+    uri: https://ws.isiknowledge.com/cps/xrpc
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <request xmlns="http://www.isinet.com/xrpc41" src="app.id=API Demo">
+          <fn name="LinksAMR.retrieve">
+            <list>
+              <map>
+                <val name="username">links_username</val>
+                <val name="password">links_password</val>
+              </map>
+              <map>
+                <list name="WOS">
+                    <val>doi</val>
+                    <val>pmid</val>
+                </list>
+              </map>
+              <map>
+                  <map name="cite_WOS:000259817100020">
+                    <val name="ut">WOS:000259817100020</val>
+                  </map>
+                  <map name="cite_WOS:000256730800021">
+                    <val name="ut">WOS:000256730800021</val>
+                  </map>
+                  <map name="cite_WOS:000252230800009">
+                    <val name="ut">WOS:000252230800009</val>
+                  </map>
+                  <map name="cite_WOS:000251905400030">
+                    <val name="ut">WOS:000251905400030</val>
+                  </map>
+                  <map name="cite_WOS:000250317500068">
+                    <val name="ut">WOS:000250317500068</val>
+                  </map>
+                  <map name="cite_WOS:000249038700050">
+                    <val name="ut">WOS:000249038700050</val>
+                  </map>
+                  <map name="cite_WOS:000245371900010">
+                    <val name="ut">WOS:000245371900010</val>
+                  </map>
+                  <map name="cite_WOS:000236198500001">
+                    <val name="ut">WOS:000236198500001</val>
+                  </map>
+                  <map name="cite_WOS:000212958400021">
+                    <val name="ut">WOS:000212958400021</val>
+                  </map>
+                  <map name="cite_WOS:000186655000011">
+                    <val name="ut">WOS:000186655000011</val>
+                  </map>
+                  <map name="cite_WOS:000212962700007">
+                    <val name="ut">WOS:000212962700007</val>
+                  </map>
+                  <map name="cite_WOS:000218296900007">
+                    <val name="ut">WOS:000218296900007</val>
+                  </map>
+                  <map name="cite_WOS:000217248400003">
+                    <val name="ut">WOS:000217248400003</val>
+                  </map>
+                  <map name="cite_WOS:000176711100016">
+                    <val name="ut">WOS:000176711100016</val>
+                  </map>
+                  <map name="cite_WOS:000276938400007">
+                    <val name="ut">WOS:000276938400007</val>
+                  </map>
+                  <map name="cite_WOS:000270210100035">
+                    <val name="ut">WOS:000270210100035</val>
+                  </map>
+                  <map name="cite_WOS:000264165900021">
+                    <val name="ut">WOS:000264165900021</val>
+                  </map>
+              </map>
+            </list>
+          </fn>
+        </request>
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 03 Apr 2019 23:00:31 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Date:
+      - Wed, 03 Apr 2019 23:00:32 GMT
+      Platform:
+      - CPS 2018.R4.0.17
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.25 (Unix) ESTI-Router/4.9.0.10
+      Set-Cookie:
+      - PRODUCT=AMR
+      - PRODUCT=AMR
+      - PRODUCT=AMR
+      - SID=A6Fvf5Vm1xrPfxDlxTQ
+      - SID=A6SFdp2sESfz8UClmZI
+      - SID=A6kzDJ2Hv5EDngCQk6T
+      Content-Length:
+      - '2743'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <response xmlns="http://www.isinet.com/xrpc41" src="app.id=API Demo">
+        <fn name="LinksAMR.retrieve" rc="OK">
+        <map>
+        <map name="cite_WOS:000259817100020">
+        <map name="WOS">
+        <val name="pmid">18717808</val>
+        <val name="doi">10.1111/j.1460-9592.2008.02715.x</val>
+        </map>
+        </map>
+        <map name="cite_WOS:000250317500068">
+        <map name="WOS">
+        <val name="doi">10.1213/01.ane.0000287015.05692.04</val>
+        </map>
+        </map>
+        <map name="cite_WOS:000212962700007">
+        <map name="WOS">
+        <val name="pmid">21134139</val>
+        <val name="doi">10.1111/j.1743-498X.2009.00336.x/full</val>
+        </map>
+        </map>
+        <map name="cite_WOS:000251905400030">
+        <map name="WOS">
+        <val name="pmid">18156902</val>
+        <val name="doi">10.1097/01.anes.0000296648.16232.28</val>
+        </map>
+        </map>
+        <map name="cite_WOS:000212958400021">
+        <map name="WOS">
+        <val name="doi">10.1111/j.1743-498X.2009.00271.x</val>
+        </map>
+        </map>
+        <map name="cite_WOS:000270210100035">
+        <map name="WOS">
+        <val name="pmid">20029255</val>
+        <val name="doi">10.1097/ALN.0b013e3181b43948</val>
+        </map>
+        </map>
+        <map name="cite_WOS:000236198500001">
+        <map name="WOS">
+        <val name="pmid">16517323</val>
+        <val name="doi">10.1016/j.jclinane.2005.12.004</val>
+        </map>
+        </map>
+        <map name="cite_WOS:000245371900010">
+        <map name="WOS">
+        <val name="pmid">17377083</val>
+        <val name="doi">10.1213/01.ane.0000258771.53068.09</val>
+        </map>
+        </map>
+        <map name="cite_WOS:000252230800009">
+        <map name="WOS">
+        <val name="pmid">18083476</val>
+        <val name="doi">10.1016/j.jclinane.2007.03.009</val>
+        </map>
+        </map>
+        <map name="cite_WOS:000217248400003">
+        <map name="WOS">
+        <val name="pmid">20046456</val>
+        <val name="doi">10.3352/jeehp.2009.6.3</val>
+        </map>
+        </map>
+        <map name="cite_WOS:000176711100016">
+        <map name="WOS">
+        <val name="pmid">12095380</val>
+        <val name="doi">10.1001/jama.288.2.166</val>
+        </map>
+        </map>
+        <map name="cite_WOS:000256730800021">
+        <map name="WOS">
+        <val name="pmid">18502376</val>
+        <val name="doi">10.1016/j.jclinane.2008.01.002</val>
+        </map>
+        </map>
+        <map name="cite_WOS:000249038700050">
+        <map name="WOS">
+        <val name="pmid">17713387</val>
+        <val name="doi">10.1097/01.CCM.0000281643.88046.DC</val>
+        </map>
+        </map>
+        <map name="cite_WOS:000186655000011">
+        <map name="WOS">
+        <val name="pmid">14617124</val>
+        <val name="doi">10.1046/j.1460-9592.2003.01171.x</val>
+        </map>
+        </map>
+        <map name="cite_WOS:000264165900021">
+        <map name="WOS">
+        <val name="pmid">19335353</val>
+        <val name="doi">10.1111/j.1460-9592.2009.02945.x</val>
+        </map>
+        </map>
+        <map name="cite_WOS:000218296900007">
+        <map name="WOS">
+        <val name="pmid">20386227</val>
+        <val name="doi">10.1097/AIA.0b013e3181cd15ef</val>
+        </map>
+        </map>
+        <map name="cite_WOS:000276938400007">
+        <map name="WOS">
+        <val name="pmid">20661010</val>
+        <val name="doi">10.1097/SIH.0b013e3181c76332</val>
+        </map>
+        </map>
+        </map>
+        </fn>
+        </response>
+    http_version: 
+  recorded_at: Wed, 03 Apr 2019 23:00:32 GMT
+- request:
+    method: post
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=Settings.PUBMED.API_KEY&db=pubmed&retmode=xml
+    body:
+      encoding: UTF-8
+      string: "&id=&id=18717808"
+    headers:
+      User-Agent:
+      - stanford-library-sul-pub
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 03 Apr 2019 23:00:35 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 03 Apr 2019 23:00:35 GMT
+      Server:
+      - Finatra
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Ratelimit-Remaining:
+      - '9'
+      Ncbi-Phid:
+      - D0BDAAD496ED878500002691AE6207AA.1.1.m_3
+      Cache-Control:
+      - private
+      L5d-Success-Class:
+      - '1.0'
+      Ncbi-Sid:
+      - 5C56991BA7711E6F_6040SID
+      Content-Encoding:
+      - gzip
+      X-Ratelimit-Limit:
+      - '10'
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Set-Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID; domain=.nih.gov; path=/; expires=Fri, 03
+        Apr 2020 23:00:35 GMT
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" ?>
+        <!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2019//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_190101.dtd">
+        <PubmedArticleSet>
+        <PubmedArticle>
+            <MedlineCitation Status="MEDLINE" Owner="NLM">
+                <PMID Version="1">18717808</PMID>
+                <DateCompleted>
+                    <Year>2009</Year>
+                    <Month>01</Month>
+                    <Day>02</Day>
+                </DateCompleted>
+                <DateRevised>
+                    <Year>2008</Year>
+                    <Month>10</Month>
+                    <Day>27</Day>
+                </DateRevised>
+                <Article PubModel="Print-Electronic">
+                    <Journal>
+                        <ISSN IssnType="Electronic">1460-9592</ISSN>
+                        <JournalIssue CitedMedium="Internet">
+                            <Volume>18</Volume>
+                            <Issue>11</Issue>
+                            <PubDate>
+                                <Year>2008</Year>
+                                <Month>Nov</Month>
+                            </PubDate>
+                        </JournalIssue>
+                        <Title>Paediatric anaesthesia</Title>
+                        <ISOAbbreviation>Paediatr Anaesth</ISOAbbreviation>
+                    </Journal>
+                    <ArticleTitle>Improving electrical safety for patients with Epidermolysis bullosa.</ArticleTitle>
+                    <Pagination>
+                        <MedlinePgn>1107-9</MedlinePgn>
+                    </Pagination>
+                    <ELocationID EIdType="doi" ValidYN="Y">10.1111/j.1460-9592.2008.02715.x</ELocationID>
+                    <AuthorList CompleteYN="Y">
+                        <Author ValidYN="Y">
+                            <LastName>Edler</LastName>
+                            <ForeName>Alice A</ForeName>
+                            <Initials>AA</Initials>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Ramamurthi</LastName>
+                            <ForeName>Radhamangalam J</ForeName>
+                            <Initials>RJ</Initials>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Valenzuela</LastName>
+                            <ForeName>Glenn A</ForeName>
+                            <Initials>GA</Initials>
+                        </Author>
+                    </AuthorList>
+                    <Language>eng</Language>
+                    <PublicationTypeList>
+                        <PublicationType UI="D016422">Letter</PublicationType>
+                    </PublicationTypeList>
+                    <ArticleDate DateType="Electronic">
+                        <Year>2008</Year>
+                        <Month>08</Month>
+                        <Day>19</Day>
+                    </ArticleDate>
+                </Article>
+                <MedlineJournalInfo>
+                    <Country>France</Country>
+                    <MedlineTA>Paediatr Anaesth</MedlineTA>
+                    <NlmUniqueID>9206575</NlmUniqueID>
+                    <ISSNLinking>1155-5645</ISSNLinking>
+                </MedlineJournalInfo>
+                <CitationSubset>IM</CitationSubset>
+                <MeshHeadingList>
+                    <MeshHeading>
+                        <DescriptorName UI="D002648" MajorTopicYN="N">Child</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D004559" MajorTopicYN="N">Electric Wiring</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D004562" MajorTopicYN="N">Electrocardiography</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D004820" MajorTopicYN="N">Epidermolysis Bullosa</DescriptorName>
+                        <QualifierName UI="Q000150" MajorTopicYN="Y">complications</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D004867" MajorTopicYN="N">Equipment Design</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D017592" MajorTopicYN="N">Skin Care</DescriptorName>
+                        <QualifierName UI="Q000295" MajorTopicYN="Y">instrumentation</QualifierName>
+                        <QualifierName UI="Q000379" MajorTopicYN="N">methods</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D013514" MajorTopicYN="Y">Surgical Procedures, Operative</DescriptorName>
+                    </MeshHeading>
+                </MeshHeadingList>
+            </MedlineCitation>
+            <PubmedData>
+                <History>
+                    <PubMedPubDate PubStatus="pubmed">
+                        <Year>2008</Year>
+                        <Month>8</Month>
+                        <Day>23</Day>
+                        <Hour>9</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="medline">
+                        <Year>2009</Year>
+                        <Month>1</Month>
+                        <Day>3</Day>
+                        <Hour>9</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="entrez">
+                        <Year>2008</Year>
+                        <Month>8</Month>
+                        <Day>23</Day>
+                        <Hour>9</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                </History>
+                <PublicationStatus>ppublish</PublicationStatus>
+                <ArticleIdList>
+                    <ArticleId IdType="pubmed">18717808</ArticleId>
+                    <ArticleId IdType="pii">PAN2715</ArticleId>
+                    <ArticleId IdType="doi">10.1111/j.1460-9592.2008.02715.x</ArticleId>
+                </ArticleIdList>
+            </PubmedData>
+        </PubmedArticle>
+
+        </PubmedArticleSet>
+    http_version: 
+  recorded_at: Wed, 03 Apr 2019 23:00:35 GMT
+- request:
+    method: post
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=Settings.PUBMED.API_KEY&db=pubmed&retmode=xml
+    body:
+      encoding: UTF-8
+      string: "&id=&id=18502376"
+    headers:
+      User-Agent:
+      - stanford-library-sul-pub
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 03 Apr 2019 23:00:35 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 03 Apr 2019 23:00:35 GMT
+      Server:
+      - Finatra
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Ratelimit-Remaining:
+      - '8'
+      Ncbi-Phid:
+      - D0BDAAD496ED878500001391AEE67CE9.1.1.m_3
+      Cache-Control:
+      - private
+      L5d-Success-Class:
+      - '1.0'
+      Ncbi-Sid:
+      - 5C56991BA7711E6F_6040SID
+      Content-Encoding:
+      - gzip
+      X-Ratelimit-Limit:
+      - '10'
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Set-Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID; domain=.nih.gov; path=/; expires=Fri, 03
+        Apr 2020 23:00:36 GMT
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" ?>
+        <!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2019//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_190101.dtd">
+        <PubmedArticleSet>
+        <PubmedArticle>
+            <MedlineCitation Status="MEDLINE" Owner="NLM">
+                <PMID Version="1">18502376</PMID>
+                <DateCompleted>
+                    <Year>2008</Year>
+                    <Month>10</Month>
+                    <Day>17</Day>
+                </DateCompleted>
+                <DateRevised>
+                    <Year>2008</Year>
+                    <Month>05</Month>
+                    <Day>26</Day>
+                </DateRevised>
+                <Article PubModel="Print">
+                    <Journal>
+                        <ISSN IssnType="Print">0952-8180</ISSN>
+                        <JournalIssue CitedMedium="Print">
+                            <Volume>20</Volume>
+                            <Issue>3</Issue>
+                            <PubDate>
+                                <Year>2008</Year>
+                                <Month>May</Month>
+                            </PubDate>
+                        </JournalIssue>
+                        <Title>Journal of clinical anesthesia</Title>
+                        <ISOAbbreviation>J Clin Anesth</ISOAbbreviation>
+                    </Journal>
+                    <ArticleTitle>Training attendings to be expert teachers: the Stanford Anesthesia Teaching Scholars program.</ArticleTitle>
+                    <Pagination>
+                        <MedlinePgn>241-2</MedlinePgn>
+                    </Pagination>
+                    <ELocationID EIdType="doi" ValidYN="Y">10.1016/j.jclinane.2008.01.002</ELocationID>
+                    <AuthorList CompleteYN="Y">
+                        <Author ValidYN="Y">
+                            <LastName>Macario</LastName>
+                            <ForeName>Alex</ForeName>
+                            <Initials>A</Initials>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Edler</LastName>
+                            <ForeName>Alice</ForeName>
+                            <Initials>A</Initials>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Pearl</LastName>
+                            <ForeName>Ronald</ForeName>
+                            <Initials>R</Initials>
+                        </Author>
+                    </AuthorList>
+                    <Language>eng</Language>
+                    <PublicationTypeList>
+                        <PublicationType UI="D016422">Letter</PublicationType>
+                    </PublicationTypeList>
+                </Article>
+                <MedlineJournalInfo>
+                    <Country>United States</Country>
+                    <MedlineTA>J Clin Anesth</MedlineTA>
+                    <NlmUniqueID>8812166</NlmUniqueID>
+                    <ISSNLinking>0952-8180</ISSNLinking>
+                </MedlineJournalInfo>
+                <CitationSubset>IM</CitationSubset>
+                <MeshHeadingList>
+                    <MeshHeading>
+                        <DescriptorName UI="D000758" MajorTopicYN="N">Anesthesia</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D000776" MajorTopicYN="N">Anesthesiology</DescriptorName>
+                        <QualifierName UI="Q000193" MajorTopicYN="Y">education</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D007396" MajorTopicYN="N">Internship and Residency</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D012577" MajorTopicYN="N">Schools, Medical</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D013663" MajorTopicYN="N">Teaching</DescriptorName>
+                    </MeshHeading>
+                </MeshHeadingList>
+            </MedlineCitation>
+            <PubmedData>
+                <History>
+                    <PubMedPubDate PubStatus="received">
+                        <Year>2007</Year>
+                        <Month>12</Month>
+                        <Day>17</Day>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="accepted">
+                        <Year>2008</Year>
+                        <Month>01</Month>
+                        <Day>22</Day>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="pubmed">
+                        <Year>2008</Year>
+                        <Month>5</Month>
+                        <Day>27</Day>
+                        <Hour>9</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="medline">
+                        <Year>2008</Year>
+                        <Month>10</Month>
+                        <Day>18</Day>
+                        <Hour>9</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="entrez">
+                        <Year>2008</Year>
+                        <Month>5</Month>
+                        <Day>27</Day>
+                        <Hour>9</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                </History>
+                <PublicationStatus>ppublish</PublicationStatus>
+                <ArticleIdList>
+                    <ArticleId IdType="pubmed">18502376</ArticleId>
+                    <ArticleId IdType="pii">S0952-8180(08)00010-X</ArticleId>
+                    <ArticleId IdType="doi">10.1016/j.jclinane.2008.01.002</ArticleId>
+                </ArticleIdList>
+            </PubmedData>
+        </PubmedArticle>
+
+        </PubmedArticleSet>
+    http_version: 
+  recorded_at: Wed, 03 Apr 2019 23:00:36 GMT
+- request:
+    method: post
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=Settings.PUBMED.API_KEY&db=pubmed&retmode=xml
+    body:
+      encoding: UTF-8
+      string: "&id=&id=18083476"
+    headers:
+      User-Agent:
+      - stanford-library-sul-pub
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 03 Apr 2019 23:00:36 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 03 Apr 2019 23:00:36 GMT
+      Server:
+      - Finatra
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Ratelimit-Remaining:
+      - '7'
+      Ncbi-Phid:
+      - D0BDAAD496ED878500002791AF6B7F68.1.1.m_3
+      Cache-Control:
+      - private
+      L5d-Success-Class:
+      - '1.0'
+      Ncbi-Sid:
+      - 5C56991BA7711E6F_6040SID
+      Content-Encoding:
+      - gzip
+      X-Ratelimit-Limit:
+      - '10'
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Set-Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID; domain=.nih.gov; path=/; expires=Fri, 03
+        Apr 2020 23:00:36 GMT
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" ?>
+        <!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2019//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_190101.dtd">
+        <PubmedArticleSet>
+        <PubmedArticle>
+            <MedlineCitation Status="MEDLINE" Owner="NLM">
+                <PMID Version="1">18083476</PMID>
+                <DateCompleted>
+                    <Year>2008</Year>
+                    <Month>03</Month>
+                    <Day>31</Day>
+                </DateCompleted>
+                <DateRevised>
+                    <Year>2007</Year>
+                    <Month>12</Month>
+                    <Day>17</Day>
+                </DateRevised>
+                <Article PubModel="Print">
+                    <Journal>
+                        <ISSN IssnType="Print">0952-8180</ISSN>
+                        <JournalIssue CitedMedium="Print">
+                            <Volume>19</Volume>
+                            <Issue>8</Issue>
+                            <PubDate>
+                                <Year>2007</Year>
+                                <Month>Dec</Month>
+                            </PubDate>
+                        </JournalIssue>
+                        <Title>Journal of clinical anesthesia</Title>
+                        <ISOAbbreviation>J Clin Anesth</ISOAbbreviation>
+                    </Journal>
+                    <ArticleTitle>Special anesthetic considerations for stereotactic radiosurgery in children.</ArticleTitle>
+                    <Pagination>
+                        <MedlinePgn>616-8</MedlinePgn>
+                    </Pagination>
+                    <Abstract>
+                        <AbstractText>Children present special anesthetic considerations, not only in their unique pharmacologic and physiologic attributes but also in the types of anesthetic care they require. A new neurosurgical technique, the gamma knife, is particularly challenging for pediatric anesthesia providers because of its extended duration, multiple site procedures, and anesthetic requirements associated with the use of a stereotactic frame.</AbstractText>
+                    </Abstract>
+                    <AuthorList CompleteYN="Y">
+                        <Author ValidYN="Y">
+                            <LastName>Edler</LastName>
+                            <ForeName>Alice</ForeName>
+                            <Initials>A</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>Department of Anesthesia, Stanford University School of Medicine, Stanford, CA 94305-5640, USA. edlera@stanford.edu</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                    </AuthorList>
+                    <Language>eng</Language>
+                    <PublicationTypeList>
+                        <PublicationType UI="D002363">Case Reports</PublicationType>
+                        <PublicationType UI="D016428">Journal Article</PublicationType>
+                    </PublicationTypeList>
+                </Article>
+                <MedlineJournalInfo>
+                    <Country>United States</Country>
+                    <MedlineTA>J Clin Anesth</MedlineTA>
+                    <NlmUniqueID>8812166</NlmUniqueID>
+                    <ISSNLinking>0952-8180</ISSNLinking>
+                </MedlineJournalInfo>
+                <CitationSubset>IM</CitationSubset>
+                <MeshHeadingList>
+                    <MeshHeading>
+                        <DescriptorName UI="D000293" MajorTopicYN="N">Adolescent</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D000758" MajorTopicYN="N">Anesthesia</DescriptorName>
+                        <QualifierName UI="Q000009" MajorTopicYN="N">adverse effects</QualifierName>
+                        <QualifierName UI="Q000379" MajorTopicYN="Y">methods</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D000768" MajorTopicYN="N">Anesthesia, General</DescriptorName>
+                        <QualifierName UI="Q000009" MajorTopicYN="N">adverse effects</QualifierName>
+                        <QualifierName UI="Q000379" MajorTopicYN="N">methods</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D001165" MajorTopicYN="N">Arteriovenous Malformations</DescriptorName>
+                        <QualifierName UI="Q000601" MajorTopicYN="Y">surgery</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D002528" MajorTopicYN="N">Cerebellar Neoplasms</DescriptorName>
+                        <QualifierName UI="Q000601" MajorTopicYN="Y">surgery</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D002648" MajorTopicYN="N">Child</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D002675" MajorTopicYN="N">Child, Preschool</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D016292" MajorTopicYN="N">Conscious Sedation</DescriptorName>
+                        <QualifierName UI="Q000009" MajorTopicYN="N">adverse effects</QualifierName>
+                        <QualifierName UI="Q000379" MajorTopicYN="N">methods</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D009373" MajorTopicYN="N">Neoplasms, Germ Cell and Embryonal</DescriptorName>
+                        <QualifierName UI="Q000556" MajorTopicYN="N">secondary</QualifierName>
+                        <QualifierName UI="Q000601" MajorTopicYN="Y">surgery</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D017253" MajorTopicYN="N">Neurofibromatoses</DescriptorName>
+                        <QualifierName UI="Q000601" MajorTopicYN="Y">surgery</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D016634" MajorTopicYN="N">Radiosurgery</DescriptorName>
+                        <QualifierName UI="Q000379" MajorTopicYN="Y">methods</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D013995" MajorTopicYN="N">Time</DescriptorName>
+                    </MeshHeading>
+                </MeshHeadingList>
+            </MedlineCitation>
+            <PubmedData>
+                <History>
+                    <PubMedPubDate PubStatus="received">
+                        <Year>2006</Year>
+                        <Month>07</Month>
+                        <Day>06</Day>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="revised">
+                        <Year>2007</Year>
+                        <Month>03</Month>
+                        <Day>15</Day>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="accepted">
+                        <Year>2007</Year>
+                        <Month>03</Month>
+                        <Day>20</Day>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="pubmed">
+                        <Year>2007</Year>
+                        <Month>12</Month>
+                        <Day>18</Day>
+                        <Hour>9</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="medline">
+                        <Year>2008</Year>
+                        <Month>4</Month>
+                        <Day>1</Day>
+                        <Hour>9</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="entrez">
+                        <Year>2007</Year>
+                        <Month>12</Month>
+                        <Day>18</Day>
+                        <Hour>9</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                </History>
+                <PublicationStatus>ppublish</PublicationStatus>
+                <ArticleIdList>
+                    <ArticleId IdType="pubmed">18083476</ArticleId>
+                    <ArticleId IdType="pii">S0952-8180(07)00208-5</ArticleId>
+                    <ArticleId IdType="doi">10.1016/j.jclinane.2007.03.009</ArticleId>
+                </ArticleIdList>
+            </PubmedData>
+        </PubmedArticle>
+
+        </PubmedArticleSet>
+    http_version: 
+  recorded_at: Wed, 03 Apr 2019 23:00:36 GMT
+- request:
+    method: post
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=Settings.PUBMED.API_KEY&db=pubmed&retmode=xml
+    body:
+      encoding: UTF-8
+      string: "&id=&id=18156902"
+    headers:
+      User-Agent:
+      - stanford-library-sul-pub
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 03 Apr 2019 23:00:36 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 03 Apr 2019 23:00:36 GMT
+      Server:
+      - Finatra
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Ratelimit-Remaining:
+      - '6'
+      Ncbi-Phid:
+      - D0BDAAD496ED878500002691AFE11FEA.1.1.m_3
+      Cache-Control:
+      - private
+      L5d-Success-Class:
+      - '1.0'
+      Ncbi-Sid:
+      - 5C56991BA7711E6F_6040SID
+      Content-Encoding:
+      - gzip
+      X-Ratelimit-Limit:
+      - '10'
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Set-Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID; domain=.nih.gov; path=/; expires=Fri, 03
+        Apr 2020 23:00:36 GMT
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" ?>
+        <!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2019//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_190101.dtd">
+        <PubmedArticleSet>
+        <PubmedArticle>
+            <MedlineCitation Status="MEDLINE" Owner="NLM">
+                <PMID Version="1">18156902</PMID>
+                <DateCompleted>
+                    <Year>2008</Year>
+                    <Month>01</Month>
+                    <Day>23</Day>
+                </DateCompleted>
+                <DateRevised>
+                    <Year>2007</Year>
+                    <Month>12</Month>
+                    <Day>24</Day>
+                </DateRevised>
+                <Article PubModel="Print">
+                    <Journal>
+                        <ISSN IssnType="Electronic">1528-1175</ISSN>
+                        <JournalIssue CitedMedium="Internet">
+                            <Volume>108</Volume>
+                            <Issue>1</Issue>
+                            <PubDate>
+                                <Year>2008</Year>
+                                <Month>Jan</Month>
+                            </PubDate>
+                        </JournalIssue>
+                        <Title>Anesthesiology</Title>
+                        <ISOAbbreviation>Anesthesiology</ISOAbbreviation>
+                    </Journal>
+                    <ArticleTitle>The use of simulation education in competency assessment: more questions than answers.</ArticleTitle>
+                    <Pagination>
+                        <MedlinePgn>167; author reply 167-8</MedlinePgn>
+                    </Pagination>
+                    <AuthorList CompleteYN="Y">
+                        <Author ValidYN="Y">
+                            <LastName>Edler</LastName>
+                            <ForeName>Alice A</ForeName>
+                            <Initials>AA</Initials>
+                        </Author>
+                    </AuthorList>
+                    <Language>eng</Language>
+                    <PublicationTypeList>
+                        <PublicationType UI="D016420">Comment</PublicationType>
+                        <PublicationType UI="D016422">Letter</PublicationType>
+                    </PublicationTypeList>
+                </Article>
+                <MedlineJournalInfo>
+                    <Country>United States</Country>
+                    <MedlineTA>Anesthesiology</MedlineTA>
+                    <NlmUniqueID>1300217</NlmUniqueID>
+                    <ISSNLinking>0003-3022</ISSNLinking>
+                </MedlineJournalInfo>
+                <CitationSubset>AIM</CitationSubset>
+                <CitationSubset>IM</CitationSubset>
+                <CommentsCorrectionsList>
+                    <CommentsCorrections RefType="CommentOn">
+                        <RefSource>Anesthesiology. 2007 May;106(5):895-6</RefSource>
+                        <PMID Version="1">17457117</PMID>
+                    </CommentsCorrections>
+                    <CommentsCorrections RefType="CommentOn">
+                        <RefSource>Anesthesiology. 2007 May;106(5):907-15</RefSource>
+                        <PMID Version="1">17457121</PMID>
+                    </CommentsCorrections>
+                </CommentsCorrectionsList>
+                <MeshHeadingList>
+                    <MeshHeading>
+                        <DescriptorName UI="D003162" MajorTopicYN="N">Competency-Based Education</DescriptorName>
+                        <QualifierName UI="Q000379" MajorTopicYN="N">methods</QualifierName>
+                        <QualifierName UI="Q000592" MajorTopicYN="Y">standards</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D004522" MajorTopicYN="N">Educational Status</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D013663" MajorTopicYN="N">Teaching</DescriptorName>
+                        <QualifierName UI="Q000379" MajorTopicYN="N">methods</QualifierName>
+                        <QualifierName UI="Q000592" MajorTopicYN="Y">standards</QualifierName>
+                    </MeshHeading>
+                </MeshHeadingList>
+            </MedlineCitation>
+            <PubmedData>
+                <History>
+                    <PubMedPubDate PubStatus="pubmed">
+                        <Year>2007</Year>
+                        <Month>12</Month>
+                        <Day>25</Day>
+                        <Hour>9</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="medline">
+                        <Year>2008</Year>
+                        <Month>1</Month>
+                        <Day>24</Day>
+                        <Hour>9</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="entrez">
+                        <Year>2007</Year>
+                        <Month>12</Month>
+                        <Day>25</Day>
+                        <Hour>9</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                </History>
+                <PublicationStatus>ppublish</PublicationStatus>
+                <ArticleIdList>
+                    <ArticleId IdType="pubmed">18156902</ArticleId>
+                    <ArticleId IdType="doi">10.1097/01.anes.0000296648.16232.28</ArticleId>
+                    <ArticleId IdType="pii">00000542-200801000-00031</ArticleId>
+                </ArticleIdList>
+            </PubmedData>
+        </PubmedArticle>
+
+        </PubmedArticleSet>
+    http_version: 
+  recorded_at: Wed, 03 Apr 2019 23:00:36 GMT
+- request:
+    method: post
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=Settings.PUBMED.API_KEY&db=pubmed&retmode=xml
+    body:
+      encoding: UTF-8
+      string: "&id=&id=17713387"
+    headers:
+      User-Agent:
+      - stanford-library-sul-pub
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 03 Apr 2019 23:00:36 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID
+      Content-Length:
+      - '16'
+      Host:
+      - eutils.ncbi.nlm.nih.gov
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 03 Apr 2019 23:00:37 GMT
+      Server:
+      - Finatra
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Ratelimit-Remaining:
+      - '7'
+      Ncbi-Phid:
+      - D0BDAAD496ED878500002591B15EB69F.1.1.m_3
+      Cache-Control:
+      - private
+      L5d-Success-Class:
+      - '1.0'
+      Ncbi-Sid:
+      - 5C56991BA7711E6F_6040SID
+      Content-Encoding:
+      - gzip
+      X-Ratelimit-Limit:
+      - '10'
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Set-Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID; domain=.nih.gov; path=/; expires=Fri, 03
+        Apr 2020 23:00:37 GMT
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" ?>
+        <!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2019//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_190101.dtd">
+        <PubmedArticleSet>
+        <PubmedArticle>
+            <MedlineCitation Status="MEDLINE" Owner="NLM">
+                <PMID Version="1">17713387</PMID>
+                <DateCompleted>
+                    <Year>2007</Year>
+                    <Month>09</Month>
+                    <Day>28</Day>
+                </DateCompleted>
+                <DateRevised>
+                    <Year>2007</Year>
+                    <Month>11</Month>
+                    <Day>15</Day>
+                </DateRevised>
+                <Article PubModel="Print">
+                    <Journal>
+                        <ISSN IssnType="Print">0090-3493</ISSN>
+                        <JournalIssue CitedMedium="Print">
+                            <Volume>35</Volume>
+                            <Issue>9</Issue>
+                            <PubDate>
+                                <Year>2007</Year>
+                                <Month>Sep</Month>
+                            </PubDate>
+                        </JournalIssue>
+                        <Title>Critical care medicine</Title>
+                        <ISOAbbreviation>Crit. Care Med.</ISOAbbreviation>
+                    </Journal>
+                    <ArticleTitle>&quot;A rose by any other name&quot;? Toward a common terminology in simulation education and assessment.</ArticleTitle>
+                    <Pagination>
+                        <MedlinePgn>2237-8; author reply 2238</MedlinePgn>
+                    </Pagination>
+                    <AuthorList CompleteYN="Y">
+                        <Author ValidYN="Y">
+                            <LastName>Edler</LastName>
+                            <ForeName>Alice A</ForeName>
+                            <Initials>AA</Initials>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Fanning</LastName>
+                            <ForeName>Ruth M</ForeName>
+                            <Initials>RM</Initials>
+                        </Author>
+                    </AuthorList>
+                    <Language>eng</Language>
+                    <PublicationTypeList>
+                        <PublicationType UI="D016420">Comment</PublicationType>
+                        <PublicationType UI="D016422">Letter</PublicationType>
+                    </PublicationTypeList>
+                </Article>
+                <MedlineJournalInfo>
+                    <Country>United States</Country>
+                    <MedlineTA>Crit Care Med</MedlineTA>
+                    <NlmUniqueID>0355501</NlmUniqueID>
+                    <ISSNLinking>0090-3493</ISSNLinking>
+                </MedlineJournalInfo>
+                <CitationSubset>AIM</CitationSubset>
+                <CitationSubset>IM</CitationSubset>
+                <CommentsCorrectionsList>
+                    <CommentsCorrections RefType="CommentOn">
+                        <RefSource>Crit Care Med. 2007 Mar;35(3):738-54</RefSource>
+                        <PMID Version="1">17255866</PMID>
+                    </CommentsCorrections>
+                </CommentsCorrectionsList>
+                <MeshHeadingList>
+                    <MeshHeading>
+                        <DescriptorName UI="D003162" MajorTopicYN="N">Competency-Based Education</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D003198" MajorTopicYN="N">Computer Simulation</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D003422" MajorTopicYN="N">Critical Care</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D004503" MajorTopicYN="N">Education, Medical, Graduate</DescriptorName>
+                        <QualifierName UI="Q000379" MajorTopicYN="Y">methods</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D004521" MajorTopicYN="N">Educational Measurement</DescriptorName>
+                        <QualifierName UI="Q000379" MajorTopicYN="Y">methods</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D009626" MajorTopicYN="Y">Terminology as Topic</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D014481" MajorTopicYN="N" Type="Geographic">United States</DescriptorName>
+                    </MeshHeading>
+                </MeshHeadingList>
+            </MedlineCitation>
+            <PubmedData>
+                <History>
+                    <PubMedPubDate PubStatus="pubmed">
+                        <Year>2007</Year>
+                        <Month>8</Month>
+                        <Day>24</Day>
+                        <Hour>9</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="medline">
+                        <Year>2007</Year>
+                        <Month>9</Month>
+                        <Day>29</Day>
+                        <Hour>9</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="entrez">
+                        <Year>2007</Year>
+                        <Month>8</Month>
+                        <Day>24</Day>
+                        <Hour>9</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                </History>
+                <PublicationStatus>ppublish</PublicationStatus>
+                <ArticleIdList>
+                    <ArticleId IdType="pubmed">17713387</ArticleId>
+                    <ArticleId IdType="doi">10.1097/01.CCM.0000281643.88046.DC</ArticleId>
+                    <ArticleId IdType="pii">00003246-200709000-00051</ArticleId>
+                </ArticleIdList>
+            </PubmedData>
+        </PubmedArticle>
+
+        </PubmedArticleSet>
+    http_version: 
+  recorded_at: Wed, 03 Apr 2019 23:00:37 GMT
+- request:
+    method: post
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=Settings.PUBMED.API_KEY&db=pubmed&retmode=xml
+    body:
+      encoding: UTF-8
+      string: "&id=&id=17377083"
+    headers:
+      User-Agent:
+      - stanford-library-sul-pub
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 03 Apr 2019 23:00:37 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 03 Apr 2019 23:00:37 GMT
+      Server:
+      - Finatra
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Ratelimit-Remaining:
+      - '7'
+      Ncbi-Phid:
+      - D0BDAAD496ED878500002591B214742D.1.1.m_3
+      Cache-Control:
+      - private
+      L5d-Success-Class:
+      - '1.0'
+      Ncbi-Sid:
+      - 5C56991BA7711E6F_6040SID
+      Content-Encoding:
+      - gzip
+      X-Ratelimit-Limit:
+      - '10'
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Set-Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID; domain=.nih.gov; path=/; expires=Fri, 03
+        Apr 2020 23:00:37 GMT
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" ?>
+        <!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2019//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_190101.dtd">
+        <PubmedArticleSet>
+        <PubmedArticle>
+            <MedlineCitation Status="MEDLINE" Owner="NLM">
+                <PMID Version="1">17377083</PMID>
+                <DateCompleted>
+                    <Year>2007</Year>
+                    <Month>04</Month>
+                    <Day>12</Day>
+                </DateCompleted>
+                <DateRevised>
+                    <Year>2013</Year>
+                    <Month>11</Month>
+                    <Day>21</Day>
+                </DateRevised>
+                <Article PubModel="Print">
+                    <Journal>
+                        <ISSN IssnType="Electronic">1526-7598</ISSN>
+                        <JournalIssue CitedMedium="Internet">
+                            <Volume>104</Volume>
+                            <Issue>4</Issue>
+                            <PubDate>
+                                <Year>2007</Year>
+                                <Month>Apr</Month>
+                            </PubDate>
+                        </JournalIssue>
+                        <Title>Anesthesia and analgesia</Title>
+                        <ISOAbbreviation>Anesth. Analg.</ISOAbbreviation>
+                    </Journal>
+                    <ArticleTitle>An analysis of factors influencing postanesthesia recovery after pediatric ambulatory tonsillectomy and adenoidectomy.</ArticleTitle>
+                    <Pagination>
+                        <MedlinePgn>784-9</MedlinePgn>
+                    </Pagination>
+                    <Abstract>
+                        <AbstractText Label="BACKGROUND" NlmCategory="BACKGROUND">Many factors contribute to prolonged length of stay (LOS) for pediatric patients in the postanesthesia care unit (PACU). We designed this prospective study to identify the pre- and postoperative factors that prolong LOS.</AbstractText>
+                        <AbstractText Label="METHODS" NlmCategory="METHODS">We studied 166 children, aged 1-18 yr, who underwent tonsillectomy and adenoidectomy or tonsillectomy and adenoidectomy, and bilateral myringotomy with tube insertion under general anesthesia. The primary outcome measure was the time spent in the PACU until predetermined discharge criteria were met.</AbstractText>
+                        <AbstractText Label="RESULTS" NlmCategory="RESULTS">The number of episodes of postoperative nausea and vomiting, patient age, and number of oxygen desaturations contributed significantly (P &lt; 0.05) to prolonged LOS. Each episode of postoperative nausea and vomiting (P &lt; 0.05) or oxygen desaturation to &lt;95% (P &lt; 0.05) increased the patient's LOS by 0.5 h. History of upper respiratory tract infection, emergence agitation, and parental anxiety did not significantly predict increased LOS.</AbstractText>
+                        <AbstractText Label="CONCLUSION" NlmCategory="CONCLUSIONS">This investigation is the first composite view of LOS in pediatric patients. The significance of identifying patients at risk of prolonged LOS prior to anesthesia is of use not only in allocating PACU resource and staffing needs, but also for improving quality of care and ensuring a minimally traumatic anesthetic experience for our pediatric patients and their families.</AbstractText>
+                    </Abstract>
+                    <AuthorList CompleteYN="Y">
+                        <Author ValidYN="Y">
+                            <LastName>Edler</LastName>
+                            <ForeName>Alice A</ForeName>
+                            <Initials>AA</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>Department of Anesthesia, Lucile Packard Children's Hospital, Stanford University School of Medicine, Stanford, California 94305, USA. edlera@aol.com</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Mariano</LastName>
+                            <ForeName>Edward R</ForeName>
+                            <Initials>ER</Initials>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Golianu</LastName>
+                            <ForeName>Brenda</ForeName>
+                            <Initials>B</Initials>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Kuan</LastName>
+                            <ForeName>Calvin</ForeName>
+                            <Initials>C</Initials>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Pentcheva</LastName>
+                            <ForeName>Krassimira</ForeName>
+                            <Initials>K</Initials>
+                        </Author>
+                    </AuthorList>
+                    <Language>eng</Language>
+                    <PublicationTypeList>
+                        <PublicationType UI="D016428">Journal Article</PublicationType>
+                    </PublicationTypeList>
+                </Article>
+                <MedlineJournalInfo>
+                    <Country>United States</Country>
+                    <MedlineTA>Anesth Analg</MedlineTA>
+                    <NlmUniqueID>1310650</NlmUniqueID>
+                    <ISSNLinking>0003-2999</ISSNLinking>
+                </MedlineJournalInfo>
+                <ChemicalList>
+                    <Chemical>
+                        <RegistryNumber>S88TT14065</RegistryNumber>
+                        <NameOfSubstance UI="D010100">Oxygen</NameOfSubstance>
+                    </Chemical>
+                </ChemicalList>
+                <CitationSubset>AIM</CitationSubset>
+                <CitationSubset>IM</CitationSubset>
+                <CommentsCorrectionsList>
+                    <CommentsCorrections RefType="CommentIn">
+                        <RefSource>Anesth Analg. 2007 Nov;105(5):1512-3; author reply 1513</RefSource>
+                        <PMID Version="1">17959997</PMID>
+                    </CommentsCorrections>
+                </CommentsCorrectionsList>
+                <MeshHeadingList>
+                    <MeshHeading>
+                        <DescriptorName UI="D000233" MajorTopicYN="Y">Adenoidectomy</DescriptorName>
+                        <QualifierName UI="Q000706" MajorTopicYN="N">statistics &amp; numerical data</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D000293" MajorTopicYN="N">Adolescent</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D000367" MajorTopicYN="N">Age Factors</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D000556" MajorTopicYN="Y">Ambulatory Surgical Procedures</DescriptorName>
+                        <QualifierName UI="Q000706" MajorTopicYN="N">statistics &amp; numerical data</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D000762" MajorTopicYN="Y">Anesthesia Recovery Period</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D000768" MajorTopicYN="N">Anesthesia, General</DescriptorName>
+                        <QualifierName UI="Q000706" MajorTopicYN="Y">statistics &amp; numerical data</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D002140" MajorTopicYN="N" Type="Geographic">California</DescriptorName>
+                        <QualifierName UI="Q000453" MajorTopicYN="N">epidemiology</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D002648" MajorTopicYN="N">Child</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D002675" MajorTopicYN="N">Child, Preschool</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D015331" MajorTopicYN="N">Cohort Studies</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D005163" MajorTopicYN="N">Factor Analysis, Statistical</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D006776" MajorTopicYN="N">Hospitals, Pediatric</DescriptorName>
+                        <QualifierName UI="Q000706" MajorTopicYN="N">statistics &amp; numerical data</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D007223" MajorTopicYN="N">Infant</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D007902" MajorTopicYN="N">Length of Stay</DescriptorName>
+                        <QualifierName UI="Q000706" MajorTopicYN="N">statistics &amp; numerical data</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D016015" MajorTopicYN="N">Logistic Models</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D016017" MajorTopicYN="N">Odds Ratio</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D010100" MajorTopicYN="N">Oxygen</DescriptorName>
+                        <QualifierName UI="Q000097" MajorTopicYN="N">blood</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D020250" MajorTopicYN="N">Postoperative Nausea and Vomiting</DescriptorName>
+                        <QualifierName UI="Q000453" MajorTopicYN="N">epidemiology</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D011237" MajorTopicYN="N">Predictive Value of Tests</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D011446" MajorTopicYN="N">Prospective Studies</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D011997" MajorTopicYN="N">Recovery Room</DescriptorName>
+                        <QualifierName UI="Q000706" MajorTopicYN="N">statistics &amp; numerical data</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D018570" MajorTopicYN="N">Risk Assessment</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D012307" MajorTopicYN="N">Risk Factors</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D014068" MajorTopicYN="Y">Tonsillectomy</DescriptorName>
+                        <QualifierName UI="Q000706" MajorTopicYN="N">statistics &amp; numerical data</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D014432" MajorTopicYN="N">Tympanic Membrane</DescriptorName>
+                        <QualifierName UI="Q000601" MajorTopicYN="N">surgery</QualifierName>
+                    </MeshHeading>
+                </MeshHeadingList>
+            </MedlineCitation>
+            <PubmedData>
+                <History>
+                    <PubMedPubDate PubStatus="pubmed">
+                        <Year>2007</Year>
+                        <Month>3</Month>
+                        <Day>23</Day>
+                        <Hour>9</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="medline">
+                        <Year>2007</Year>
+                        <Month>4</Month>
+                        <Day>14</Day>
+                        <Hour>9</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="entrez">
+                        <Year>2007</Year>
+                        <Month>3</Month>
+                        <Day>23</Day>
+                        <Hour>9</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                </History>
+                <PublicationStatus>ppublish</PublicationStatus>
+                <ArticleIdList>
+                    <ArticleId IdType="pubmed">17377083</ArticleId>
+                    <ArticleId IdType="pii">104/4/784</ArticleId>
+                    <ArticleId IdType="doi">10.1213/01.ane.0000258771.53068.09</ArticleId>
+                </ArticleIdList>
+            </PubmedData>
+        </PubmedArticle>
+
+        </PubmedArticleSet>
+    http_version: 
+  recorded_at: Wed, 03 Apr 2019 23:00:37 GMT
+- request:
+    method: post
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=Settings.PUBMED.API_KEY&db=pubmed&retmode=xml
+    body:
+      encoding: UTF-8
+      string: "&id=&id=16517323"
+    headers:
+      User-Agent:
+      - stanford-library-sul-pub
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 03 Apr 2019 23:00:37 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 03 Apr 2019 23:00:38 GMT
+      Server:
+      - Finatra
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Ratelimit-Remaining:
+      - '7'
+      Ncbi-Phid:
+      - D0BDAAD496ED878500002091B29B724F.1.1.m_3
+      Cache-Control:
+      - private
+      L5d-Success-Class:
+      - '1.0'
+      Ncbi-Sid:
+      - 5C56991BA7711E6F_6040SID
+      Content-Encoding:
+      - gzip
+      X-Ratelimit-Limit:
+      - '10'
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Set-Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID; domain=.nih.gov; path=/; expires=Fri, 03
+        Apr 2020 23:00:38 GMT
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" ?>
+        <!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2019//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_190101.dtd">
+        <PubmedArticleSet>
+        <PubmedArticle>
+            <MedlineCitation Status="MEDLINE" Owner="NLM">
+                <PMID Version="1">16517323</PMID>
+                <DateCompleted>
+                    <Year>2006</Year>
+                    <Month>09</Month>
+                    <Day>12</Day>
+                </DateCompleted>
+                <DateRevised>
+                    <Year>2008</Year>
+                    <Month>11</Month>
+                    <Day>21</Day>
+                </DateRevised>
+                <Article PubModel="Print">
+                    <Journal>
+                        <ISSN IssnType="Print">0952-8180</ISSN>
+                        <JournalIssue CitedMedium="Print">
+                            <Volume>18</Volume>
+                            <Issue>1</Issue>
+                            <PubDate>
+                                <Year>2006</Year>
+                                <Month>Feb</Month>
+                            </PubDate>
+                        </JournalIssue>
+                        <Title>Journal of clinical anesthesia</Title>
+                        <ISOAbbreviation>J Clin Anesth</ISOAbbreviation>
+                    </Journal>
+                    <ArticleTitle>Avian flu (H5N1): its epidemiology, prevention, and implications for anesthesiology.</ArticleTitle>
+                    <Pagination>
+                        <MedlinePgn>1-4</MedlinePgn>
+                    </Pagination>
+                    <Abstract>
+                        <AbstractText>Avian flu, influenza A subtype H5N1, is an emergent and virulent disease that poses a threat to the health and safety of the world community. Avian flu is 1 of more than 25 influenza A viruses that reside primarily in birds but also infect humans and other mammals. Avian flu is responsible for the current outbreak in Asia; H5N1 has now displayed probable human-to-human transmission; it could be a harbinger of a global epidemic. Anesthesiologists are exposed to a risk for infection when they are involved in airway instrumentation of infected patients. Given the evidence of emerging resistance to common antiviral agents used to treat H5N1 influenza virus and limited supply of H5N1 vaccine, prevention is our best protection. The following article will detail the virology and preventive public health practices for H5N1. This knowledge can also be used to define and prevent other yet unidentified infectious threats.</AbstractText>
+                    </Abstract>
+                    <AuthorList CompleteYN="Y">
+                        <Author ValidYN="Y">
+                            <LastName>Edler</LastName>
+                            <ForeName>Alice A</ForeName>
+                            <Initials>AA</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>Department of Anesthesia, Stanford University Medical Center, Stanford, CA 94305-5640, USA. edlera@aol.com</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                    </AuthorList>
+                    <Language>eng</Language>
+                    <PublicationTypeList>
+                        <PublicationType UI="D016428">Journal Article</PublicationType>
+                    </PublicationTypeList>
+                </Article>
+                <MedlineJournalInfo>
+                    <Country>United States</Country>
+                    <MedlineTA>J Clin Anesth</MedlineTA>
+                    <NlmUniqueID>8812166</NlmUniqueID>
+                    <ISSNLinking>0952-8180</ISSNLinking>
+                </MedlineJournalInfo>
+                <CitationSubset>IM</CitationSubset>
+                <MeshHeadingList>
+                    <MeshHeading>
+                        <DescriptorName UI="D000776" MajorTopicYN="Y">Anesthesiology</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D004196" MajorTopicYN="N">Disease Outbreaks</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D017758" MajorTopicYN="N">Infectious Disease Transmission, Patient-to-Professional</DescriptorName>
+                        <QualifierName UI="Q000517" MajorTopicYN="Y">prevention &amp; control</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D053124" MajorTopicYN="Y">Influenza A Virus, H5N1 Subtype</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D007251" MajorTopicYN="N">Influenza, Human</DescriptorName>
+                        <QualifierName UI="Q000453" MajorTopicYN="N">epidemiology</QualifierName>
+                        <QualifierName UI="Q000517" MajorTopicYN="Y">prevention &amp; control</QualifierName>
+                        <QualifierName UI="Q000628" MajorTopicYN="N">therapy</QualifierName>
+                        <QualifierName UI="Q000635" MajorTopicYN="N">transmission</QualifierName>
+                    </MeshHeading>
+                </MeshHeadingList>
+            </MedlineCitation>
+            <PubmedData>
+                <History>
+                    <PubMedPubDate PubStatus="received">
+                        <Year>2005</Year>
+                        <Month>02</Month>
+                        <Day>08</Day>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="accepted">
+                        <Year>2005</Year>
+                        <Month>12</Month>
+                        <Day>06</Day>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="pubmed">
+                        <Year>2006</Year>
+                        <Month>3</Month>
+                        <Day>7</Day>
+                        <Hour>9</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="medline">
+                        <Year>2006</Year>
+                        <Month>9</Month>
+                        <Day>13</Day>
+                        <Hour>9</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="entrez">
+                        <Year>2006</Year>
+                        <Month>3</Month>
+                        <Day>7</Day>
+                        <Hour>9</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                </History>
+                <PublicationStatus>ppublish</PublicationStatus>
+                <ArticleIdList>
+                    <ArticleId IdType="pubmed">16517323</ArticleId>
+                    <ArticleId IdType="pii">S0952-8180(05)00355-7</ArticleId>
+                    <ArticleId IdType="doi">10.1016/j.jclinane.2005.12.004</ArticleId>
+                </ArticleIdList>
+            </PubmedData>
+        </PubmedArticle>
+
+        </PubmedArticleSet>
+    http_version: 
+  recorded_at: Wed, 03 Apr 2019 23:00:38 GMT
+- request:
+    method: post
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=Settings.PUBMED.API_KEY&db=pubmed&retmode=xml
+    body:
+      encoding: UTF-8
+      string: "&id=&id=14617124"
+    headers:
+      User-Agent:
+      - stanford-library-sul-pub
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 03 Apr 2019 23:00:38 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 03 Apr 2019 23:00:38 GMT
+      Server:
+      - Finatra
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Ratelimit-Remaining:
+      - '6'
+      Ncbi-Phid:
+      - D0BDAAD496ED878500001E91B35133BA.1.1.m_3
+      Cache-Control:
+      - private
+      L5d-Success-Class:
+      - '1.0'
+      Ncbi-Sid:
+      - 5C56991BA7711E6F_6040SID
+      Content-Encoding:
+      - gzip
+      X-Ratelimit-Limit:
+      - '10'
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Set-Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID; domain=.nih.gov; path=/; expires=Fri, 03
+        Apr 2020 23:00:38 GMT
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" ?>
+        <!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2019//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_190101.dtd">
+        <PubmedArticleSet>
+        <PubmedArticle>
+            <MedlineCitation Status="MEDLINE" Owner="NLM">
+                <PMID Version="1">14617124</PMID>
+                <DateCompleted>
+                    <Year>2004</Year>
+                    <Month>04</Month>
+                    <Day>22</Day>
+                </DateCompleted>
+                <DateRevised>
+                    <Year>2006</Year>
+                    <Month>11</Month>
+                    <Day>15</Day>
+                </DateRevised>
+                <Article PubModel="Print">
+                    <Journal>
+                        <ISSN IssnType="Print">1155-5645</ISSN>
+                        <JournalIssue CitedMedium="Print">
+                            <Volume>13</Volume>
+                            <Issue>9</Issue>
+                            <PubDate>
+                                <Year>2003</Year>
+                                <Month>Nov</Month>
+                            </PubDate>
+                        </JournalIssue>
+                        <Title>Paediatric anaesthesia</Title>
+                        <ISOAbbreviation>Paediatr Anaesth</ISOAbbreviation>
+                    </Journal>
+                    <ArticleTitle>Blood loss during posterior spinal fusion surgery in patients with neuromuscular disease: is there an increased risk?</ArticleTitle>
+                    <Pagination>
+                        <MedlinePgn>818-22</MedlinePgn>
+                    </Pagination>
+                    <Abstract>
+                        <AbstractText Label="BACKGROUND" NlmCategory="BACKGROUND">Scoliosis surgery in paediatric patients can carry significant morbidity associated with intraoperative blood loss and the resultant transfusion therapy. Patients with neuromuscular disease may be at an increased risk for this intraoperative blood loss, but it is unclear if this is because of direct vascular pathophysiological changes or the fact that neuromuscular patients typically have more extensive orthopaedic disease and more vertebral segments involved. This study examined the risk of extensive blood loss (&gt;50% of total blood volume) in patients with neuromuscular disease compared with patients who did not have neuromuscular disease when the extent of the surgery (number of segments fused), age and preoperative coagulation profile where taken into consideration.</AbstractText>
+                        <AbstractText Label="METHODS" NlmCategory="METHODS">Retrospective chart review of 163 paediatric patients was preformed. Patients who carried a diagnosis of preexisting neuromuscular disease were classified as such. Idiopathic, traumatic and iatrogenic scoliosis were classified as nonneuromuscular. Extensive blood loss was defined as &gt;50% of estimated total blood volume. Logistic regression was used to predict the risk of extensive blood loss between the two groups when age, weight, extent of surgery was controlled for and anaesthetic and surgical techniques remained similar.</AbstractText>
+                        <AbstractText Label="RESULTS" NlmCategory="RESULTS">Patients with neuromuscular disease did not vary significantly in age, weight, or preoperative haematocrit and platelet count from patients without neuromuscular disease. Neuromuscular patients did have significantly more vertebral segments fused. When this difference was controlled for statistically, neuromuscular patients had an almost seven times higher risk (adjusted odds ration 6.9, P &lt; 0.05) of losing &gt;50% of their estimated total blood volume during scoliosis surgery.</AbstractText>
+                        <AbstractText Label="CONCLUSIONS" NlmCategory="CONCLUSIONS">Patients with neuromuscular disease can present various anaesthetic challenges during scoliosis surgery, among these is the inherent risk of extensive blood loss. Recognizing this may help anaesthesiologists and surgeons more accurately prepare for and treat intraoperative blood loss during scoliosis surgery in patients with neuromuscular disease.</AbstractText>
+                    </Abstract>
+                    <AuthorList CompleteYN="Y">
+                        <Author ValidYN="Y">
+                            <LastName>Edler</LastName>
+                            <ForeName>Alice</ForeName>
+                            <Initials>A</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>Clinical Anesthesiology, Stanford University of Medicine, Stanford, CA, USA. edlera@stanford.edu</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Murray</LastName>
+                            <ForeName>David J</ForeName>
+                            <Initials>DJ</Initials>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Forbes</LastName>
+                            <ForeName>Robert B</ForeName>
+                            <Initials>RB</Initials>
+                        </Author>
+                    </AuthorList>
+                    <Language>eng</Language>
+                    <PublicationTypeList>
+                        <PublicationType UI="D003160">Comparative Study</PublicationType>
+                        <PublicationType UI="D016428">Journal Article</PublicationType>
+                    </PublicationTypeList>
+                </Article>
+                <MedlineJournalInfo>
+                    <Country>France</Country>
+                    <MedlineTA>Paediatr Anaesth</MedlineTA>
+                    <NlmUniqueID>9206575</NlmUniqueID>
+                    <ISSNLinking>1155-5645</ISSNLinking>
+                </MedlineJournalInfo>
+                <CitationSubset>IM</CitationSubset>
+                <MeshHeadingList>
+                    <MeshHeading>
+                        <DescriptorName UI="D000293" MajorTopicYN="N">Adolescent</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D000367" MajorTopicYN="N">Age Factors</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D016063" MajorTopicYN="N">Blood Loss, Surgical</DescriptorName>
+                        <QualifierName UI="Q000706" MajorTopicYN="Y">statistics &amp; numerical data</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D001792" MajorTopicYN="N">Blood Platelets</DescriptorName>
+                        <QualifierName UI="Q000502" MajorTopicYN="N">physiology</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D001835" MajorTopicYN="N">Body Weight</DescriptorName>
+                        <QualifierName UI="Q000502" MajorTopicYN="N">physiology</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D006400" MajorTopicYN="N">Hematocrit</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D016015" MajorTopicYN="N">Logistic Models</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D009468" MajorTopicYN="N">Neuromuscular Diseases</DescriptorName>
+                        <QualifierName UI="Q000150" MajorTopicYN="Y">complications</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D016017" MajorTopicYN="N">Odds Ratio</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D012189" MajorTopicYN="N">Retrospective Studies</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D012307" MajorTopicYN="N">Risk Factors</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D012600" MajorTopicYN="N">Scoliosis</DescriptorName>
+                        <QualifierName UI="Q000150" MajorTopicYN="Y">complications</QualifierName>
+                        <QualifierName UI="Q000601" MajorTopicYN="Y">surgery</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D012720" MajorTopicYN="N">Severity of Illness Index</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D013123" MajorTopicYN="N">Spinal Fusion</DescriptorName>
+                        <QualifierName UI="Q000009" MajorTopicYN="Y">adverse effects</QualifierName>
+                    </MeshHeading>
+                </MeshHeadingList>
+            </MedlineCitation>
+            <PubmedData>
+                <History>
+                    <PubMedPubDate PubStatus="pubmed">
+                        <Year>2003</Year>
+                        <Month>11</Month>
+                        <Day>18</Day>
+                        <Hour>5</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="medline">
+                        <Year>2004</Year>
+                        <Month>4</Month>
+                        <Day>23</Day>
+                        <Hour>5</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="entrez">
+                        <Year>2003</Year>
+                        <Month>11</Month>
+                        <Day>18</Day>
+                        <Hour>5</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                </History>
+                <PublicationStatus>ppublish</PublicationStatus>
+                <ArticleIdList>
+                    <ArticleId IdType="pubmed">14617124</ArticleId>
+                    <ArticleId IdType="pii">1171</ArticleId>
+                </ArticleIdList>
+            </PubmedData>
+        </PubmedArticle>
+
+        </PubmedArticleSet>
+    http_version: 
+  recorded_at: Wed, 03 Apr 2019 23:00:38 GMT
+- request:
+    method: post
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=Settings.PUBMED.API_KEY&db=pubmed&retmode=xml
+    body:
+      encoding: UTF-8
+      string: "&id=&id=21134139"
+    headers:
+      User-Agent:
+      - stanford-library-sul-pub
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 03 Apr 2019 23:00:38 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 03 Apr 2019 23:00:38 GMT
+      Server:
+      - Finatra
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Ratelimit-Remaining:
+      - '6'
+      Ncbi-Phid:
+      - D0BDAAD496ED878500002091B3C38005.1.1.m_3
+      Cache-Control:
+      - private
+      L5d-Success-Class:
+      - '1.0'
+      Ncbi-Sid:
+      - 5C56991BA7711E6F_6040SID
+      Content-Encoding:
+      - gzip
+      X-Ratelimit-Limit:
+      - '10'
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Set-Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID; domain=.nih.gov; path=/; expires=Fri, 03
+        Apr 2020 23:00:38 GMT
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" ?>
+        <!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2019//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_190101.dtd">
+        <PubmedArticleSet>
+        <PubmedArticle>
+            <MedlineCitation Status="MEDLINE" Owner="NLM">
+                <PMID Version="1">21134139</PMID>
+                <DateCompleted>
+                    <Year>2011</Year>
+                    <Month>05</Month>
+                    <Day>05</Day>
+                </DateCompleted>
+                <DateRevised>
+                    <Year>2011</Year>
+                    <Month>08</Month>
+                    <Day>25</Day>
+                </DateRevised>
+                <Article PubModel="Print">
+                    <Journal>
+                        <ISSN IssnType="Electronic">1743-498X</ISSN>
+                        <JournalIssue CitedMedium="Internet">
+                            <Volume>7</Volume>
+                            <Issue>1</Issue>
+                            <PubDate>
+                                <Year>2010</Year>
+                                <Month>Mar</Month>
+                            </PubDate>
+                        </JournalIssue>
+                        <Title>The clinical teacher</Title>
+                        <ISOAbbreviation>Clin Teach</ISOAbbreviation>
+                    </Journal>
+                    <ArticleTitle>Leadership lessons from military education for postgraduate medical curricular improvement.</ArticleTitle>
+                    <Pagination>
+                        <MedlinePgn>26-31</MedlinePgn>
+                    </Pagination>
+                    <ELocationID EIdType="doi" ValidYN="Y">10.1111/j.1743-498X.2009.00336.x</ELocationID>
+                    <Abstract>
+                        <AbstractText Label="BACKGROUND" NlmCategory="BACKGROUND">quality medical education includes both teaching and learning of data-driven knowledge, and appropriate technical skills and tacit behaviours, such as effective communication and professional leadership. But these implicit behaviours are not readily adaptable to traditional medical curriculum models. This manuscript explores a medical leadership curriculum informed by military education.</AbstractText>
+                        <AbstractText Label="CONTEXT" NlmCategory="BACKGROUND">our paediatric anaesthesia residents expressed a strong desire for more leadership opportunity within the training programme. Upon exploration, current health care models for leadership training were limited to short didactic presentations or lengthy certificate programmes. We could not find an appropriate model for our 1-year fellowship.</AbstractText>
+                        <AbstractText Label="INNOVATION" NlmCategory="METHODS">in collaboration with the US Naval Academy, we modified the 'Leadership Education and Development Program' curriculum to introduce daily and graduated leadership opportunities: starting with low-risk decision-making tasks and progressing to independent professional decision making and leadership. Each resident who opted into the programme had a 3-month role as team leader and spent 9 months as a team member. At the end of the first year of this curriculum both quantitative assessment and qualitative reflection from residents and faculty members noted significantly improved clinical and administrative decision making. The second-year residents' performance showed further improvement.</AbstractText>
+                        <AbstractText Label="IMPLICATIONS" NlmCategory="CONCLUSIONS">medical education has long emphasised subject-matter knowledge as a prime focus. However, in competency-based medical education, new curriculum models are needed. Many helpful models can be found in other professional fields. Collaborations between professional educators benefit the students, who are learning these new skills, the medical educators, who work jointly with other professionals, and the original curriculum designer, who has an opportunity to reflect on the strengths and weaknesses of his or her model.</AbstractText>
+                        <CopyrightInformation>Blackwell Publishing Ltd 2010.</CopyrightInformation>
+                    </Abstract>
+                    <AuthorList CompleteYN="Y">
+                        <Author ValidYN="Y">
+                            <LastName>Edler</LastName>
+                            <ForeName>Alice</ForeName>
+                            <Initials>A</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>Stanford Hospital and Clinics, Stanford University School of Medicine, US Naval Academy, Stanford, California, USA. edlera@aaol.com</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Adamshick</LastName>
+                            <ForeName>Mark</ForeName>
+                            <Initials>M</Initials>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Fanning</LastName>
+                            <ForeName>Ruth</ForeName>
+                            <Initials>R</Initials>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Piro</LastName>
+                            <ForeName>Nancy</ForeName>
+                            <Initials>N</Initials>
+                        </Author>
+                    </AuthorList>
+                    <Language>eng</Language>
+                    <PublicationTypeList>
+                        <PublicationType UI="D016428">Journal Article</PublicationType>
+                        <PublicationType UI="D013485">Research Support, Non-U.S. Gov't</PublicationType>
+                    </PublicationTypeList>
+                </Article>
+                <MedlineJournalInfo>
+                    <Country>England</Country>
+                    <MedlineTA>Clin Teach</MedlineTA>
+                    <NlmUniqueID>101227511</NlmUniqueID>
+                    <ISSNLinking>1743-4971</ISSNLinking>
+                </MedlineJournalInfo>
+                <CitationSubset>IM</CitationSubset>
+                <MeshHeadingList>
+                    <MeshHeading>
+                        <DescriptorName UI="D000776" MajorTopicYN="N">Anesthesiology</DescriptorName>
+                        <QualifierName UI="Q000193" MajorTopicYN="Y">education</QualifierName>
+                        <QualifierName UI="Q000592" MajorTopicYN="N">standards</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D002983" MajorTopicYN="N">Clinical Competence</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D003479" MajorTopicYN="N">Curriculum</DescriptorName>
+                        <QualifierName UI="Q000592" MajorTopicYN="Y">standards</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D004503" MajorTopicYN="N">Education, Medical, Graduate</DescriptorName>
+                        <QualifierName UI="Q000379" MajorTopicYN="Y">methods</QualifierName>
+                        <QualifierName UI="Q000592" MajorTopicYN="N">standards</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D005180" MajorTopicYN="N">Faculty, Medical</DescriptorName>
+                        <QualifierName UI="Q000592" MajorTopicYN="N">standards</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D007722" MajorTopicYN="N">Health Knowledge, Attitudes, Practice</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D007396" MajorTopicYN="N">Internship and Residency</DescriptorName>
+                        <QualifierName UI="Q000592" MajorTopicYN="Y">standards</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D007857" MajorTopicYN="Y">Leadership</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D007858" MajorTopicYN="N">Learning</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D008887" MajorTopicYN="N">Military Medicine</DescriptorName>
+                        <QualifierName UI="Q000193" MajorTopicYN="Y">education</QualifierName>
+                        <QualifierName UI="Q000458" MajorTopicYN="N">organization &amp; administration</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D017145" MajorTopicYN="N">Models, Educational</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D010372" MajorTopicYN="N">Pediatrics</DescriptorName>
+                        <QualifierName UI="Q000193" MajorTopicYN="Y">education</QualifierName>
+                        <QualifierName UI="Q000592" MajorTopicYN="N">standards</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D036301" MajorTopicYN="N">Qualitative Research</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D013337" MajorTopicYN="N">Students, Medical</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D013663" MajorTopicYN="N">Teaching</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D014481" MajorTopicYN="N" Type="Geographic">United States</DescriptorName>
+                    </MeshHeading>
+                </MeshHeadingList>
+            </MedlineCitation>
+            <PubmedData>
+                <History>
+                    <PubMedPubDate PubStatus="entrez">
+                        <Year>2010</Year>
+                        <Month>12</Month>
+                        <Day>8</Day>
+                        <Hour>6</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="pubmed">
+                        <Year>2010</Year>
+                        <Month>12</Month>
+                        <Day>8</Day>
+                        <Hour>6</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="medline">
+                        <Year>2011</Year>
+                        <Month>5</Month>
+                        <Day>6</Day>
+                        <Hour>6</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                </History>
+                <PublicationStatus>ppublish</PublicationStatus>
+                <ArticleIdList>
+                    <ArticleId IdType="pubmed">21134139</ArticleId>
+                    <ArticleId IdType="doi">10.1111/j.1743-498X.2009.00336.x</ArticleId>
+                </ArticleIdList>
+            </PubmedData>
+        </PubmedArticle>
+
+        </PubmedArticleSet>
+    http_version: 
+  recorded_at: Wed, 03 Apr 2019 23:00:38 GMT
+- request:
+    method: post
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=Settings.PUBMED.API_KEY&db=pubmed&retmode=xml
+    body:
+      encoding: UTF-8
+      string: "&id=&id=20386227"
+    headers:
+      User-Agent:
+      - stanford-library-sul-pub
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 03 Apr 2019 23:00:38 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 03 Apr 2019 23:00:38 GMT
+      Server:
+      - Finatra
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Ratelimit-Remaining:
+      - '7'
+      Ncbi-Phid:
+      - D0BDAAD496ED878500001E91B46713FB.1.1.m_3
+      Cache-Control:
+      - private
+      L5d-Success-Class:
+      - '1.0'
+      Ncbi-Sid:
+      - 5C56991BA7711E6F_6040SID
+      Content-Encoding:
+      - gzip
+      X-Ratelimit-Limit:
+      - '10'
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Set-Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID; domain=.nih.gov; path=/; expires=Fri, 03
+        Apr 2020 23:00:39 GMT
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" ?>
+        <!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2019//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_190101.dtd">
+        <PubmedArticleSet>
+        <PubmedArticle>
+            <MedlineCitation Status="MEDLINE" Owner="NLM">
+                <PMID Version="1">20386227</PMID>
+                <DateCompleted>
+                    <Year>2010</Year>
+                    <Month>08</Month>
+                    <Day>06</Day>
+                </DateCompleted>
+                <DateRevised>
+                    <Year>2018</Year>
+                    <Month>12</Month>
+                    <Day>01</Day>
+                </DateRevised>
+                <Article PubModel="Print">
+                    <Journal>
+                        <ISSN IssnType="Electronic">1537-1913</ISSN>
+                        <JournalIssue CitedMedium="Internet">
+                            <Volume>48</Volume>
+                            <Issue>2</Issue>
+                            <PubDate>
+                                <Year>2010</Year>
+                                <Season>Spring</Season>
+                            </PubDate>
+                        </JournalIssue>
+                        <Title>International anesthesiology clinics</Title>
+                        <ISOAbbreviation>Int Anesthesiol Clin</ISOAbbreviation>
+                    </Journal>
+                    <ArticleTitle>Teaching NonPhysician Anesthesia Providers in Tanzania: a movement toward sustainable healthcare development.</ArticleTitle>
+                    <Pagination>
+                        <MedlinePgn>59-69</MedlinePgn>
+                    </Pagination>
+                    <ELocationID EIdType="doi" ValidYN="Y">10.1097/AIA.0b013e3181cd15ef</ELocationID>
+                    <AuthorList CompleteYN="Y">
+                        <Author ValidYN="Y">
+                            <LastName>Edler</LastName>
+                            <ForeName>Alice A</ForeName>
+                            <Initials>AA</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>Stanford University Hospitals and Clinics, Stanford, California 94305, USA. Edlera@stanford.edu</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Gipp</LastName>
+                            <ForeName>Melanie S</ForeName>
+                            <Initials>MS</Initials>
+                        </Author>
+                    </AuthorList>
+                    <Language>eng</Language>
+                    <PublicationTypeList>
+                        <PublicationType UI="D016428">Journal Article</PublicationType>
+                    </PublicationTypeList>
+                </Article>
+                <MedlineJournalInfo>
+                    <Country>United States</Country>
+                    <MedlineTA>Int Anesthesiol Clin</MedlineTA>
+                    <NlmUniqueID>0370760</NlmUniqueID>
+                    <ISSNLinking>0020-5907</ISSNLinking>
+                </MedlineJournalInfo>
+                <CitationSubset>IM</CitationSubset>
+                <MeshHeadingList>
+                    <MeshHeading>
+                        <DescriptorName UI="D000776" MajorTopicYN="N">Anesthesiology</DescriptorName>
+                        <QualifierName UI="Q000193" MajorTopicYN="Y">education</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D003695" MajorTopicYN="Y">Delivery of Health Care</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D013636" MajorTopicYN="N">Tanzania</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D013663" MajorTopicYN="Y">Teaching</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D014838" MajorTopicYN="Y">Volunteers</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D000078329" MajorTopicYN="N">Workforce</DescriptorName>
+                    </MeshHeading>
+                </MeshHeadingList>
+            </MedlineCitation>
+            <PubmedData>
+                <History>
+                    <PubMedPubDate PubStatus="entrez">
+                        <Year>2010</Year>
+                        <Month>4</Month>
+                        <Day>14</Day>
+                        <Hour>6</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="pubmed">
+                        <Year>2010</Year>
+                        <Month>4</Month>
+                        <Day>14</Day>
+                        <Hour>6</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="medline">
+                        <Year>2010</Year>
+                        <Month>8</Month>
+                        <Day>7</Day>
+                        <Hour>6</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                </History>
+                <PublicationStatus>ppublish</PublicationStatus>
+                <ArticleIdList>
+                    <ArticleId IdType="pubmed">20386227</ArticleId>
+                    <ArticleId IdType="doi">10.1097/AIA.0b013e3181cd15ef</ArticleId>
+                    <ArticleId IdType="pii">00004311-201004820-00007</ArticleId>
+                </ArticleIdList>
+            </PubmedData>
+        </PubmedArticle>
+
+        </PubmedArticleSet>
+    http_version: 
+  recorded_at: Wed, 03 Apr 2019 23:00:39 GMT
+- request:
+    method: post
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=Settings.PUBMED.API_KEY&db=pubmed&retmode=xml
+    body:
+      encoding: UTF-8
+      string: "&id=&id=20046456"
+    headers:
+      User-Agent:
+      - stanford-library-sul-pub
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 03 Apr 2019 23:00:39 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 03 Apr 2019 23:00:39 GMT
+      Server:
+      - Finatra
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Ratelimit-Remaining:
+      - '6'
+      Ncbi-Phid:
+      - D0BDAAD496ED878500002791B4E2E073.1.1.m_3
+      Cache-Control:
+      - private
+      L5d-Success-Class:
+      - '1.0'
+      Ncbi-Sid:
+      - 5C56991BA7711E6F_6040SID
+      Content-Encoding:
+      - gzip
+      X-Ratelimit-Limit:
+      - '10'
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Set-Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID; domain=.nih.gov; path=/; expires=Fri, 03
+        Apr 2020 23:00:39 GMT
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" ?>
+        <!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2019//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_190101.dtd">
+        <PubmedArticleSet>
+        <PubmedArticle>
+            <MedlineCitation Status="PubMed-not-MEDLINE" Owner="NLM">
+                <PMID Version="1">20046456</PMID>
+                <DateCompleted>
+                    <Year>2011</Year>
+                    <Month>07</Month>
+                    <Day>14</Day>
+                </DateCompleted>
+                <DateRevised>
+                    <Year>2018</Year>
+                    <Month>11</Month>
+                    <Day>13</Day>
+                </DateRevised>
+                <Article PubModel="Electronic">
+                    <Journal>
+                        <ISSN IssnType="Electronic">1975-5937</ISSN>
+                        <JournalIssue CitedMedium="Internet">
+                            <Volume>6</Volume>
+                            <PubDate>
+                                <Year>2009</Year>
+                                <Month>Dec</Month>
+                                <Day>20</Day>
+                            </PubDate>
+                        </JournalIssue>
+                        <Title>Journal of educational evaluation for health professions</Title>
+                        <ISOAbbreviation>J Educ Eval Health Prof</ISOAbbreviation>
+                    </Journal>
+                    <ArticleTitle>Patient simulation: a literary synthesis of assessment tools in anesthesiology.</ArticleTitle>
+                    <Pagination>
+                        <MedlinePgn>3</MedlinePgn>
+                    </Pagination>
+                    <ELocationID EIdType="doi" ValidYN="Y">10.3352/jeehp.2009.6.3</ELocationID>
+                    <Abstract>
+                        <AbstractText>High-fidelity patient simulation (HFPS) has been hypothesized as a modality for assessing competency of knowledge and skill in patient simulation, but uniform methods for HFPS performance assessment (PA) have not yet been completely achieved. Anesthesiology as a field founded the HFPS discipline and also leads in its PA. This project reviews the types, quality, and designated purpose of HFPS PA tools in anesthesiology. We used the systematic review method and systematically reviewed anesthesiology literature referenced in PubMed to assess the quality and reliability of available PA tools in HFPS. Of 412 articles identified, 50 met our inclusion criteria. Seventy seven percent of studies have been published since 2000; more recent studies demonstrated higher quality. Investigators reported a variety of test construction and validation methods. The most commonly reported test construction methods included &quot;modified Delphi Techniques&quot; for item selection, reliability measurement using inter-rater agreement, and intra-class correlations between test items or subtests. Modern test theory, in particular generalizability theory, was used in nine (18%) of studies. Test score validity has been addressed in multiple investigations and shown a significant improvement in reporting accuracy. However the assessment of predicative has been low across the majority of studies. Usability and practicality of testing occasions and tools was only anecdotally reported. To more completely comply with the gold standards for PA design, both shared experience of experts and recognition of test construction standards, including reliability and validity measurements, instrument piloting, rater training, and explicit identification of the purpose and proposed use of the assessment tool, are required.</AbstractText>
+                    </Abstract>
+                    <AuthorList CompleteYN="Y">
+                        <Author ValidYN="Y">
+                            <LastName>Edler</LastName>
+                            <ForeName>Alice A</ForeName>
+                            <Initials>AA</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>Department of Graduate Medical Education, Stanford Hospitals and Clinics, Stanford, CA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Fanning</LastName>
+                            <ForeName>Ruth G</ForeName>
+                            <Initials>RG</Initials>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Chen</LastName>
+                            <ForeName>Michael I</ForeName>
+                            <Initials>MI</Initials>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Claure</LastName>
+                            <ForeName>Rebecca</ForeName>
+                            <Initials>R</Initials>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Almazan</LastName>
+                            <ForeName>Dondee</ForeName>
+                            <Initials>D</Initials>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Struyk</LastName>
+                            <ForeName>Brain</ForeName>
+                            <Initials>B</Initials>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Seiden</LastName>
+                            <ForeName>Samuel C</ForeName>
+                            <Initials>SC</Initials>
+                        </Author>
+                    </AuthorList>
+                    <Language>eng</Language>
+                    <PublicationTypeList>
+                        <PublicationType UI="D016428">Journal Article</PublicationType>
+                    </PublicationTypeList>
+                    <ArticleDate DateType="Electronic">
+                        <Year>2009</Year>
+                        <Month>12</Month>
+                        <Day>20</Day>
+                    </ArticleDate>
+                </Article>
+                <MedlineJournalInfo>
+                    <Country>Korea (South)</Country>
+                    <MedlineTA>J Educ Eval Health Prof</MedlineTA>
+                    <NlmUniqueID>101490061</NlmUniqueID>
+                    <ISSNLinking>1975-5937</ISSNLinking>
+                </MedlineJournalInfo>
+                <KeywordList Owner="NOTNLM">
+                    <Keyword MajorTopicYN="N">Anesthesiology</Keyword>
+                    <Keyword MajorTopicYN="N">High-Fidelity Patient Simulation</Keyword>
+                    <Keyword MajorTopicYN="N">Patient Simulation</Keyword>
+                    <Keyword MajorTopicYN="N">Performance Assessment</Keyword>
+                    <Keyword MajorTopicYN="N">Systemic Review</Keyword>
+                    <Keyword MajorTopicYN="N">Test Theory</Keyword>
+                </KeywordList>
+            </MedlineCitation>
+            <PubmedData>
+                <History>
+                    <PubMedPubDate PubStatus="received">
+                        <Year>2009</Year>
+                        <Month>10</Month>
+                        <Day>17</Day>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="accepted">
+                        <Year>2009</Year>
+                        <Month>12</Month>
+                        <Day>12</Day>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="entrez">
+                        <Year>2010</Year>
+                        <Month>1</Month>
+                        <Day>5</Day>
+                        <Hour>6</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="pubmed">
+                        <Year>2010</Year>
+                        <Month>1</Month>
+                        <Day>5</Day>
+                        <Hour>6</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="medline">
+                        <Year>2010</Year>
+                        <Month>1</Month>
+                        <Day>5</Day>
+                        <Hour>6</Hour>
+                        <Minute>1</Minute>
+                    </PubMedPubDate>
+                </History>
+                <PublicationStatus>epublish</PublicationStatus>
+                <ArticleIdList>
+                    <ArticleId IdType="pubmed">20046456</ArticleId>
+                    <ArticleId IdType="doi">10.3352/jeehp.2009.6.3</ArticleId>
+                    <ArticleId IdType="pmc">PMC2796725</ArticleId>
+                </ArticleIdList>
+                <ReferenceList>
+                    <Reference>
+                        <Citation>Anesth Analg. 2003 Dec;97(6):1695-705</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">14633545</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Anesth Analg. 2003 Dec;97(6):1690-4</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">14633544</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Br J Anaesth. 2004 Mar;92(3):388-92</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">14742327</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Med Teach. 2003 Nov;25(6):654-8</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">15369915</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Anesthesiology. 2004 Nov;101(5):1084-95</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">15505443</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Anaesthesia. 2005 Mar;60(3):245-50</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">15710009</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>AACN Clin Issues. 2005 Jan-Mar;16(1):89-104</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">15714021</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Anesth Analg. 2005 May;100(5):1375-80, table of contents</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">15845689</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Anesth Analg. 2005 Jul;101(1):48-58, table of contents</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">15976205</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Anesthesiology. 2005 Aug;103(2):241-8</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">16052105</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Anesth Analg. 2005 Oct;101(4):1068-74, table of contents</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">16192523</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Anesth Analg. 2005 Oct;101(4):1127-34, table of contents</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">16192533</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Crit Care Med. 2006 Jan;34(1):151-7</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">16374169</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Anesth Analg. 2006 Mar;102(3):865-7</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">16492842</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Anesthesiology. 2006 Mar;104(3):475-81</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">16508394</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Med Teach. 2006 Feb;28(1):e10-5</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">16627314</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Anesthesiology. 2006 Aug;105(2):260-6</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">16871059</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Anesth Analg. 2006 Sep;103(3):551-6</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">16931660</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Isr Med Assoc J. 2006 Oct;8(10):728-33</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">17125130</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Anaesthesia. 2007 Feb;62(2):122-6</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">17223802</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Anesthesiology. 2007 Apr;106(4):812-25</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">17413920</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Anesthesiology. 2007 May;106(5):907-15</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">17457121</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Emerg Med Australas. 2008 Feb;20(1):1-9</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">17999685</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Anesthesiology. 2007 Nov;107(5):705-13</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">18073544</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Pediatrics. 2008 Jan;121(1):e34-43</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">18166542</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Anaesthesia. 2008 Apr;63(4):379-84</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">18336488</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Anaesth Intensive Care. 2008 Mar;36(2):185-9</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">18361009</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Anesthesiology. 2008 May;108(5):831-40</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">18431118</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nurs Educ Perspect. 2008 Mar-Apr;29(2):105-9</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">18459626</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Simul Healthc. 2008 Summer;3(2):72-81</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">19088645</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Aviat Space Environ Med. 1992 Sep;63(9):763-70</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">1524531</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Anesthesiology. 1992 Apr;76(4):495-501</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">1550273</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Anesth Analg. 1989 Apr;68(4):444-51</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">2929977</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Am Psychol. 1973 Jan;28(1):1-14</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">4684069</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Acad Med. 1995 Jul;70(7):642-53</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">7612129</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Br J Anaesth. 1994 Sep;73(3):293-7</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">7946851</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Br J Anaesth. 1997 May;78(5):553-6</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">9175971</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Can J Anaesth. 1997 Sep;44(9):924-8</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">9305554</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Can J Anaesth. 1997 Nov;44(11):1191-5</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">9398961</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>J Clin Monit. 1997 Nov;13(6):399-407</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">9495293</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Br J Anaesth. 1998 Jan;80(1):58-62</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">9505779</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Anesth Analg. 1998 Jun;86(6):1160-4</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">9620496</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Anesthesiology. 1998 Jul;89(1):8-18</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">9667288</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Acad Med. 1999 Feb;74(2):202</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">10065064</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Crit Care Med. 1999 Apr;27(4):821-4</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">10321676</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Med Educ. 2000 Jan;34(1):42-5</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">10607278</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Acta Anaesthesiol Scand. 2001 Mar;45(3):315-9</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">11207467</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Can J Anaesth. 2001 Mar;48(3):225-33</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">11305821</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Anesthesiology. 2001 Jul;95(1):36-42</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">11465581</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Acad Med. 2001 Oct;76(10):1053-5</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">11597848</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Anesth Analg. 2002 Jan;94(1):149-53, table of contents</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">11772818</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>JAMA. 2002 Jan 9;287(2):226-35</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">11779266</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Br J Anaesth. 2002 Mar;88(3):338-44</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">11990263</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Med Educ. 2002 Sep;36(9):833-41</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">12354246</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Anesthesiology. 2002 Dec;97(6):1434-44</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">12459669</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Br J Anaesth. 2003 Jan;90(1):43-7</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">12488377</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>J Clin Monit Comput. 2000;16(4):273-85</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">12578075</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Br J Anaesth. 2003 May;90(5):580-8</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">12697584</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Anesthesiology. 2003 Jun;98(6):1345-55; discussion 5A</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">12766642</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Br J Anaesth. 2003 Sep;91(3):312-8</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">12925467</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Psychol Bull. 1955 Jul;52(4):281-302</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">13245896</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Anesthesiology. 2003 Dec;99(6):1270-80</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">14639138</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                </ReferenceList>
+            </PubmedData>
+        </PubmedArticle>
+
+        </PubmedArticleSet>
+    http_version: 
+  recorded_at: Wed, 03 Apr 2019 23:00:39 GMT
+- request:
+    method: post
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=Settings.PUBMED.API_KEY&db=pubmed&retmode=xml
+    body:
+      encoding: UTF-8
+      string: "&id=&id=12095380"
+    headers:
+      User-Agent:
+      - stanford-library-sul-pub
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 03 Apr 2019 23:00:39 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 03 Apr 2019 23:00:39 GMT
+      Server:
+      - Finatra
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Ratelimit-Remaining:
+      - '6'
+      Ncbi-Phid:
+      - D0BDAAD496ED878500002591B5481372.1.1.m_3
+      Cache-Control:
+      - private
+      L5d-Success-Class:
+      - '1.0'
+      Ncbi-Sid:
+      - 5C56991BA7711E6F_6040SID
+      Content-Encoding:
+      - gzip
+      X-Ratelimit-Limit:
+      - '10'
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Set-Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID; domain=.nih.gov; path=/; expires=Fri, 03
+        Apr 2020 23:00:39 GMT
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" ?>
+        <!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2019//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_190101.dtd">
+        <PubmedArticleSet>
+        <PubmedArticle>
+            <MedlineCitation Status="MEDLINE" Owner="NLM">
+                <PMID Version="1">12095380</PMID>
+                <DateCompleted>
+                    <Year>2002</Year>
+                    <Month>07</Month>
+                    <Day>18</Day>
+                </DateCompleted>
+                <DateRevised>
+                    <Year>2016</Year>
+                    <Month>10</Month>
+                    <Day>17</Day>
+                </DateRevised>
+                <Article PubModel="Print">
+                    <Journal>
+                        <ISSN IssnType="Print">0098-7484</ISSN>
+                        <JournalIssue CitedMedium="Print">
+                            <Volume>288</Volume>
+                            <Issue>2</Issue>
+                            <PubDate>
+                                <Year>2002</Year>
+                                <Month>Jul</Month>
+                                <Day>10</Day>
+                            </PubDate>
+                        </JournalIssue>
+                        <Title>JAMA</Title>
+                        <ISOAbbreviation>JAMA</ISOAbbreviation>
+                    </Journal>
+                    <ArticleTitle>Policies for exposure to bloodborne pathogens among US-based international voluntary medical organizations.</ArticleTitle>
+                    <Pagination>
+                        <MedlinePgn>166</MedlinePgn>
+                    </Pagination>
+                    <AuthorList CompleteYN="Y">
+                        <Author ValidYN="Y">
+                            <LastName>Edler</LastName>
+                            <ForeName>Alice</ForeName>
+                            <Initials>A</Initials>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Olsen</LastName>
+                            <ForeName>Margaret A</ForeName>
+                            <Initials>MA</Initials>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Mbwille</LastName>
+                            <ForeName>M C E</ForeName>
+                            <Initials>MC</Initials>
+                        </Author>
+                    </AuthorList>
+                    <Language>eng</Language>
+                    <PublicationTypeList>
+                        <PublicationType UI="D016422">Letter</PublicationType>
+                    </PublicationTypeList>
+                </Article>
+                <MedlineJournalInfo>
+                    <Country>United States</Country>
+                    <MedlineTA>JAMA</MedlineTA>
+                    <NlmUniqueID>7501160</NlmUniqueID>
+                    <ISSNLinking>0098-7484</ISSNLinking>
+                </MedlineJournalInfo>
+                <CitationSubset>AIM</CitationSubset>
+                <CitationSubset>IM</CitationSubset>
+                <MeshHeadingList>
+                    <MeshHeading>
+                        <DescriptorName UI="D017848" MajorTopicYN="Y">Blood-Borne Pathogens</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D003906" MajorTopicYN="N">Developing Countries</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D015658" MajorTopicYN="N">HIV Infections</DescriptorName>
+                        <QualifierName UI="Q000517" MajorTopicYN="Y">prevention &amp; control</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D006282" MajorTopicYN="N">Health Personnel</DescriptorName>
+                        <QualifierName UI="Q000592" MajorTopicYN="Y">standards</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D007390" MajorTopicYN="N">International Agencies</DescriptorName>
+                        <QualifierName UI="Q000592" MajorTopicYN="Y">standards</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D016273" MajorTopicYN="N">Occupational Exposure</DescriptorName>
+                        <QualifierName UI="Q000517" MajorTopicYN="Y">prevention &amp; control</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D011050" MajorTopicYN="N">Policy Making</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D014837" MajorTopicYN="N">Voluntary Health Agencies</DescriptorName>
+                        <QualifierName UI="Q000592" MajorTopicYN="Y">standards</QualifierName>
+                    </MeshHeading>
+                </MeshHeadingList>
+            </MedlineCitation>
+            <PubmedData>
+                <History>
+                    <PubMedPubDate PubStatus="pubmed">
+                        <Year>2002</Year>
+                        <Month>7</Month>
+                        <Day>4</Day>
+                        <Hour>10</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="medline">
+                        <Year>2002</Year>
+                        <Month>7</Month>
+                        <Day>19</Day>
+                        <Hour>10</Hour>
+                        <Minute>1</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="entrez">
+                        <Year>2002</Year>
+                        <Month>7</Month>
+                        <Day>4</Day>
+                        <Hour>10</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                </History>
+                <PublicationStatus>ppublish</PublicationStatus>
+                <ArticleIdList>
+                    <ArticleId IdType="pubmed">12095380</ArticleId>
+                    <ArticleId IdType="pii">jlt0710-5</ArticleId>
+                </ArticleIdList>
+            </PubmedData>
+        </PubmedArticle>
+
+        </PubmedArticleSet>
+    http_version: 
+  recorded_at: Wed, 03 Apr 2019 23:00:39 GMT
+- request:
+    method: post
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=Settings.PUBMED.API_KEY&db=pubmed&retmode=xml
+    body:
+      encoding: UTF-8
+      string: "&id=&id=20661010"
+    headers:
+      User-Agent:
+      - stanford-library-sul-pub
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 03 Apr 2019 23:00:39 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 03 Apr 2019 23:00:39 GMT
+      Server:
+      - Finatra
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Ratelimit-Remaining:
+      - '6'
+      Ncbi-Phid:
+      - D0BDAAD496ED878500002091B609DCDD.1.1.m_3
+      Cache-Control:
+      - private
+      L5d-Success-Class:
+      - '1.0'
+      Ncbi-Sid:
+      - 5C56991BA7711E6F_6040SID
+      Content-Encoding:
+      - gzip
+      X-Ratelimit-Limit:
+      - '10'
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Set-Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID; domain=.nih.gov; path=/; expires=Fri, 03
+        Apr 2020 23:00:40 GMT
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" ?>
+        <!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2019//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_190101.dtd">
+        <PubmedArticleSet>
+        <PubmedArticle>
+            <MedlineCitation Status="MEDLINE" Owner="NLM">
+                <PMID Version="1">20661010</PMID>
+                <DateCompleted>
+                    <Year>2010</Year>
+                    <Month>12</Month>
+                    <Day>20</Day>
+                </DateCompleted>
+                <DateRevised>
+                    <Year>2011</Year>
+                    <Month>03</Month>
+                    <Day>03</Day>
+                </DateRevised>
+                <Article PubModel="Print">
+                    <Journal>
+                        <ISSN IssnType="Electronic">1559-713X</ISSN>
+                        <JournalIssue CitedMedium="Internet">
+                            <Volume>5</Volume>
+                            <Issue>2</Issue>
+                            <PubDate>
+                                <Year>2010</Year>
+                                <Month>Apr</Month>
+                            </PubDate>
+                        </JournalIssue>
+                        <Title>Simulation in healthcare : journal of the Society for Simulation in Healthcare</Title>
+                        <ISOAbbreviation>Simul Healthc</ISOAbbreviation>
+                    </Journal>
+                    <ArticleTitle>Affordable simulation for small-scale training and assessment.</ArticleTitle>
+                    <Pagination>
+                        <MedlinePgn>112-5</MedlinePgn>
+                    </Pagination>
+                    <ELocationID EIdType="doi" ValidYN="Y">10.1097/SIH.0b013e3181c76332</ELocationID>
+                    <Abstract>
+                        <AbstractText Label="INTRODUCTION" NlmCategory="BACKGROUND">High-fidelity patient simulation is increasingly recognized as an effective means of team training, acquisition and maintenance of technical and professional skills, and reliable performance assessment; however, finding a cost effective solution to providing such instruction can be difficult. This report describes the rationale, design, and appropriateness of a portable simulation model and example of its successful use at national meetings.</AbstractText>
+                        <AbstractText Label="METHODS" NlmCategory="METHODS">The Stanford Simulation Group, in association with several other centers, developed a portable Pediatric Simulation Training and Assessment Program (Pediatric Anesthesia in-Situ Simulation) and presented it at two national meetings. The technical challenges and costs of development are outlined, and a satisfaction survey was conducted at the completion of the program.</AbstractText>
+                        <AbstractText Label="RESULTS" NlmCategory="RESULTS">All respondents (100%) either agreed or strongly agreed that the course was useful, met expectations, was enjoyable, and that the scenarios were realistic.</AbstractText>
+                        <AbstractText Label="CONCLUSIONS" NlmCategory="CONCLUSIONS">The Portable Simulation Training and Assessment Program (Pediatric Anesthesia in-Situ Simulation) presents innovative educational and financial opportunities to assist in both training and assessment of critical emergency response skills at smaller institutions and allows specialized instruction in an in situ setting.</AbstractText>
+                    </Abstract>
+                    <AuthorList CompleteYN="Y">
+                        <Author ValidYN="Y">
+                            <LastName>Edler</LastName>
+                            <ForeName>Alice A</ForeName>
+                            <Initials>AA</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>Department of Anesthesia, Stanford University School of Medicine, Stanford, CA 94305, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Chen</LastName>
+                            <ForeName>Michael</ForeName>
+                            <Initials>M</Initials>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Honkanen</LastName>
+                            <ForeName>Anita</ForeName>
+                            <Initials>A</Initials>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Hackel</LastName>
+                            <ForeName>Al</ForeName>
+                            <Initials>A</Initials>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Golianu</LastName>
+                            <ForeName>Brenda</ForeName>
+                            <Initials>B</Initials>
+                        </Author>
+                    </AuthorList>
+                    <Language>eng</Language>
+                    <PublicationTypeList>
+                        <PublicationType UI="D016428">Journal Article</PublicationType>
+                    </PublicationTypeList>
+                </Article>
+                <MedlineJournalInfo>
+                    <Country>United States</Country>
+                    <MedlineTA>Simul Healthc</MedlineTA>
+                    <NlmUniqueID>101264408</NlmUniqueID>
+                    <ISSNLinking>1559-2332</ISSNLinking>
+                </MedlineJournalInfo>
+                <CitationSubset>IM</CitationSubset>
+                <CommentsCorrectionsList>
+                    <CommentsCorrections RefType="CommentIn">
+                        <RefSource>Simul Healthc. 2010 Aug;5(4):254; discussion 254</RefSource>
+                        <PMID Version="1">20703147</PMID>
+                    </CommentsCorrections>
+                </CommentsCorrectionsList>
+                <MeshHeadingList>
+                    <MeshHeading>
+                        <DescriptorName UI="D000758" MajorTopicYN="N">Anesthesia</DescriptorName>
+                        <QualifierName UI="Q000379" MajorTopicYN="N">methods</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D000776" MajorTopicYN="N">Anesthesiology</DescriptorName>
+                        <QualifierName UI="Q000193" MajorTopicYN="N">education</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D003198" MajorTopicYN="N">Computer Simulation</DescriptorName>
+                        <QualifierName UI="Q000191" MajorTopicYN="Y">economics</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D004502" MajorTopicYN="N">Education, Medical, Continuing</DescriptorName>
+                        <QualifierName UI="Q000191" MajorTopicYN="N">economics</QualifierName>
+                        <QualifierName UI="Q000379" MajorTopicYN="Y">methods</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D008348" MajorTopicYN="N">Manikins</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D010372" MajorTopicYN="N">Pediatrics</DescriptorName>
+                        <QualifierName UI="Q000191" MajorTopicYN="N">economics</QualifierName>
+                        <QualifierName UI="Q000193" MajorTopicYN="Y">education</QualifierName>
+                        <QualifierName UI="Q000379" MajorTopicYN="N">methods</QualifierName>
+                    </MeshHeading>
+                </MeshHeadingList>
+            </MedlineCitation>
+            <PubmedData>
+                <History>
+                    <PubMedPubDate PubStatus="entrez">
+                        <Year>2010</Year>
+                        <Month>7</Month>
+                        <Day>28</Day>
+                        <Hour>6</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="pubmed">
+                        <Year>2010</Year>
+                        <Month>7</Month>
+                        <Day>28</Day>
+                        <Hour>6</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="medline">
+                        <Year>2010</Year>
+                        <Month>12</Month>
+                        <Day>21</Day>
+                        <Hour>6</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                </History>
+                <PublicationStatus>ppublish</PublicationStatus>
+                <ArticleIdList>
+                    <ArticleId IdType="pubmed">20661010</ArticleId>
+                    <ArticleId IdType="doi">10.1097/SIH.0b013e3181c76332</ArticleId>
+                    <ArticleId IdType="pii">01266021-201004000-00007</ArticleId>
+                </ArticleIdList>
+            </PubmedData>
+        </PubmedArticle>
+
+        </PubmedArticleSet>
+    http_version: 
+  recorded_at: Wed, 03 Apr 2019 23:00:39 GMT
+- request:
+    method: post
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=Settings.PUBMED.API_KEY&db=pubmed&retmode=xml
+    body:
+      encoding: UTF-8
+      string: "&id=&id=20029255"
+    headers:
+      User-Agent:
+      - stanford-library-sul-pub
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 03 Apr 2019 23:00:40 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 03 Apr 2019 23:00:39 GMT
+      Server:
+      - Finatra
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Ratelimit-Remaining:
+      - '6'
+      Ncbi-Phid:
+      - D0BDAAD496ED878500002091B6919469.1.1.m_3
+      Cache-Control:
+      - private
+      L5d-Success-Class:
+      - '1.0'
+      Ncbi-Sid:
+      - 5C56991BA7711E6F_6040SID
+      Content-Encoding:
+      - gzip
+      X-Ratelimit-Limit:
+      - '10'
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Set-Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID; domain=.nih.gov; path=/; expires=Fri, 03
+        Apr 2020 23:00:40 GMT
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" ?>
+        <!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2019//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_190101.dtd">
+        <PubmedArticleSet>
+        <PubmedArticle>
+            <MedlineCitation Status="MEDLINE" Owner="NLM">
+                <PMID Version="1">20029255</PMID>
+                <DateCompleted>
+                    <Year>2010</Year>
+                    <Month>01</Month>
+                    <Day>12</Day>
+                </DateCompleted>
+                <DateRevised>
+                    <Year>2009</Year>
+                    <Month>12</Month>
+                    <Day>23</Day>
+                </DateRevised>
+                <Article PubModel="Print">
+                    <Journal>
+                        <ISSN IssnType="Electronic">1528-1175</ISSN>
+                        <JournalIssue CitedMedium="Internet">
+                            <Volume>111</Volume>
+                            <Issue>4</Issue>
+                            <PubDate>
+                                <Year>2009</Year>
+                                <Month>Oct</Month>
+                            </PubDate>
+                        </JournalIssue>
+                        <Title>Anesthesiology</Title>
+                        <ISOAbbreviation>Anesthesiology</ISOAbbreviation>
+                    </Journal>
+                    <ArticleTitle>Paradigm consciousness: a new approach to understanding anesthesia knowledge and education.</ArticleTitle>
+                    <Pagination>
+                        <MedlinePgn>920</MedlinePgn>
+                    </Pagination>
+                    <ELocationID EIdType="doi" ValidYN="Y">10.1097/ALN.0b013e3181b43948</ELocationID>
+                    <AuthorList CompleteYN="Y">
+                        <Author ValidYN="Y">
+                            <LastName>Edler</LastName>
+                            <ForeName>Alice A</ForeName>
+                            <Initials>AA</Initials>
+                        </Author>
+                    </AuthorList>
+                    <Language>eng</Language>
+                    <PublicationTypeList>
+                        <PublicationType UI="D016420">Comment</PublicationType>
+                        <PublicationType UI="D016422">Letter</PublicationType>
+                    </PublicationTypeList>
+                </Article>
+                <MedlineJournalInfo>
+                    <Country>United States</Country>
+                    <MedlineTA>Anesthesiology</MedlineTA>
+                    <NlmUniqueID>1300217</NlmUniqueID>
+                    <ISSNLinking>0003-3022</ISSNLinking>
+                </MedlineJournalInfo>
+                <CitationSubset>AIM</CitationSubset>
+                <CitationSubset>IM</CitationSubset>
+                <CommentsCorrectionsList>
+                    <CommentsCorrections RefType="CommentOn">
+                        <RefSource>Anesthesiology. 2009 Mar;110(3):480-6</RefSource>
+                        <PMID Version="1">19225393</PMID>
+                    </CommentsCorrections>
+                </CommentsCorrectionsList>
+                <MeshHeadingList>
+                    <MeshHeading>
+                        <DescriptorName UI="D000758" MajorTopicYN="Y">Anesthesia</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D000776" MajorTopicYN="N">Anesthesiology</DescriptorName>
+                        <QualifierName UI="Q000193" MajorTopicYN="Y">education</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D007258" MajorTopicYN="N">Informed Consent</DescriptorName>
+                        <QualifierName UI="Q000592" MajorTopicYN="Y">standards</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D013663" MajorTopicYN="N">Teaching</DescriptorName>
+                    </MeshHeading>
+                </MeshHeadingList>
+            </MedlineCitation>
+            <PubmedData>
+                <History>
+                    <PubMedPubDate PubStatus="entrez">
+                        <Year>2009</Year>
+                        <Month>12</Month>
+                        <Day>24</Day>
+                        <Hour>6</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="pubmed">
+                        <Year>2009</Year>
+                        <Month>12</Month>
+                        <Day>24</Day>
+                        <Hour>6</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="medline">
+                        <Year>2010</Year>
+                        <Month>1</Month>
+                        <Day>13</Day>
+                        <Hour>6</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                </History>
+                <PublicationStatus>ppublish</PublicationStatus>
+                <ArticleIdList>
+                    <ArticleId IdType="pubmed">20029255</ArticleId>
+                    <ArticleId IdType="doi">10.1097/ALN.0b013e3181b43948</ArticleId>
+                    <ArticleId IdType="pii">00000542-200910000-00036</ArticleId>
+                </ArticleIdList>
+            </PubmedData>
+        </PubmedArticle>
+
+        </PubmedArticleSet>
+    http_version: 
+  recorded_at: Wed, 03 Apr 2019 23:00:40 GMT
+- request:
+    method: post
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=Settings.PUBMED.API_KEY&db=pubmed&retmode=xml
+    body:
+      encoding: UTF-8
+      string: "&id=&id=19335353"
+    headers:
+      User-Agent:
+      - stanford-library-sul-pub
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 03 Apr 2019 23:00:40 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 03 Apr 2019 23:00:40 GMT
+      Server:
+      - Finatra
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Ratelimit-Remaining:
+      - '7'
+      Ncbi-Phid:
+      - D0BDAAD496ED878500002791B772EF99.1.1.m_3
+      Cache-Control:
+      - private
+      L5d-Success-Class:
+      - '1.0'
+      Ncbi-Sid:
+      - 5C56991BA7711E6F_6040SID
+      Content-Encoding:
+      - gzip
+      X-Ratelimit-Limit:
+      - '10'
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Set-Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID; domain=.nih.gov; path=/; expires=Fri, 03
+        Apr 2020 23:00:40 GMT
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" ?>
+        <!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2019//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_190101.dtd">
+        <PubmedArticleSet>
+        <PubmedArticle>
+            <MedlineCitation Status="MEDLINE" Owner="NLM">
+                <PMID Version="1">19335353</PMID>
+                <DateCompleted>
+                    <Year>2009</Year>
+                    <Month>07</Month>
+                    <Day>16</Day>
+                </DateCompleted>
+                <DateRevised>
+                    <Year>2009</Year>
+                    <Month>04</Month>
+                    <Day>01</Day>
+                </DateRevised>
+                <Article PubModel="Print">
+                    <Journal>
+                        <ISSN IssnType="Electronic">1460-9592</ISSN>
+                        <JournalIssue CitedMedium="Internet">
+                            <Volume>19</Volume>
+                            <Issue>4</Issue>
+                            <PubDate>
+                                <Year>2009</Year>
+                                <Month>Apr</Month>
+                            </PubDate>
+                        </JournalIssue>
+                        <Title>Paediatric anaesthesia</Title>
+                        <ISOAbbreviation>Paediatr Anaesth</ISOAbbreviation>
+                    </Journal>
+                    <ArticleTitle>A case series of airway management for wireless capsule endoscopy in pediatric patients.</ArticleTitle>
+                    <Pagination>
+                        <MedlinePgn>406-7</MedlinePgn>
+                    </Pagination>
+                    <ELocationID EIdType="doi" ValidYN="Y">10.1111/j.1460-9592.2009.02945.x</ELocationID>
+                    <AuthorList CompleteYN="Y">
+                        <Author ValidYN="Y">
+                            <LastName>Edler</LastName>
+                            <ForeName>Alice</ForeName>
+                            <Initials>A</Initials>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Claure</LastName>
+                            <ForeName>Rebecca</ForeName>
+                            <Initials>R</Initials>
+                        </Author>
+                    </AuthorList>
+                    <Language>eng</Language>
+                    <PublicationTypeList>
+                        <PublicationType UI="D016422">Letter</PublicationType>
+                    </PublicationTypeList>
+                </Article>
+                <MedlineJournalInfo>
+                    <Country>France</Country>
+                    <MedlineTA>Paediatr Anaesth</MedlineTA>
+                    <NlmUniqueID>9206575</NlmUniqueID>
+                    <ISSNLinking>1155-5645</ISSNLinking>
+                </MedlineJournalInfo>
+                <CitationSubset>IM</CitationSubset>
+                <MeshHeadingList>
+                    <MeshHeading>
+                        <DescriptorName UI="D000768" MajorTopicYN="Y">Anesthesia, General</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D053704" MajorTopicYN="Y">Capsule Endoscopy</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D002648" MajorTopicYN="N">Child</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D004064" MajorTopicYN="N">Digestive System</DescriptorName>
+                        <QualifierName UI="Q000033" MajorTopicYN="N">anatomy &amp; histology</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D007442" MajorTopicYN="N">Intubation, Intratracheal</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D008279" MajorTopicYN="N">Magnetic Resonance Imaging</DescriptorName>
+                    </MeshHeading>
+                </MeshHeadingList>
+            </MedlineCitation>
+            <PubmedData>
+                <History>
+                    <PubMedPubDate PubStatus="entrez">
+                        <Year>2009</Year>
+                        <Month>4</Month>
+                        <Day>2</Day>
+                        <Hour>9</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="pubmed">
+                        <Year>2009</Year>
+                        <Month>4</Month>
+                        <Day>2</Day>
+                        <Hour>9</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="medline">
+                        <Year>2009</Year>
+                        <Month>7</Month>
+                        <Day>17</Day>
+                        <Hour>9</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                </History>
+                <PublicationStatus>ppublish</PublicationStatus>
+                <ArticleIdList>
+                    <ArticleId IdType="pubmed">19335353</ArticleId>
+                    <ArticleId IdType="pii">PAN2945</ArticleId>
+                    <ArticleId IdType="doi">10.1111/j.1460-9592.2009.02945.x</ArticleId>
+                </ArticleIdList>
+            </PubmedData>
+        </PubmedArticle>
+
+        </PubmedArticleSet>
+    http_version: 
+  recorded_at: Wed, 03 Apr 2019 23:00:40 GMT
+- request:
+    method: post
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?api_key=Settings.PUBMED.API_KEY&db=pubmed&retmax=100000&retmode=xml
+    body:
+      encoding: UTF-8
+      string: term=((Edler Alice[Author])) AND (Stanford University[Affiliation])
+    headers:
+      User-Agent:
+      - stanford-library-sul-pub
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 03 Apr 2019 23:00:40 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 03 Apr 2019 23:00:40 GMT
+      Server:
+      - Finatra
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Ratelimit-Remaining:
+      - '6'
+      Ncbi-Phid:
+      - D0BDAAD496ED878500002091B8250BD9.1.1.m_1
+      Cache-Control:
+      - private
+      L5d-Success-Class:
+      - '1.0'
+      Ncbi-Sid:
+      - 5C56991BA7711E6F_6040SID
+      Content-Encoding:
+      - gzip
+      X-Ratelimit-Limit:
+      - '10'
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Set-Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID; domain=.nih.gov; path=/; expires=Fri, 03
+        Apr 2020 23:00:40 GMT
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n<!DOCTYPE eSearchResult
+        PUBLIC \"-//NLM//DTD esearch 20060628//EN\" \"https://eutils.ncbi.nlm.nih.gov/eutils/dtd/20060628/esearch.dtd\">\n<eSearchResult>\n<Count>8</Count><RetMax>8</RetMax><RetStart>0</RetStart>\n<IdList>\n\t<Id>21134139</Id>\n\t<Id>20661010</Id>\n\t<Id>20386227</Id>\n\t<Id>18083476</Id>\n\t<Id>19088623</Id>\n\t<Id>17377083</Id>\n\t<Id>16517323</Id>\n\t<Id>14617124</Id>\n</IdList>\n<TranslationSet><Translation>
+        \    <From>Edler Alice[Author]</From>     <To>Edler, Alice[Full Author Name]</To>
+        \   </Translation></TranslationSet><TranslationStack>   <TermSet>    <Term>Edler,
+        Alice[Full Author Name]</Term>    <Field>Full Author Name</Field>    <Count>18</Count>
+        \   <Explode>N</Explode>   </TermSet>   <TermSet>    <Term>Stanford University[Affiliation]</Term>
+        \   <Field>Affiliation</Field>    <Count>85296</Count>    <Explode>N</Explode>
+        \  </TermSet>   <OP>AND</OP>  </TranslationStack><QueryTranslation>Edler,
+        Alice[Full Author Name] AND Stanford University[Affiliation]</QueryTranslation>\n\n</eSearchResult>\n"
+    http_version: 
+  recorded_at: Wed, 03 Apr 2019 23:00:40 GMT
+- request:
+    method: post
+    uri: http://search.webofknowledge.com/esti/wokmws/ws/WokSearch
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://woksearch.v3.wokmws.thomsonreuters.com"
+        xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Body><tns:search><queryParameters><databaseId>WOK</databaseId><userQuery>AU=(&quot;Edler,Alice&quot;
+        OR &quot;Edler,Alice,Jim&quot; OR &quot;Edler,Alice,J&quot;) AND AD=(&quot;stanford&quot;)</userQuery><queryLanguage>en</queryLanguage></queryParameters><retrieveParameters><firstRecord>1</firstRecord><count>100</count><viewField><collectionName>WOS</collectionName><fieldName></fieldName></viewField><viewField><collectionName>MEDLINE</collectionName><fieldName></fieldName></viewField><option><key>RecordIDs</key><value>On</value></option></retrieveParameters></tns:search></soapenv:Body></soapenv:Envelope>
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.5.1 (2018-03-29))
+      Accept:
+      - "*/*"
+      Date:
+      - Wed, 03 Apr 2019 23:00:40 GMT
+      Cookie:
+      - SID="7BpaQrkTPsk18oNgGx1"
+      Soapaction:
+      - ''
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Content-Length:
+      - '890'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Date:
+      - Wed, 03 Apr 2019 23:00:40 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Content-Length:
+      - '5236'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><ns2:searchResponse
+        xmlns:ns2="http://woksearch.v3.wokmws.thomsonreuters.com"><return><queryId>3</queryId><recordsFound>18</recordsFound><recordsSearched>81062482</recordsSearched><optionValue><label>RecordIDs</label><value>WOS:000218296900007</value><value>MEDLINE:19088623</value><value>WOS:000264165900021</value><value>WOS:000252230800009</value><value>WOS:000270210100035</value><value>WOS:000212962700007</value><value>WOS:000276938400007</value><value>WOS:000249038700050</value><value>WOS:000217248400003</value><value>WOS:000236198500001</value><value>WOS:000251905400030</value><value>WOS:000250317500068</value><value>WOS:000176711100016</value><value>WOS:000212958400021</value><value>WOS:000186655000011</value><value>WOS:000256730800021</value><value>WOS:000259817100020</value><value>WOS:000245371900010</value></optionValue><records>&lt;records
+        xmlns="http://scientific.thomsonreuters.com/schema/wok5.4/public/Fields">&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000218296900007&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>MEDLINE:19088623&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000264165900021&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000252230800009&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000270210100035&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000212962700007&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000276938400007&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000249038700050&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000217248400003&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000236198500001&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000251905400030&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000250317500068&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000176711100016&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000212958400021&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000186655000011&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data&gt;&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000256730800021&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000259817100020&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>WOS:000245371900010&lt;/UID>&lt;static_data>&lt;/static_data>&lt;dynamic_data>&lt;cluster_related>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;/records></records></return></ns2:searchResponse></soap:Body></soap:Envelope>
+    http_version: 
+  recorded_at: Wed, 03 Apr 2019 23:00:41 GMT
+- request:
+    method: post
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?api_key=Settings.PUBMED.API_KEY&db=pubmed&retmax=100000&retmode=xml
+    body:
+      encoding: UTF-8
+      string: term=((Edler Alice[Author])) AND (Stanford University[Affiliation])
+    headers:
+      User-Agent:
+      - stanford-library-sul-pub
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 03 Apr 2019 23:00:42 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID
+      Content-Length:
+      - '67'
+      Host:
+      - eutils.ncbi.nlm.nih.gov
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 03 Apr 2019 23:00:42 GMT
+      Server:
+      - Finatra
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Ratelimit-Remaining:
+      - '9'
+      Ncbi-Phid:
+      - D0BDAAD496ED878500002791BC3F8C39.1.1.m_1
+      Cache-Control:
+      - private
+      L5d-Success-Class:
+      - '1.0'
+      Ncbi-Sid:
+      - 5C56991BA7711E6F_6040SID
+      Content-Encoding:
+      - gzip
+      X-Ratelimit-Limit:
+      - '10'
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Set-Cookie:
+      - ncbi_sid=5C56991BA7711E6F_6040SID; domain=.nih.gov; path=/; expires=Fri, 03
+        Apr 2020 23:00:43 GMT
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n<!DOCTYPE eSearchResult
+        PUBLIC \"-//NLM//DTD esearch 20060628//EN\" \"https://eutils.ncbi.nlm.nih.gov/eutils/dtd/20060628/esearch.dtd\">\n<eSearchResult>\n<Count>8</Count><RetMax>8</RetMax><RetStart>0</RetStart>\n<IdList>\n\t<Id>21134139</Id>\n\t<Id>20661010</Id>\n\t<Id>20386227</Id>\n\t<Id>18083476</Id>\n\t<Id>19088623</Id>\n\t<Id>17377083</Id>\n\t<Id>16517323</Id>\n\t<Id>14617124</Id>\n</IdList>\n<TranslationSet><Translation>
+        \    <From>Edler Alice[Author]</From>     <To>Edler, Alice[Full Author Name]</To>
+        \   </Translation></TranslationSet><TranslationStack>   <TermSet>    <Term>Edler,
+        Alice[Full Author Name]</Term>    <Field>Full Author Name</Field>    <Count>18</Count>
+        \   <Explode>N</Explode>   </TermSet>   <TermSet>    <Term>Stanford University[Affiliation]</Term>
+        \   <Field>Affiliation</Field>    <Count>85296</Count>    <Explode>N</Explode>
+        \  </TermSet>   <OP>AND</OP>  </TranslationStack><QueryTranslation>Edler,
+        Alice[Full Author Name] AND Stanford University[Affiliation]</QueryTranslation>\n\n</eSearchResult>\n"
+    http_version: 
+  recorded_at: Wed, 03 Apr 2019 23:00:42 GMT
+recorded_with: VCR 4.0.0

--- a/lib/all_sources/harvester.rb
+++ b/lib/all_sources/harvester.rb
@@ -1,0 +1,16 @@
+# a class that will harvest from all sources, useful for the regular cron jobs
+module AllSources
+  class Harvester < ::Harvester::Base
+    # Harvest all publications for an author from all sources
+    # @param [Author] author
+    # @param [Hash] options
+    # @return [Array<String>] WosUIDs that create Publications
+    def process_author(author, options = {})
+      raise(ArgumentError, 'author must be an Author') unless author.is_a? Author
+      WebOfScience.harvester.process_author(author, options) if Settings.WOS.enabled
+      Pubmed.harvester.process_author(author, options)
+    rescue StandardError => err
+      NotificationManager.error(err, "#{self.class} - harvest all sources failed for author #{author.id}", self)
+    end
+  end
+end

--- a/lib/pubmed/harvester.rb
+++ b/lib/pubmed/harvester.rb
@@ -4,19 +4,18 @@ module Pubmed
   # This class is responsible for processing Pubmed API response data
   # to integrate it into the application data models.
   class Harvester < ::Harvester::Base
-    # Harvest all publications for an author
+    # Harvest all publications for an author from Pubmed
     # @param [Author] author
     # @param [Hash] _options
     # @return [Array<String>] pmids that create Publications
     def process_author(author, options = {})
       raise(ArgumentError, 'author must be an Author') unless author.is_a? Author
       log_info(author, "processing author #{author.id}")
-
       pmids = process_pmids(author, Pubmed::QueryAuthor.new(author, options).pmids)
       log_info(author, "processed author #{author.id}: #{pmids.count} new publications")
       pmids
     rescue StandardError => err
-      NotificationManager.error(err, "#{self.class} - harvest failed for author #{author.id}", self)
+      NotificationManager.error(err, "#{self.class} - Pubmed harvest failed for author #{author.id}", self)
     end
 
     private

--- a/lib/tasks/harvest.rake
+++ b/lib/tasks/harvest.rake
@@ -1,0 +1,33 @@
+namespace :harvest do
+  desc 'Harvest from all sources, for all authors, for all time'
+  task all_authors: :environment do
+    AllSources::Harvester.new.harvest_all
+  end
+
+  desc 'Update harvest from all sources, for all authors, using default update timeframes'
+  task all_authors_update: :environment do
+    options = {
+      symbolicTimeSpan: Settings.WOS.regular_harvest_timeframe,
+      relDate: Settings.PUBMED.regular_harvest_timeframe
+    }
+    AllSources::Harvester.new.harvest_all(options)
+  end
+
+  desc 'Harvest from all sources for single author, for all time'
+  task :author, [:cap_profile_id] => :environment do |_t, args|
+    author = Author.find_by(cap_profile_id: args[:cap_profile_id])
+    raise "Could not find Author by cap_profile_id: #{args[:cap_profile_id]}." if author.nil?
+    AllSources::Harvester.new.process_author(author)
+  end
+
+  desc 'Harvest from all sources for single author, using default update timeframes'
+  task :author_update, [:cap_profile_id] => :environment do |_t, args|
+    author = Author.find_by(cap_profile_id: args[:cap_profile_id])
+    raise "Could not find Author by cap_profile_id: #{args[:cap_profile_id]}." if author.nil?
+    options = {
+      symbolicTimeSpan: Settings.WOS.regular_harvest_timeframe,
+      relDate: Settings.PUBMED.regular_harvest_timeframe
+    }
+    AllSources::Harvester.new.process_author(author, options)
+  end
+end

--- a/lib/tasks/pubmed.rake
+++ b/lib/tasks/pubmed.rake
@@ -122,7 +122,7 @@ namespace :pubmed do
   #   puts "errors: #{failed}"
   # end
 
-  desc 'Harvest from Pubmed, for all authors'
+  desc 'Harvest from Pubmed, for all authors, for all time'
   task harvest_authors: :environment do
     Pubmed.harvester.harvest_all
   end

--- a/lib/tasks/wos.rake
+++ b/lib/tasks/wos.rake
@@ -12,7 +12,7 @@ namespace :wos do
     puts "#{new_uids.count} newly associated Contributions"
   end
 
-  desc 'Harvest from Web of Science, for all authors'
+  desc 'Harvest from Web of Science, for all authors, for all time'
   task harvest_authors: :environment do
     WebOfScience.harvester.harvest_all
   end

--- a/lib/web_of_science/harvester.rb
+++ b/lib/web_of_science/harvester.rb
@@ -4,7 +4,7 @@ module WebOfScience
   # This class is responsible for processing WebOfScience API response data
   # to integrate it into the application data models.
   class Harvester < ::Harvester::Base
-    # Harvest all publications for an author
+    # Harvest all publications for an author from Web of Science
     # @param [Author] author
     # @param [Hash] options
     # @return [Array<String>] WosUIDs that create Publications
@@ -15,7 +15,7 @@ module WebOfScience
       log_info(author, "processed author #{author.id}: #{uids.count} new publications")
       uids
     rescue StandardError => err
-      NotificationManager.error(err, "#{self.class} - harvest failed for author #{author.id}", self)
+      NotificationManager.error(err, "#{self.class} - WoS harvest failed for author #{author.id}", self)
     end
 
     # Harvest WOS-UID publications for an author

--- a/spec/controllers/authors_controller_spec.rb
+++ b/spec/controllers/authors_controller_spec.rb
@@ -18,14 +18,7 @@ describe AuthorsController do
         expect do
           post :harvest, params: { cap_profile_id: author.cap_profile_id, format: :json }
           expect(response.status).to eq 202
-        end.to have_enqueued_job(AuthorHarvestJob).with(author.cap_profile_id.to_s, harvest_alternate_names: false)
-      end
-      it 'enqueues an AuthorHarvestJob with an Author and altNames parameter' do
-        ActiveJob::Base.queue_adapter = :test
-        expect do
-          post :harvest, params: { cap_profile_id: author.cap_profile_id, format: :json, altNames: 'true' }
-          expect(response.status).to eq 202
-        end.to have_enqueued_job(AuthorHarvestJob).with(author.cap_profile_id.to_s, harvest_alternate_names: true)
+        end.to have_enqueued_job(AuthorHarvestJob).with(author.cap_profile_id.to_s)
       end
     end
   end

--- a/spec/integration/author_harvest_spec.rb
+++ b/spec/integration/author_harvest_spec.rb
@@ -15,26 +15,15 @@ feature 'Author harvest', 'data-integration': true, type: :controller do
   ##
   # These tests test the /authors/{cap_profile_id}/harvest endpoint with real
   # Stanford authors.
-  scenario 'for an Author without alternate identities' do
+  scenario 'for an Author' do
     pre_harvest_count = author.publications.count
     post :harvest, cap_profile_id: author.cap_profile_id, format: :json
     expect(response.status).to eq 202
     sleep 10 # this is a delayed job API, wait for it to do something
     author.publications.reload
     post_harvest_count = author.publications.count
-    logger.info("author_harvest: author=#{author.last_name}, with-alt-names: false, pre: #{pre_harvest_count}, post: #{post_harvest_count}")
+    logger.info("author_harvest: author=#{author.last_name}, pre: #{pre_harvest_count}, post: #{post_harvest_count}")
     expect(post_harvest_count).to be >= pre_harvest_count
     expect(post_harvest_count).to be_between(500, 600) # 567 on 2016.05.13
-  end
-  scenario 'for an Author with alternate identities' do
-    pre_harvest_count = author.publications.count
-    post :harvest, cap_profile_id: author.cap_profile_id, format: :json, altNames: 'true'
-    expect(response.status).to eq 202
-    sleep 10 # this is a delayed job API, wait for it to do something
-    author.publications.reload
-    post_harvest_count = author.publications.count
-    logger.info("author_harvest: author=#{author.last_name}, with-alt-names: true,  pre: #{pre_harvest_count}, post: #{post_harvest_count}")
-    expect(post_harvest_count).to be >= pre_harvest_count
-    expect(post_harvest_count).to be_between(500, 600) # 568 on 2016.05.13
   end
 end

--- a/spec/lib/all_sources/harvester_spec.rb
+++ b/spec/lib/all_sources/harvester_spec.rb
@@ -1,0 +1,26 @@
+describe AllSources::Harvester do
+  let(:harvester) { described_class.new }
+
+  describe '#process_author' do
+    let(:options) { { some_options: 'here' } }
+    let(:author) { create :author }
+
+    context 'wos enabled' do
+      it 'calls both pubmed and wos harvester for the author' do
+        allow(Settings.WOS).to receive(:enabled).and_return(true)
+        expect(WebOfScience.harvester).to receive(:process_author).with(author, options)
+        expect(Pubmed.harvester).to receive(:process_author).with(author, options)
+        harvester.process_author(author, options)
+      end
+    end
+
+    context 'wos disabled' do
+      it 'calls only the pubmed harvester for the author' do
+        allow(Settings.WOS).to receive(:enabled).and_return(false)
+        expect(WebOfScience.harvester).not_to receive(:process_author).with(author, options)
+        expect(Pubmed.harvester).to receive(:process_author).with(author, options)
+        harvester.process_author(author, options)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- create a new harvester class subclassed from the base class that runs `process_author` for both WoS and Pubmed ...  running through the main `harvest_all` loop in the harvest base class only once for both sources will improve efficiency since we only query and iterate through all authors once (as opposed to querying and iterating over all others once for WoS and once for Pubmed for all authors)
- refactor the cap author poller class to take advantage of this new class instead of calling each source harvester separately
- create new rake tasks for harvesting authors for both sources
- update the cron jobs used in `schedule.rb` to use this new rake task 
- update the `author_harvest_job` class to use the new all sources class
- remove the 'harvest-alternate-names' parameter from the immediate harvest authors controller API call, it is not supported and wasn't working anyway
- some small clarifications to inline method documentation
