### PR TITLE
prefer pubmed central when searching by pmid

### DIFF
--- a/fixtures/vcr_cassettes/PubmedHarvester/_fetch_remote_pubmed/WOS_enabled/searches_WoS_if_not_found_in_pubmed_first.yml
+++ b/fixtures/vcr_cassettes/PubmedHarvester/_fetch_remote_pubmed/WOS_enabled/searches_WoS_if_not_found_in_pubmed_first.yml
@@ -8,11 +8,11 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - HTTPClient/1.0 (2.8.3, ruby 2.4.1 (2017-03-22))
+      - HTTPClient/1.0 (2.8.3, ruby 2.5.1 (2018-03-29))
       Accept:
       - "*/*"
       Date:
-      - Fri, 27 Apr 2018 01:52:05 GMT
+      - Tue, 19 Mar 2019 21:06:17 GMT
       Authorization:
       - Basic Settings.WOS.AUTH_CODE
       Soapaction:
@@ -25,7 +25,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Date:
-      - Fri, 27 Apr 2018 01:52:04 GMT
+      - Tue, 19 Mar 2019 21:06:18 GMT
       Server:
       - Apache-Coyote/1.1
       Content-Length:
@@ -224,7 +224,7 @@ http_interactions:
           </wsdl:service>
         </wsdl:definitions>
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 01:52:05 GMT
+  recorded_at: Tue, 19 Mar 2019 21:06:17 GMT
 - request:
     method: post
     uri: http://search.webofknowledge.com/esti/wokmws/ws/WOKMWSAuthenticate
@@ -235,11 +235,11 @@ http_interactions:
         xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Body><tns:authenticate></tns:authenticate></soapenv:Body></soapenv:Envelope>
     headers:
       User-Agent:
-      - HTTPClient/1.0 (2.8.3, ruby 2.4.1 (2017-03-22))
+      - HTTPClient/1.0 (2.8.3, ruby 2.5.1 (2018-03-29))
       Accept:
       - "*/*"
       Date:
-      - Fri, 27 Apr 2018 01:52:05 GMT
+      - Tue, 19 Mar 2019 21:06:17 GMT
       Authorization:
       - Basic Settings.WOS.AUTH_CODE
       Soapaction:
@@ -256,11 +256,11 @@ http_interactions:
       Content-Type:
       - text/xml;charset=UTF-8
       Date:
-      - Fri, 27 Apr 2018 01:52:04 GMT
+      - Tue, 19 Mar 2019 21:06:18 GMT
       Server:
       - Apache-Coyote/1.1
       Set-Cookie:
-      - SID=5D5X8HeUFbnJmObBHwA
+      - SID=5E4xpHsrxbsytjJctpO
       Content-Length:
       - '252'
       Connection:
@@ -268,9 +268,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><ns2:authenticateResponse
-        xmlns:ns2="http://auth.cxf.wokmws.thomsonreuters.com"><return>5D5X8HeUFbnJmObBHwA</return></ns2:authenticateResponse></soap:Body></soap:Envelope>
+        xmlns:ns2="http://auth.cxf.wokmws.thomsonreuters.com"><return>5E4xpHsrxbsytjJctpO</return></ns2:authenticateResponse></soap:Body></soap:Envelope>
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 01:52:05 GMT
+  recorded_at: Tue, 19 Mar 2019 21:06:17 GMT
 - request:
     method: get
     uri: http://search.webofknowledge.com/esti/wokmws/ws/WokSearch?wsdl
@@ -279,13 +279,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - HTTPClient/1.0 (2.8.3, ruby 2.4.1 (2017-03-22))
+      - HTTPClient/1.0 (2.8.3, ruby 2.5.1 (2018-03-29))
       Accept:
       - "*/*"
       Date:
-      - Fri, 27 Apr 2018 01:52:05 GMT
+      - Tue, 19 Mar 2019 21:06:17 GMT
       Cookie:
-      - SID="5D5X8HeUFbnJmObBHwA"
+      - SID="5E4xpHsrxbsytjJctpO"
       Soapaction:
       - ''
   response:
@@ -296,11 +296,11 @@ http_interactions:
       Content-Type:
       - text/xml
       Date:
-      - Fri, 27 Apr 2018 01:52:05 GMT
+      - Tue, 19 Mar 2019 21:06:17 GMT
       Server:
       - Apache-Coyote/1.1
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '32204'
       Connection:
       - keep-alive
     body:
@@ -988,7 +988,7 @@ http_interactions:
           </wsdl:service>
         </wsdl:definitions>
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 01:52:05 GMT
+  recorded_at: Tue, 19 Mar 2019 21:06:17 GMT
 - request:
     method: post
     uri: http://search.webofknowledge.com/esti/wokmws/ws/WokSearch
@@ -999,13 +999,13 @@ http_interactions:
         xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Body><tns:retrieveById><databaseId>WOK</databaseId><uid>MEDLINE:24930130</uid><queryLanguage>en</queryLanguage><retrieveParameters><firstRecord>1</firstRecord><count>100</count><option><key>RecordIDs</key><value>On</value></option><option><key>targetNamespace</key><value>http://scientific.thomsonreuters.com/schema/wok5.4/public/FullRecord</value></option></retrieveParameters></tns:retrieveById></soapenv:Body></soapenv:Envelope>
     headers:
       User-Agent:
-      - HTTPClient/1.0 (2.8.3, ruby 2.4.1 (2017-03-22))
+      - HTTPClient/1.0 (2.8.3, ruby 2.5.1 (2018-03-29))
       Accept:
       - "*/*"
       Date:
-      - Fri, 27 Apr 2018 01:52:05 GMT
+      - Tue, 19 Mar 2019 21:06:17 GMT
       Cookie:
-      - SID="5D5X8HeUFbnJmObBHwA"
+      - SID="5E4xpHsrxbsytjJctpO"
       Soapaction:
       - ''
       Content-Type:
@@ -1020,19 +1020,142 @@ http_interactions:
       Content-Type:
       - text/xml;charset=UTF-8
       Date:
-      - Fri, 27 Apr 2018 01:52:05 GMT
+      - Tue, 19 Mar 2019 21:06:18 GMT
       Server:
       - Apache-Coyote/1.1
       Content-Length:
-      - '20379'
+      - '13130'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: |-
-        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><ns2:retrieveByIdResponse xmlns:ns2="http://woksearch.v3.wokmws.thomsonreuters.com"><return><queryId>1</queryId><recordsFound>1</recordsFound><recordsSearched>76312650</recordsSearched><optionValue><label>RecordIDs</label><value>MEDLINE:24930130</value></optionValue><records>&lt;records xmlns="http://scientific.thomsonreuters.com/schema/wok5.4/public/FullRecord">
-        &lt;REC r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>MEDLINE:24930130&lt;/UID>&lt;static_data>&lt;summary>&lt;EWUID>&lt;WUID coll_id="MEDLINE">&lt;/WUID>&lt;edition value="MEDLINE.MEDLINE">&lt;/edition>&lt;/EWUID>&lt;pub_info sortdate="2014-08-01" pubyear="2014" pubmonth="Aug" coverdate="2014-Aug" edate="2014-06-15" vol="11" issue="8" pubtype="Journal" medium="Internet" model="Print-Electronic" has_abstract="Y">&lt;page begin="855" end="60">855-60&lt;/page>&lt;/pub_info>&lt;titles count="4">&lt;title type="item">Chemically defined generation of human cardiomyocytes.&lt;/title>&lt;title type="source">Nature methods&lt;/title>&lt;title type="abbrev_iso">Nat. Methods&lt;/title>&lt;title type="source_abbrev">Nat Methods&lt;/title>&lt;/titles>&lt;names count="15">&lt;name seq_no="1" role="author" display="Y">&lt;display_name>Burridge, Paul W&lt;/display_name>&lt;full_name>Burridge, Paul W&lt;/full_name>&lt;initials>PW&lt;/initials>&lt;/name>&lt;name seq_no="2" role="author" display="Y">&lt;display_name>Matsa, Elena&lt;/display_name>&lt;full_name>Matsa, Elena&lt;/full_name>&lt;initials>E&lt;/initials>&lt;/name>&lt;name seq_no="3" role="author" display="Y">&lt;display_name>Shukla, Praveen&lt;/display_name>&lt;full_name>Shukla, Praveen&lt;/full_name>&lt;initials>P&lt;/initials>&lt;/name>&lt;name seq_no="4" role="author" display="Y">&lt;display_name>Lin, Ziliang C&lt;/display_name>&lt;full_name>Lin, Ziliang C&lt;/full_name>&lt;initials>ZC&lt;/initials>&lt;/name>&lt;name seq_no="5" role="author" display="Y">&lt;display_name>Churko, Jared M&lt;/display_name>&lt;full_name>Churko, Jared M&lt;/full_name>&lt;initials>JM&lt;/initials>&lt;/name>&lt;name seq_no="6" role="author" display="Y">&lt;display_name>Ebert, Antje D&lt;/display_name>&lt;full_name>Ebert, Antje D&lt;/full_name>&lt;initials>AD&lt;/initials>&lt;/name>&lt;name seq_no="7" role="author" display="Y">&lt;display_name>Lan, Feng&lt;/display_name>&lt;full_name>Lan, Feng&lt;/full_name>&lt;initials>F&lt;/initials>&lt;/name>&lt;name seq_no="8" role="author" display="Y">&lt;display_name>Diecke, Sebastian&lt;/display_name>&lt;full_name>Diecke, Sebastian&lt;/full_name>&lt;initials>S&lt;/initials>&lt;/name>&lt;name seq_no="9" role="author" display="Y">&lt;display_name>Huber, Bruno&lt;/display_name>&lt;full_name>Huber, Bruno&lt;/full_name>&lt;initials>B&lt;/initials>&lt;/name>&lt;name seq_no="10" role="author" display="Y">&lt;display_name>Mordwinkin, Nicholas M&lt;/display_name>&lt;full_name>Mordwinkin, Nicholas M&lt;/full_name>&lt;initials>NM&lt;/initials>&lt;/name>&lt;name seq_no="11" role="author" display="Y">&lt;display_name>Plews, Jordan R&lt;/display_name>&lt;full_name>Plews, Jordan R&lt;/full_name>&lt;initials>JR&lt;/initials>&lt;/name>&lt;name seq_no="12" role="author" display="Y">&lt;display_name&gt;Abilez, Oscar J&lt;/display_name>&lt;full_name>Abilez, Oscar J&lt;/full_name>&lt;initials>OJ&lt;/initials>&lt;/name>&lt;name seq_no="13" role="author" display="Y">&lt;display_name>Cui, Bianxiao&lt;/display_name>&lt;full_name>Cui, Bianxiao&lt;/full_name>&lt;initials>B&lt;/initials>&lt;/name>&lt;name seq_no="14" role="author" display="Y">&lt;display_name>Gold, Joseph D&lt;/display_name>&lt;full_name>Gold, Joseph D&lt;/full_name>&lt;initials>JD&lt;/initials>&lt;/name>&lt;name seq_no="15" role="author" display="Y">&lt;display_name>Wu, Joseph C&lt;/display_name>&lt;full_name>Wu, Joseph C&lt;/full_name>&lt;initials>JC&lt;/initials>&lt;/name>&lt;/names>&lt;doctypes count="3">&lt;doctype>Journal Article&lt;/doctype>&lt;doctype>Research Support, N.I.H., Extramural&lt;/doctype>&lt;doctype>Research Support, Non-U.S. Gov&amp;apos;t&lt;/doctype>&lt;/doctypes>&lt;/summary>&lt;fullrecord_metadata>&lt;languages count="1">&lt;language type="primary">English&lt;/language>&lt;/languages>&lt;normalized_languages count="1">&lt;language type="primary">English&lt;/language>&lt;/normalized_languages>&lt;normalized_doctypes count="2">&lt;doctype>Article&lt;/doctype>&lt;doctype>Other&lt;/doctype>&lt;/normalized_doctypes>&lt;addresses count="1">&lt;address_name>&lt;address_spec addr_no="1">&lt;full_address>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.&lt;/full_address>&lt;/address_spec>&lt;/address_name>&lt;/addresses>&lt;category_info>&lt;headings count="1">&lt;heading>Science &amp;amp; Technology&lt;/heading>&lt;/headings>&lt;subheadings count="1">&lt;subheading>Life Sciences &amp;amp; Biomedicine&lt;/subheading>&lt;/subheadings>&lt;subjects count="2">&lt;subject ascatype="traditional" code="DR">CELL BIOLOGY&lt;/subject>&lt;subject ascatype="extended">Cell Biology&lt;/subject>&lt;/subjects>&lt;/category_info>&lt;fund_ack>&lt;grants count="6" complete="Y">&lt;grant>&lt;grant_agency>NHLBI NIH HHS&lt;/grant_agency>&lt;grant_ids count="1">&lt;grant_id>R01 HL113006&lt;/grant_id>&lt;/grant_ids>&lt;country>United States&lt;/country>&lt;acronym>HL&lt;/acronym>&lt;/grant>&lt;grant>&lt;grant_agency>NIBIB NIH HHS&lt;/grant_agency>&lt;grant_ids count="1">&lt;grant_id>T32 EB009035&lt;/grant_id>&lt;/grant_ids>&lt;country>United States&lt;/country>&lt;acronym>EB&lt;/acronym>&lt;/grant>&lt;grant>&lt;grant_agency>NHLBI NIH HHS&lt;/grant_agency>&lt;grant_ids count="1">&lt;grant_id>U01 HL099776&lt;/grant_id>&lt;/grant_ids>&lt;country>United States&lt;/country>&lt;acronym>HL&lt;/acronym>&lt;/grant>&lt;grant>&lt;grant_agency>NHLBI NIH HHS&lt;/grant_agency>&lt;grant_ids count="1">&lt;grant_id>R24 HL117756&lt;/grant_id>&lt;/grant_ids>&lt;country>United States&lt;/country>&lt;acronym>HL&lt;/acronym>&lt;/grant>&lt;grant>&lt;grant_agency>NHLBI NIH HHS&lt;/grant_agency>&lt;grant_ids count="1">&lt;grant_id>K99 HL121177&lt;/grant_id>&lt;/grant_ids>&lt;country>United States&lt;/country>&lt;acronym>HL&lt;/acronym>&lt;/grant>&lt;grant>&lt;grant_agency>NHLBI NIH HHS&lt;/grant_agency>&lt;grant_ids count="1">&lt;grant_id>R00 HL121177&lt;/grant_id>&lt;/grant_ids>&lt;country>United States&lt;/country>&lt;acronym>HL&lt;/acronym>&lt;/grant>&lt;/grants>&lt;/fund_ack>&lt;abstracts count="1">&lt;abstract>&lt;abstract_text>&lt;p>Existing methods for human induced pluripotent stem cell (hiPSC) cardiac differentiation are efficient but require complex, undefined medium constituents that hinder further elucidation of the molecular mechanisms of cardiomyogenesis. Using hiPSCs derived under chemically defined conditions on synthetic matrices, we systematically developed an optimized cardiac differentiation strategy, using a chemically defined medium consisting of just three components: the basal medium RPMI 1640, L-ascorbic acid 2-phosphate and rice-derived recombinant human albumin. Along with small molecule-based induction of differentiation, this protocol produced contractile sheets of up to 95% TNNT2(+) cardiomyocytes at a yield of up to 100 cardiomyocytes for every input pluripotent cell and was effective in 11 hiPSC lines tested. This chemically defined platform for cardiac specification of hiPSCs will allow the elucidation of cardiomyocyte macromolecular and metabolic requirements and will provide a minimal system for the study of maturation and subtype specification. &lt;/p>&lt;/abstract_text>&lt;/abstract>&lt;/abstracts>&lt;/fullrecord_metadata>&lt;item xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Owner="NLM" Status="MEDLINE" xsi:type="itemType_medline" coll_id="MEDLINE">&lt;MedlineJournalInfo>&lt;Country>United States&lt;/Country>&lt;NlmUniqueID>101215604&lt;/NlmUniqueID>&lt;ISSNLinking>1548-7091&lt;/ISSNLinking>&lt;/MedlineJournalInfo>&lt;DateCompleted>2014-09-29&lt;/DateCompleted>&lt;DateRevised>2017-02-20&lt;/DateRevised>&lt;Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.&lt;/Affiliation>&lt;ChemicalList>&lt;Chemical>&lt;RegistryNumber>0&lt;/RegistryNumber>&lt;NameOfSubstance UI="D003470">Culture Media&lt;/NameOfSubstance>&lt;/Chemical>&lt;/ChemicalList>&lt;CitationSubset>IM&lt;/CitationSubset>&lt;CommentsCorrectionsList>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Nature. 2013 Aug 8;500(7461):222-6&lt;/RefSource>&lt;PMID Version="1">23812591&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Cell Res. 2011 Mar;21(3):518-29&lt;/RefSource>&lt;PMID Version="1">21243013&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Cell Stem Cell. 2012 Jan 6;10(1):16-28&lt;/RefSource>&lt;PMID Version="1">22226352&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Cell Stem Cell. 2011 Feb 4;8(2):228-40&lt;/RefSource>&lt;PMID Version="1">21295278&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Nat Protoc. 2008;3(5):768-76&lt;/RefSource>&lt;PMID Version="1">18451785&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>BMC Dev Biol. 2010;10:60&lt;/RefSource>&lt;PMID Version="1">20525219&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Nat Methods. 2011 May;8(5):409-12&lt;/RefSource>&lt;PMID Version="1">21460823&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Nat Biotechnol. 2007 Sep;25(9):1015-24&lt;/RefSource>&lt;PMID Version="1">17721512&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>PLoS One. 2011;6(8):e23657&lt;/RefSource>&lt;PMID Version="1">21876760&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Cytotechnology. 2010 Jan;62(1):1-16&lt;/RefSource>&lt;PMID Version="1">20373019&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Tissue Eng Part C Methods. 2011 Feb;17(2):193-207&lt;/RefSource>&lt;PMID Version="1">20726687&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Nature. 2008 May 22;453(7194):524-8&lt;/RefSource>&lt;PMID Version="1">18432194&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Cell Stem Cell. 2013 Jan 3;12(1):127-37&lt;/RefSource>&lt;PMID Version="1">23168164&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Science. 1998 Nov 6;282(5391):1145-7&lt;/RefSource>&lt;PMID Version="1">9804556&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>PLoS One. 2011;6(4):e18293&lt;/RefSource>&lt;PMID Version="1">21494607&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Cell Res. 2011 Apr;21(4):579-87&lt;/RefSource>&lt;PMID Version="1">21102549&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>JAMA. 1967 Feb 20;199(8):519-24&lt;/RefSource>&lt;PMID Version="1">4960081&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Cell Rep. 2012 Nov 29;2(5):1448-60&lt;/RefSource>&lt;PMID Version="1">23103164&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Stem Cells. 2007 Apr;25(4):929-38&lt;/RefSource>&lt;PMID Version="1">17185609&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Dev Dyn. 2006 Jul;235(7):1994-2002&lt;/RefSource>&lt;PMID Version="1">16649168&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Cell Stem Cell. 2012 Aug 3;11(2):242-52&lt;/RefSource>&lt;PMID Version="1">22862949&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>J Biol Chem. 1981 Jan 25;256(2):964-8&lt;/RefSource>&lt;PMID Version="1">7451483&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>PLoS One. 2012;7(12):e52405&lt;/RefSource>&lt;PMID Version="1">23300662&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>PLoS One. 2010;5(6):e11134&lt;/RefSource>&lt;PMID Version="1">20559569&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Am J Physiol Cell Physiol. 2010 Dec;299(6):C1234-49&lt;/RefSource>&lt;PMID Version="1">20844252&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Nat Biotechnol. 2010 Jun;28(6):606-10&lt;/RefSource>&lt;PMID Version="1">20512120&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Proc Jpn Acad Ser B Phys Biol Sci. 2009;85(8):348-62&lt;/RefSource>&lt;PMID Version="1">19838014&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Stem Cells Dev. 2012 Apr 10;21(6):977-86&lt;/RefSource>&lt;PMID Version="1">22182484&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Brain Res. 1989 Aug 7;494(1):65-74&lt;/RefSource>&lt;PMID Version="1">2765923&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Stem Cells. 2010 Apr;28(4):713-20&lt;/RefSource>&lt;PMID Version="1">20201064&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Cardiovasc Res. 2003 May 1;58(2):423-34&lt;/RefSource>&lt;PMID Version="1">12757876&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Differentiation. 2008 Apr;76(4):357-70&lt;/RefSource>&lt;PMID Version="1">18021257&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Nat Commun. 2012;3:1236&lt;/RefSource>&lt;PMID Version="1">23212365&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>J Mol Histol. 2004 Jun;35(5):463-70&lt;/RefSource>&lt;PMID Version="1">15571324&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Cell Res. 2012 Jan;22(1):219-36&lt;/RefSource>&lt;PMID Version="1">22143566&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Nature. 2011 May 19;473(7347):326-35&lt;/RefSource>&lt;PMID Version="1">21593865&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Stem Cells. 2008 Sep;26(9):2257-65&lt;/RefSource>&lt;PMID Version="1">18599809&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Annu Rev Cell Dev Biol. 2012;28:523-53&lt;/RefSource>&lt;PMID Version="1">23057746&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Nat Methods. 2011 May;8(5):424-9&lt;/RefSource>&lt;PMID Version="1">21478862&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Proc Natl Acad Sci U S A. 2012 Jul 3;109(27):E1848-57&lt;/RefSource>&lt;PMID Version="1">22645348&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Circulation. 2003 Apr 15;107(14):1912-6&lt;/RefSource>&lt;PMID Version="1">12668514&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Nat Commun. 2014;5:3195&lt;/RefSource>&lt;PMID Version="1">24463987&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Nat Methods. 2011 Dec;8(12):1037-40&lt;/RefSource>&lt;PMID Version="1">22020065&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Can J Physiol Pharmacol. 2006 Aug-Sep;84(8-9):935-41&lt;/RefSource>&lt;PMID Version="1">17111039&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Circ Res. 2012 Oct 12;111(9):1125-36&lt;/RefSource>&lt;PMID Version="1">22912385&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Nat Nanotechnol. 2012 Mar;7(3):185-90&lt;/RefSource>&lt;PMID Version="1">22327876&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Nat Commun. 2014;5:3206&lt;/RefSource>&lt;PMID Version="1">24487777&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Nat Biotechnol. 2010 Jun;28(6):611-5&lt;/RefSource>&lt;PMID Version="1">20512123&lt;/PMID>&lt;/CommentsCorrections>&lt;CommentsCorrections RefType="Cites">&lt;RefSource>Stem Cells Dev. 2013 Aug 15;22(16):2315-25&lt;/RefSource>&lt;PMID Version="1">23517131&lt;/PMID>&lt;/CommentsCorrections>&lt;/CommentsCorrectionsList>&lt;MeshHeadingList>&lt;MeshHeading>&lt;DescriptorName MajorTopicYN="N" UI="D002454">Cell Differentiation&lt;/DescriptorName>&lt;TreeCodeList>&lt;TreeCode MajorTopicYN="N">G04.299.151&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;MeshHeading>&lt;DescriptorName MajorTopicYN="N" UI="D003470">Culture Media&lt;/DescriptorName>&lt;TreeCodeList>&lt;TreeCode MajorTopicYN="N">D27.720.470.305&lt;/TreeCode>&lt;TreeCode MajorTopicYN="N">E07.206&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;MeshHeading>&lt;DescriptorName MajorTopicYN="N" UI="D006801">Humans&lt;/DescriptorName>&lt;TreeCodeList>&lt;TreeCode MajorTopicYN="N">B01.050.150.900.649.801.400.112.400.400&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;MeshHeading>&lt;DescriptorName MajorTopicYN="N" UI="D057026">Induced Pluripotent Stem Cells&lt;/DescriptorName>&lt;QualifierName MajorTopicYN="N" UI="Q000166">cytology&lt;/QualifierName>&lt;TreeCodeList>&lt;TreeCode MajorTopicYN="N">A11.872.040.500&lt;/TreeCode>&lt;TreeCode MajorTopicYN="N">A11.872.700.500&lt;/TreeCode>&lt;TreeCode MajorTopicYN="N">Y02.020&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;MeshHeading>&lt;DescriptorName MajorTopicYN="N" UI="D032383">Myocytes, Cardiac&lt;/DescriptorName>&lt;QualifierName MajorTopicYN="Y" UI="Q000166">cytology&lt;/QualifierName>&lt;TreeCodeList>&lt;TreeCode MajorTopicYN="N">A07.541.704.570&lt;/TreeCode>&lt;TreeCode MajorTopicYN="N">A10.690.552.750.570&lt;/TreeCode>&lt;TreeCode MajorTopicYN="N">A11.620.500&lt;/TreeCode>&lt;TreeCode MajorTopicYN="Y">Y02.020&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;/MeshHeadingList>&lt;OtherID Source="NLM">NIHMS599769&lt;/OtherID>&lt;OtherID Source="NLM">PMC4169698&lt;/OtherID>&lt;/item>&lt;contributors count="3">&lt;contributor>&lt;name seq_no="1" role="researcher_id" r_id="D-2336-2015">&lt;display_name>Matsa, Elena&lt;/display_name>&lt;full_name>Matsa, Elena&lt;/full_name>&lt;first_name>Elena&lt;/first_name>&lt;last_name>Matsa&lt;/last_name>&lt;/name>&lt;/contributor>&lt;contributor>&lt;name seq_no="2" role="researcher_id" orcid_id="0000-0002-3019-0170">&lt;display_name>Mordwinkin, Nicholas&lt;/display_name>&lt;full_name>Mordwinkin, Nicholas&lt;/full_name>&lt;first_name>Nicholas&lt;/first_name>&lt;last_name>Mordwinkin&lt;/last_name>&lt;/name>&lt;/contributor>&lt;contributor>&lt;name seq_no="3" role="researcher_id" orcid_id="0000-0002-9991-400X">&lt;display_name>Abilez, Oscar&lt;/display_name>&lt;full_name>Abilez, Oscar&lt;/full_name>&lt;first_name>Oscar&lt;/first_name>&lt;last_name>Abilez&lt;/last_name>&lt;/name>&lt;/contributor>&lt;/contributors>&lt;/static_data>&lt;dynamic_data>&lt;citation_related>&lt;tc_list>&lt;silo_tc coll_id="MEDLINE" local_count="0">&lt;/silo_tc>&lt;/tc_list>&lt;/citation_related>&lt;cluster_related>&lt;identifiers>&lt;identifier type="doi" value="10.1038/nmeth.2999">&lt;/identifier>&lt;identifier type="eissn" value="1548-7105">&lt;/identifier>&lt;identifier type="pmid" value="MEDLINE:24930130">&lt;/identifier>&lt;/identifiers>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>
-        &lt;/records></records></return></ns2:retrieveByIdResponse></soap:Body></soap:Envelope>
+      string: '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><ns2:retrieveByIdResponse
+        xmlns:ns2="http://woksearch.v3.wokmws.thomsonreuters.com"><return><queryId>1</queryId><recordsFound>1</recordsFound><recordsSearched>80893971</recordsSearched><optionValue><label>RecordIDs</label><value>MEDLINE:24930130</value></optionValue><records>&lt;records
+        xmlns="http://scientific.thomsonreuters.com/schema/wok5.4/public/FullRecord">&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>MEDLINE:24930130&lt;/UID>&lt;static_data>&lt;summary>&lt;EWUID>&lt;WUID
+        coll_id="MEDLINE">&lt;/WUID>&lt;edition value="MEDLINE.MEDLINE">&lt;/edition>&lt;/EWUID>&lt;pub_info
+        sortdate="2014-08-01" pubyear="2014" pubmonth="Aug" coverdate="2014-Aug" edate="2014-06-15"
+        vol="11" issue="8" pubtype="Journal" medium="Internet" model="Print-Electronic"
+        has_abstract="Y">&lt;page begin="855" end="60">855-60&lt;/page>&lt;/pub_info>&lt;titles
+        count="4">&lt;title type="item">Chemically defined generation of human cardiomyocytes.&lt;/title>&lt;title
+        type="source">Nature methods&lt;/title>&lt;title type="abbrev_iso">Nat. Methods&lt;/title>&lt;title
+        type="source_abbrev">Nat Methods&lt;/title>&lt;/titles>&lt;names count="15">&lt;name
+        seq_no="1" role="author" display="Y">&lt;display_name>Burridge, Paul W&lt;/display_name>&lt;full_name>Burridge,
+        Paul W&lt;/full_name>&lt;initials>PW&lt;/initials>&lt;/name>&lt;name seq_no="2"
+        role="author" display="Y">&lt;display_name>Matsa, Elena&lt;/display_name>&lt;full_name>Matsa,
+        Elena&lt;/full_name>&lt;initials>E&lt;/initials>&lt;/name>&lt;name seq_no="3"
+        role="author" display="Y">&lt;display_name>Shukla, Praveen&lt;/display_name>&lt;full_name>Shukla,
+        Praveen&lt;/full_name>&lt;initials>P&lt;/initials>&lt;/name>&lt;name seq_no="4"
+        role="author" display="Y">&lt;display_name>Lin, Ziliang C&lt;/display_name>&lt;full_name>Lin,
+        Ziliang C&lt;/full_name>&lt;initials>ZC&lt;/initials>&lt;/name>&lt;name seq_no="5"
+        role="author" display="Y">&lt;display_name>Churko, Jared M&lt;/display_name>&lt;full_name>Churko,
+        Jared M&lt;/full_name>&lt;initials>JM&lt;/initials>&lt;/name>&lt;name seq_no="6"
+        role="author" display="Y">&lt;display_name>Ebert, Antje D&lt;/display_name>&lt;full_name>Ebert,
+        Antje D&lt;/full_name>&lt;initials>AD&lt;/initials>&lt;/name>&lt;name seq_no="7"
+        role="author" display="Y">&lt;display_name>Lan, Feng&lt;/display_name>&lt;full_name>Lan,
+        Feng&lt;/full_name>&lt;initials>F&lt;/initials>&lt;/name>&lt;name seq_no="8"
+        role="author" display="Y">&lt;display_name>Diecke, Sebastian&lt;/display_name>&lt;full_name>Diecke,
+        Sebastian&lt;/full_name>&lt;initials>S&lt;/initials>&lt;/name>&lt;name seq_no="9"
+        role="author" display="Y">&lt;display_name>Huber, Bruno&lt;/display_name>&lt;full_name>Huber,
+        Bruno&lt;/full_name>&lt;initials>B&lt;/initials>&lt;/name>&lt;name seq_no="10"
+        role="author" display="Y">&lt;display_name>Mordwinkin, Nicholas M&lt;/display_name>&lt;full_name>Mordwinkin,
+        Nicholas M&lt;/full_name>&lt;initials>NM&lt;/initials>&lt;/name>&lt;name seq_no="11"
+        role="author" display="Y">&lt;display_name>Plews, Jordan R&lt;/display_name>&lt;full_name>Plews,
+        Jordan R&lt;/full_name>&lt;initials>JR&lt;/initials>&lt;/name>&lt;name seq_no="12"
+        role="author" display="Y">&lt;display_name>Abilez, Oscar J&lt;/display_name>&lt;full_name>Abilez,
+        Oscar J&lt;/full_name>&lt;initials>OJ&lt;/initials>&lt;/name>&lt;name seq_no="13"
+        role="author" display="Y">&lt;display_name>Cui, Bianxiao&lt;/display_name>&lt;full_name>Cui,
+        Bianxiao&lt;/full_name>&lt;initials>B&lt;/initials>&lt;/name>&lt;name seq_no="14"
+        role="author" display="Y">&lt;display_name>Gold, Joseph D&lt;/display_name>&lt;full_name>Gold,
+        Joseph D&lt;/full_name>&lt;initials>JD&lt;/initials>&lt;/name>&lt;name seq_no="15"
+        role="author" display="Y">&lt;display_name>Wu, Joseph C&lt;/display_name>&lt;full_name>Wu,
+        Joseph C&lt;/full_name>&lt;initials>JC&lt;/initials>&lt;/name>&lt;/names>&lt;doctypes
+        count="3">&lt;doctype>Journal Article&lt;/doctype>&lt;doctype>Research Support,
+        N.I.H., Extramural&lt;/doctype>&lt;doctype>Research Support, Non-U.S. Gov&amp;apos;t&lt;/doctype>&lt;/doctypes>&lt;/summary>&lt;fullrecord_metadata>&lt;languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/languages>&lt;normalized_languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/normalized_languages>&lt;normalized_doctypes
+        count="2">&lt;doctype>Article&lt;/doctype>&lt;doctype>Other&lt;/doctype>&lt;/normalized_doctypes>&lt;addresses
+        count="4">&lt;address_name>&lt;address_spec addr_no="1">&lt;full_address>1]
+        Stanford Cardiovascular Institute, Stanford University School of Medicine,
+        Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative
+        Medicine, Stanford University School of Medicine, Stanford, California, USA.
+        [3] Department of Medicine, Division of Cardiology, Stanford University School
+        of Medicine, Stanford, California, USA.&lt;/full_address>&lt;/address_spec>&lt;/address_name>&lt;address_name>&lt;address_spec
+        addr_no="2">&lt;full_address>Department of Applied Physics, Stanford University
+        School of Medicine, Stanford, California, USA.&lt;/full_address>&lt;/address_spec>&lt;/address_name>&lt;address_name>&lt;address_spec
+        addr_no="3">&lt;full_address>Department of Chemistry, Stanford University
+        School of Medicine, Stanford, California, USA.&lt;/full_address>&lt;/address_spec>&lt;/address_name>&lt;address_name>&lt;address_spec
+        addr_no="4">&lt;full_address>Stanford Cardiovascular Institute, Stanford University
+        School of Medicine, Stanford, California, USA.&lt;/full_address>&lt;/address_spec>&lt;/address_name>&lt;/addresses>&lt;category_info>&lt;headings
+        count="1">&lt;heading>Science &amp;amp; Technology&lt;/heading>&lt;/headings>&lt;subheadings
+        count="1">&lt;subheading>Life Sciences &amp;amp; Biomedicine&lt;/subheading>&lt;/subheadings>&lt;subjects
+        count="2">&lt;subject ascatype="traditional" code="DR">CELL BIOLOGY&lt;/subject>&lt;subject
+        ascatype="extended">Cell Biology&lt;/subject>&lt;/subjects>&lt;/category_info>&lt;fund_ack>&lt;grants
+        count="7" complete="Y">&lt;grant>&lt;grant_agency>NHLBI NIH HHS&lt;/grant_agency>&lt;grant_ids
+        count="1">&lt;grant_id>R01 HL113006&lt;/grant_id>&lt;/grant_ids>&lt;country>United
+        States&lt;/country>&lt;acronym>HL&lt;/acronym>&lt;/grant>&lt;grant>&lt;grant_agency>NIBIB
+        NIH HHS&lt;/grant_agency>&lt;grant_ids count="1">&lt;grant_id>T32 EB009035&lt;/grant_id>&lt;/grant_ids>&lt;country>United
+        States&lt;/country>&lt;acronym>EB&lt;/acronym>&lt;/grant>&lt;grant>&lt;grant_agency>NHLBI
+        NIH HHS&lt;/grant_agency>&lt;grant_ids count="1">&lt;grant_id>U01 HL099776&lt;/grant_id>&lt;/grant_ids>&lt;country>United
+        States&lt;/country>&lt;acronym>HL&lt;/acronym>&lt;/grant>&lt;grant>&lt;grant_agency>NHLBI
+        NIH HHS&lt;/grant_agency>&lt;grant_ids count="1">&lt;grant_id>R24 HL117756&lt;/grant_id>&lt;/grant_ids>&lt;country>United
+        States&lt;/country>&lt;acronym>HL&lt;/acronym>&lt;/grant>&lt;grant>&lt;grant_agency>NHLBI
+        NIH HHS&lt;/grant_agency>&lt;grant_ids count="1">&lt;grant_id>T32 HL098049&lt;/grant_id>&lt;/grant_ids>&lt;country>United
+        States&lt;/country>&lt;acronym>HL&lt;/acronym>&lt;/grant>&lt;grant>&lt;grant_agency>NHLBI
+        NIH HHS&lt;/grant_agency>&lt;grant_ids count="1">&lt;grant_id>K99 HL121177&lt;/grant_id>&lt;/grant_ids>&lt;country>United
+        States&lt;/country>&lt;acronym>HL&lt;/acronym>&lt;/grant>&lt;grant>&lt;grant_agency>NHLBI
+        NIH HHS&lt;/grant_agency>&lt;grant_ids count="1">&lt;grant_id>R00 HL121177&lt;/grant_id>&lt;/grant_ids>&lt;country>United
+        States&lt;/country>&lt;acronym>HL&lt;/acronym>&lt;/grant>&lt;/grants>&lt;/fund_ack>&lt;abstracts
+        count="1">&lt;abstract>&lt;abstract_text>&lt;p>Existing methods for human
+        induced pluripotent stem cell (hiPSC) cardiac differentiation are efficient
+        but require complex, undefined medium constituents that hinder further elucidation
+        of the molecular mechanisms of cardiomyogenesis. Using hiPSCs derived under
+        chemically defined conditions on synthetic matrices, we systematically developed
+        an optimized cardiac differentiation strategy, using a chemically defined
+        medium consisting of just three components: the basal medium RPMI 1640, L-ascorbic
+        acid 2-phosphate and rice-derived recombinant human albumin. Along with small
+        molecule-based induction of differentiation, this protocol produced contractile
+        sheets of up to 95% TNNT2(+) cardiomyocytes at a yield of up to 100 cardiomyocytes
+        for every input pluripotent cell and was effective in 11 hiPSC lines tested.
+        This chemically defined platform for cardiac specification of hiPSCs will
+        allow the elucidation of cardiomyocyte macromolecular and metabolic requirements
+        and will provide a minimal system for the study of maturation and subtype
+        specification. &lt;/p>&lt;/abstract_text>&lt;/abstract>&lt;/abstracts>&lt;/fullrecord_metadata>&lt;item
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Owner="NLM" Status="MEDLINE"
+        xsi:type="itemType_medline" coll_id="MEDLINE">&lt;MedlineJournalInfo>&lt;Country>United
+        States&lt;/Country>&lt;NlmUniqueID>101215604&lt;/NlmUniqueID>&lt;ISSNLinking>1548-7091&lt;/ISSNLinking>&lt;/MedlineJournalInfo>&lt;DateCompleted>2014-09-29&lt;/DateCompleted>&lt;DateRevised>2018-12-18&lt;/DateRevised>&lt;Affiliation>1]
+        Stanford Cardiovascular Institute, Stanford University School of Medicine,
+        Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative
+        Medicine, Stanford University School of Medicine, Stanford, California, USA.
+        [3] Department of Medicine, Division of Cardiology, Stanford University School
+        of Medicine, Stanford, California, USA.&lt;/Affiliation>&lt;ChemicalList>&lt;Chemical>&lt;RegistryNumber>0&lt;/RegistryNumber>&lt;NameOfSubstance
+        UI="D003470">Culture Media&lt;/NameOfSubstance>&lt;/Chemical>&lt;/ChemicalList>&lt;CitationSubset>IM&lt;/CitationSubset>&lt;MeshHeadingList>&lt;MeshHeading>&lt;DescriptorName
+        MajorTopicYN="N" UI="D002454">Cell Differentiation&lt;/DescriptorName>&lt;TreeCodeList>&lt;TreeCode
+        MajorTopicYN="N">G04.299.151&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;MeshHeading>&lt;DescriptorName
+        MajorTopicYN="N" UI="D003470">Culture Media&lt;/DescriptorName>&lt;TreeCodeList>&lt;TreeCode
+        MajorTopicYN="N">D27.720.470.305&lt;/TreeCode>&lt;TreeCode MajorTopicYN="N">E07.206&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;MeshHeading>&lt;DescriptorName
+        MajorTopicYN="N" UI="D006801">Humans&lt;/DescriptorName>&lt;TreeCodeList>&lt;TreeCode
+        MajorTopicYN="N">B01.050.150.900.649.801.400.112.400.400&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;MeshHeading>&lt;DescriptorName
+        MajorTopicYN="N" UI="D057026">Induced Pluripotent Stem Cells&lt;/DescriptorName>&lt;QualifierName
+        MajorTopicYN="N" UI="Q000166">cytology&lt;/QualifierName>&lt;TreeCodeList>&lt;TreeCode
+        MajorTopicYN="N">A11.872.040.500&lt;/TreeCode>&lt;TreeCode MajorTopicYN="N">A11.872.700.500&lt;/TreeCode>&lt;TreeCode
+        MajorTopicYN="N">Y02.020&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;MeshHeading>&lt;DescriptorName
+        MajorTopicYN="N" UI="D032383">Myocytes, Cardiac&lt;/DescriptorName>&lt;QualifierName
+        MajorTopicYN="Y" UI="Q000166">cytology&lt;/QualifierName>&lt;TreeCodeList>&lt;TreeCode
+        MajorTopicYN="N">A07.541.704.570&lt;/TreeCode>&lt;TreeCode MajorTopicYN="N">A10.690.552.750.570&lt;/TreeCode>&lt;TreeCode
+        MajorTopicYN="N">A11.620.500&lt;/TreeCode>&lt;TreeCode MajorTopicYN="Y">Y02.020&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;/MeshHeadingList>&lt;/item>&lt;contributors
+        count="4">&lt;contributor>&lt;name seq_no="1" role="researcher_id" r_id="B-5014-2012"
+        orcid_id="0000-0002-9991-400X">&lt;display_name>Abilez, Oscar&lt;/display_name>&lt;full_name>Abilez,
+        Oscar&lt;/full_name>&lt;first_name>Oscar&lt;/first_name>&lt;last_name>Abilez&lt;/last_name>&lt;/name>&lt;/contributor>&lt;contributor>&lt;name
+        seq_no="2" role="researcher_id" r_id="I-2023-2012" orcid_id="0000-0002-9038-4014">&lt;display_name>Lan,
+        Feng&lt;/display_name>&lt;full_name>Lan, Feng&lt;/full_name>&lt;first_name>Feng&lt;/first_name>&lt;last_name>Lan&lt;/last_name>&lt;/name>&lt;/contributor>&lt;contributor>&lt;name
+        seq_no="3" role="researcher_id" r_id="D-2336-2015">&lt;display_name>Matsa,
+        Elena&lt;/display_name>&lt;full_name>Matsa, Elena&lt;/full_name>&lt;first_name>Elena&lt;/first_name>&lt;last_name>Matsa&lt;/last_name>&lt;/name>&lt;/contributor>&lt;contributor>&lt;name
+        seq_no="4" role="researcher_id" orcid_id="0000-0002-3019-0170">&lt;display_name>Mordwinkin,
+        Nicholas&lt;/display_name>&lt;full_name>Mordwinkin, Nicholas&lt;/full_name>&lt;first_name>Nicholas&lt;/first_name>&lt;last_name>Mordwinkin&lt;/last_name>&lt;/name>&lt;/contributor>&lt;/contributors>&lt;/static_data>&lt;dynamic_data>&lt;citation_related>&lt;tc_list>&lt;silo_tc
+        coll_id="MEDLINE" local_count="0">&lt;/silo_tc>&lt;/tc_list>&lt;/citation_related>&lt;cluster_related>&lt;identifiers>&lt;identifier
+        type="doi" value="10.1038/nmeth.2999">&lt;/identifier>&lt;identifier type="eissn"
+        value="1548-7105">&lt;/identifier>&lt;identifier type="pmid" value="MEDLINE:24930130">&lt;/identifier>&lt;/identifiers>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;/records></records></return></ns2:retrieveByIdResponse></soap:Body></soap:Envelope>'
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 01:52:05 GMT
+  recorded_at: Tue, 19 Mar 2019 21:06:17 GMT
 recorded_with: VCR 4.0.0

--- a/fixtures/vcr_cassettes/PubmedHarvester/_fetch_remote_pubmed/WOS_enabled/still_searches_pubmed_first.yml
+++ b/fixtures/vcr_cassettes/PubmedHarvester/_fetch_remote_pubmed/WOS_enabled/still_searches_pubmed_first.yml
@@ -1,0 +1,657 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
+    body:
+      encoding: UTF-8
+      string: "&id=24930130"
+    headers:
+      User-Agent:
+      - stanford-library-sul-pub
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Tue, 19 Mar 2019 21:03:50 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 19 Mar 2019 21:03:53 GMT
+      Server:
+      - Finatra
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Ratelimit-Remaining:
+      - '9'
+      Ncbi-Phid:
+      - 322C1335D2DEB7E50000211516EF8325.1.1.m_3
+      Cache-Control:
+      - private
+      L5d-Success-Class:
+      - '1.0'
+      Ncbi-Sid:
+      - 5D146A88810F3BAB_9737SID
+      Content-Encoding:
+      - gzip
+      X-Ratelimit-Limit:
+      - '10'
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Set-Cookie:
+      - ncbi_sid=5D146A88810F3BAB_9737SID; domain=.nih.gov; path=/; expires=Thu, 19
+        Mar 2020 21:03:53 GMT
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" ?>
+        <!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2019//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_190101.dtd">
+        <PubmedArticleSet>
+        <PubmedArticle>
+            <MedlineCitation Status="MEDLINE" Owner="NLM">
+                <PMID Version="1">24930130</PMID>
+                <DateCompleted>
+                    <Year>2014</Year>
+                    <Month>09</Month>
+                    <Day>29</Day>
+                </DateCompleted>
+                <DateRevised>
+                    <Year>2018</Year>
+                    <Month>12</Month>
+                    <Day>18</Day>
+                </DateRevised>
+                <Article PubModel="Print-Electronic">
+                    <Journal>
+                        <ISSN IssnType="Electronic">1548-7105</ISSN>
+                        <JournalIssue CitedMedium="Internet">
+                            <Volume>11</Volume>
+                            <Issue>8</Issue>
+                            <PubDate>
+                                <Year>2014</Year>
+                                <Month>Aug</Month>
+                            </PubDate>
+                        </JournalIssue>
+                        <Title>Nature methods</Title>
+                        <ISOAbbreviation>Nat. Methods</ISOAbbreviation>
+                    </Journal>
+                    <ArticleTitle>Chemically defined generation of human cardiomyocytes.</ArticleTitle>
+                    <Pagination>
+                        <MedlinePgn>855-60</MedlinePgn>
+                    </Pagination>
+                    <ELocationID EIdType="doi" ValidYN="Y">10.1038/nmeth.2999</ELocationID>
+                    <Abstract>
+                        <AbstractText>Existing methods for human induced pluripotent stem cell (hiPSC) cardiac differentiation are efficient but require complex, undefined medium constituents that hinder further elucidation of the molecular mechanisms of cardiomyogenesis. Using hiPSCs derived under chemically defined conditions on synthetic matrices, we systematically developed an optimized cardiac differentiation strategy, using a chemically defined medium consisting of just three components: the basal medium RPMI 1640, L-ascorbic acid 2-phosphate and rice-derived recombinant human albumin. Along with small molecule-based induction of differentiation, this protocol produced contractile sheets of up to 95% TNNT2(+) cardiomyocytes at a yield of up to 100 cardiomyocytes for every input pluripotent cell and was effective in 11 hiPSC lines tested. This chemically defined platform for cardiac specification of hiPSCs will allow the elucidation of cardiomyocyte macromolecular and metabolic requirements and will provide a minimal system for the study of maturation and subtype specification. </AbstractText>
+                    </Abstract>
+                    <AuthorList CompleteYN="Y">
+                        <Author ValidYN="Y">
+                            <LastName>Burridge</LastName>
+                            <ForeName>Paul W</ForeName>
+                            <Initials>PW</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Matsa</LastName>
+                            <ForeName>Elena</ForeName>
+                            <Initials>E</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Shukla</LastName>
+                            <ForeName>Praveen</ForeName>
+                            <Initials>P</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Lin</LastName>
+                            <ForeName>Ziliang C</ForeName>
+                            <Initials>ZC</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>Department of Applied Physics, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Churko</LastName>
+                            <ForeName>Jared M</ForeName>
+                            <Initials>JM</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Ebert</LastName>
+                            <ForeName>Antje D</ForeName>
+                            <Initials>AD</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Lan</LastName>
+                            <ForeName>Feng</ForeName>
+                            <Initials>F</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Diecke</LastName>
+                            <ForeName>Sebastian</ForeName>
+                            <Initials>S</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Huber</LastName>
+                            <ForeName>Bruno</ForeName>
+                            <Initials>B</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Mordwinkin</LastName>
+                            <ForeName>Nicholas M</ForeName>
+                            <Initials>NM</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Plews</LastName>
+                            <ForeName>Jordan R</ForeName>
+                            <Initials>JR</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Abilez</LastName>
+                            <ForeName>Oscar J</ForeName>
+                            <Initials>OJ</Initials>
+                            <Identifier Source="ORCID">000000029991400X</Identifier>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Cui</LastName>
+                            <ForeName>Bianxiao</ForeName>
+                            <Initials>B</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>Department of Chemistry, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Gold</LastName>
+                            <ForeName>Joseph D</ForeName>
+                            <Initials>JD</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Wu</LastName>
+                            <ForeName>Joseph C</ForeName>
+                            <Initials>JC</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                    </AuthorList>
+                    <Language>eng</Language>
+                    <GrantList CompleteYN="Y">
+                        <Grant>
+                            <GrantID>R01 HL113006</GrantID>
+                            <Acronym>HL</Acronym>
+                            <Agency>NHLBI NIH HHS</Agency>
+                            <Country>United States</Country>
+                        </Grant>
+                        <Grant>
+                            <GrantID>T32 EB009035</GrantID>
+                            <Acronym>EB</Acronym>
+                            <Agency>NIBIB NIH HHS</Agency>
+                            <Country>United States</Country>
+                        </Grant>
+                        <Grant>
+                            <GrantID>U01 HL099776</GrantID>
+                            <Acronym>HL</Acronym>
+                            <Agency>NHLBI NIH HHS</Agency>
+                            <Country>United States</Country>
+                        </Grant>
+                        <Grant>
+                            <GrantID>R24 HL117756</GrantID>
+                            <Acronym>HL</Acronym>
+                            <Agency>NHLBI NIH HHS</Agency>
+                            <Country>United States</Country>
+                        </Grant>
+                        <Grant>
+                            <GrantID>T32 HL098049</GrantID>
+                            <Acronym>HL</Acronym>
+                            <Agency>NHLBI NIH HHS</Agency>
+                            <Country>United States</Country>
+                        </Grant>
+                        <Grant>
+                            <GrantID>K99 HL121177</GrantID>
+                            <Acronym>HL</Acronym>
+                            <Agency>NHLBI NIH HHS</Agency>
+                            <Country>United States</Country>
+                        </Grant>
+                        <Grant>
+                            <GrantID>R00 HL121177</GrantID>
+                            <Acronym>HL</Acronym>
+                            <Agency>NHLBI NIH HHS</Agency>
+                            <Country>United States</Country>
+                        </Grant>
+                    </GrantList>
+                    <PublicationTypeList>
+                        <PublicationType UI="D016428">Journal Article</PublicationType>
+                        <PublicationType UI="D052061">Research Support, N.I.H., Extramural</PublicationType>
+                        <PublicationType UI="D013485">Research Support, Non-U.S. Gov't</PublicationType>
+                    </PublicationTypeList>
+                    <ArticleDate DateType="Electronic">
+                        <Year>2014</Year>
+                        <Month>06</Month>
+                        <Day>15</Day>
+                    </ArticleDate>
+                </Article>
+                <MedlineJournalInfo>
+                    <Country>United States</Country>
+                    <MedlineTA>Nat Methods</MedlineTA>
+                    <NlmUniqueID>101215604</NlmUniqueID>
+                    <ISSNLinking>1548-7091</ISSNLinking>
+                </MedlineJournalInfo>
+                <ChemicalList>
+                    <Chemical>
+                        <RegistryNumber>0</RegistryNumber>
+                        <NameOfSubstance UI="D003470">Culture Media</NameOfSubstance>
+                    </Chemical>
+                </ChemicalList>
+                <CitationSubset>IM</CitationSubset>
+                <MeshHeadingList>
+                    <MeshHeading>
+                        <DescriptorName UI="D002454" MajorTopicYN="N">Cell Differentiation</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D003470" MajorTopicYN="N">Culture Media</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D057026" MajorTopicYN="N">Induced Pluripotent Stem Cells</DescriptorName>
+                        <QualifierName UI="Q000166" MajorTopicYN="N">cytology</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D032383" MajorTopicYN="N">Myocytes, Cardiac</DescriptorName>
+                        <QualifierName UI="Q000166" MajorTopicYN="Y">cytology</QualifierName>
+                    </MeshHeading>
+                </MeshHeadingList>
+            </MedlineCitation>
+            <PubmedData>
+                <History>
+                    <PubMedPubDate PubStatus="received">
+                        <Year>2013</Year>
+                        <Month>10</Month>
+                        <Day>15</Day>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="accepted">
+                        <Year>2014</Year>
+                        <Month>05</Month>
+                        <Day>06</Day>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="entrez">
+                        <Year>2014</Year>
+                        <Month>6</Month>
+                        <Day>16</Day>
+                        <Hour>6</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="pubmed">
+                        <Year>2014</Year>
+                        <Month>6</Month>
+                        <Day>16</Day>
+                        <Hour>6</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="medline">
+                        <Year>2014</Year>
+                        <Month>9</Month>
+                        <Day>30</Day>
+                        <Hour>6</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                </History>
+                <PublicationStatus>ppublish</PublicationStatus>
+                <ArticleIdList>
+                    <ArticleId IdType="pubmed">24930130</ArticleId>
+                    <ArticleId IdType="pii">nmeth.2999</ArticleId>
+                    <ArticleId IdType="doi">10.1038/nmeth.2999</ArticleId>
+                    <ArticleId IdType="pmc">PMC4169698</ArticleId>
+                    <ArticleId IdType="mid">NIHMS599769</ArticleId>
+                </ArticleIdList>
+                <ReferenceList>
+                    <Reference>
+                        <Citation>Nature. 2013 Aug 8;500(7461):222-6</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">23812591</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Cell Res. 2011 Mar;21(3):518-29</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">21243013</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Cell Stem Cell. 2012 Jan 6;10(1):16-28</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">22226352</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Cell Stem Cell. 2011 Feb 4;8(2):228-40</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">21295278</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Protoc. 2008;3(5):768-76</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">18451785</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>BMC Dev Biol. 2010;10:60</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">20525219</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Methods. 2011 May;8(5):409-12</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">21460823</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Biotechnol. 2007 Sep;25(9):1015-24</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">17721512</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>PLoS One. 2011;6(8):e23657</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">21876760</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Cytotechnology. 2010 Jan;62(1):1-16</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">20373019</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Tissue Eng Part C Methods. 2011 Feb;17(2):193-207</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">20726687</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nature. 2008 May 22;453(7194):524-8</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">18432194</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Cell Stem Cell. 2013 Jan 3;12(1):127-37</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">23168164</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Science. 1998 Nov 6;282(5391):1145-7</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">9804556</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>PLoS One. 2011;6(4):e18293</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">21494607</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Cell Res. 2011 Apr;21(4):579-87</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">21102549</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>JAMA. 1967 Feb 20;199(8):519-24</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">4960081</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Cell Rep. 2012 Nov 29;2(5):1448-60</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">23103164</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Stem Cells. 2007 Apr;25(4):929-38</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">17185609</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Dev Dyn. 2006 Jul;235(7):1994-2002</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">16649168</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Cell Stem Cell. 2012 Aug 3;11(2):242-52</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">22862949</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>J Biol Chem. 1981 Jan 25;256(2):964-8</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">7451483</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>PLoS One. 2012;7(12):e52405</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">23300662</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>PLoS One. 2010;5(6):e11134</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">20559569</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Am J Physiol Cell Physiol. 2010 Dec;299(6):C1234-49</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">20844252</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Biotechnol. 2010 Jun;28(6):606-10</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">20512120</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Proc Jpn Acad Ser B Phys Biol Sci. 2009;85(8):348-62</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">19838014</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Stem Cells Dev. 2012 Apr 10;21(6):977-86</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">22182484</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Brain Res. 1989 Aug 7;494(1):65-74</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">2765923</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Stem Cells. 2010 Apr;28(4):713-20</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">20201064</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Cardiovasc Res. 2003 May 1;58(2):423-34</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">12757876</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Differentiation. 2008 Apr;76(4):357-70</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">18021257</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Commun. 2012;3:1236</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">23212365</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>J Mol Histol. 2004 Jun;35(5):463-70</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">15571324</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Cell Res. 2012 Jan;22(1):219-36</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">22143566</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nature. 2011 May 19;473(7347):326-35</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">21593865</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Stem Cells. 2008 Sep;26(9):2257-65</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">18599809</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Annu Rev Cell Dev Biol. 2012;28:523-53</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">23057746</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Methods. 2011 May;8(5):424-9</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">21478862</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Proc Natl Acad Sci U S A. 2012 Jul 3;109(27):E1848-57</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">22645348</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Circulation. 2003 Apr 15;107(14):1912-6</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">12668514</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Commun. 2014;5:3195</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">24463987</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Methods. 2011 Dec;8(12):1037-40</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">22020065</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Can J Physiol Pharmacol. 2006 Aug-Sep;84(8-9):935-41</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">17111039</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Circ Res. 2012 Oct 12;111(9):1125-36</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">22912385</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Nanotechnol. 2012 Mar;7(3):185-90</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">22327876</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Commun. 2014;5:3206</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">24487777</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Biotechnol. 2010 Jun;28(6):611-5</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">20512123</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Stem Cells Dev. 2013 Aug 15;22(16):2315-25</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">23517131</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                </ReferenceList>
+            </PubmedData>
+        </PubmedArticle>
+
+        </PubmedArticleSet>
+    http_version:
+  recorded_at: Tue, 19 Mar 2019 21:03:52 GMT
+recorded_with: VCR 4.0.0

--- a/fixtures/vcr_cassettes/PubmedHarvester/_fetch_remote_pubmed/WOS_enabled/still_searches_pubmed_first_by_default.yml
+++ b/fixtures/vcr_cassettes/PubmedHarvester/_fetch_remote_pubmed/WOS_enabled/still_searches_pubmed_first_by_default.yml
@@ -1,0 +1,657 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
+    body:
+      encoding: UTF-8
+      string: "&id=24930130"
+    headers:
+      User-Agent:
+      - stanford-library-sul-pub
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Tue, 19 Mar 2019 21:06:16 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 19 Mar 2019 21:06:17 GMT
+      Server:
+      - Finatra
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Ratelimit-Remaining:
+      - '9'
+      Ncbi-Phid:
+      - 939B06706F9C03E50000281493D48FA0.1.1.m_3
+      Cache-Control:
+      - private
+      L5d-Success-Class:
+      - '1.0'
+      Ncbi-Sid:
+      - 8DC2497E06B7889F_652CSID
+      Content-Encoding:
+      - gzip
+      X-Ratelimit-Limit:
+      - '10'
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Set-Cookie:
+      - ncbi_sid=8DC2497E06B7889F_652CSID; domain=.nih.gov; path=/; expires=Thu, 19
+        Mar 2020 21:06:18 GMT
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" ?>
+        <!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2019//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_190101.dtd">
+        <PubmedArticleSet>
+        <PubmedArticle>
+            <MedlineCitation Status="MEDLINE" Owner="NLM">
+                <PMID Version="1">24930130</PMID>
+                <DateCompleted>
+                    <Year>2014</Year>
+                    <Month>09</Month>
+                    <Day>29</Day>
+                </DateCompleted>
+                <DateRevised>
+                    <Year>2018</Year>
+                    <Month>12</Month>
+                    <Day>18</Day>
+                </DateRevised>
+                <Article PubModel="Print-Electronic">
+                    <Journal>
+                        <ISSN IssnType="Electronic">1548-7105</ISSN>
+                        <JournalIssue CitedMedium="Internet">
+                            <Volume>11</Volume>
+                            <Issue>8</Issue>
+                            <PubDate>
+                                <Year>2014</Year>
+                                <Month>Aug</Month>
+                            </PubDate>
+                        </JournalIssue>
+                        <Title>Nature methods</Title>
+                        <ISOAbbreviation>Nat. Methods</ISOAbbreviation>
+                    </Journal>
+                    <ArticleTitle>Chemically defined generation of human cardiomyocytes.</ArticleTitle>
+                    <Pagination>
+                        <MedlinePgn>855-60</MedlinePgn>
+                    </Pagination>
+                    <ELocationID EIdType="doi" ValidYN="Y">10.1038/nmeth.2999</ELocationID>
+                    <Abstract>
+                        <AbstractText>Existing methods for human induced pluripotent stem cell (hiPSC) cardiac differentiation are efficient but require complex, undefined medium constituents that hinder further elucidation of the molecular mechanisms of cardiomyogenesis. Using hiPSCs derived under chemically defined conditions on synthetic matrices, we systematically developed an optimized cardiac differentiation strategy, using a chemically defined medium consisting of just three components: the basal medium RPMI 1640, L-ascorbic acid 2-phosphate and rice-derived recombinant human albumin. Along with small molecule-based induction of differentiation, this protocol produced contractile sheets of up to 95% TNNT2(+) cardiomyocytes at a yield of up to 100 cardiomyocytes for every input pluripotent cell and was effective in 11 hiPSC lines tested. This chemically defined platform for cardiac specification of hiPSCs will allow the elucidation of cardiomyocyte macromolecular and metabolic requirements and will provide a minimal system for the study of maturation and subtype specification. </AbstractText>
+                    </Abstract>
+                    <AuthorList CompleteYN="Y">
+                        <Author ValidYN="Y">
+                            <LastName>Burridge</LastName>
+                            <ForeName>Paul W</ForeName>
+                            <Initials>PW</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Matsa</LastName>
+                            <ForeName>Elena</ForeName>
+                            <Initials>E</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Shukla</LastName>
+                            <ForeName>Praveen</ForeName>
+                            <Initials>P</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Lin</LastName>
+                            <ForeName>Ziliang C</ForeName>
+                            <Initials>ZC</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>Department of Applied Physics, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Churko</LastName>
+                            <ForeName>Jared M</ForeName>
+                            <Initials>JM</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Ebert</LastName>
+                            <ForeName>Antje D</ForeName>
+                            <Initials>AD</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Lan</LastName>
+                            <ForeName>Feng</ForeName>
+                            <Initials>F</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Diecke</LastName>
+                            <ForeName>Sebastian</ForeName>
+                            <Initials>S</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Huber</LastName>
+                            <ForeName>Bruno</ForeName>
+                            <Initials>B</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Mordwinkin</LastName>
+                            <ForeName>Nicholas M</ForeName>
+                            <Initials>NM</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Plews</LastName>
+                            <ForeName>Jordan R</ForeName>
+                            <Initials>JR</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Abilez</LastName>
+                            <ForeName>Oscar J</ForeName>
+                            <Initials>OJ</Initials>
+                            <Identifier Source="ORCID">000000029991400X</Identifier>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Cui</LastName>
+                            <ForeName>Bianxiao</ForeName>
+                            <Initials>B</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>Department of Chemistry, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Gold</LastName>
+                            <ForeName>Joseph D</ForeName>
+                            <Initials>JD</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Wu</LastName>
+                            <ForeName>Joseph C</ForeName>
+                            <Initials>JC</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                    </AuthorList>
+                    <Language>eng</Language>
+                    <GrantList CompleteYN="Y">
+                        <Grant>
+                            <GrantID>R01 HL113006</GrantID>
+                            <Acronym>HL</Acronym>
+                            <Agency>NHLBI NIH HHS</Agency>
+                            <Country>United States</Country>
+                        </Grant>
+                        <Grant>
+                            <GrantID>T32 EB009035</GrantID>
+                            <Acronym>EB</Acronym>
+                            <Agency>NIBIB NIH HHS</Agency>
+                            <Country>United States</Country>
+                        </Grant>
+                        <Grant>
+                            <GrantID>U01 HL099776</GrantID>
+                            <Acronym>HL</Acronym>
+                            <Agency>NHLBI NIH HHS</Agency>
+                            <Country>United States</Country>
+                        </Grant>
+                        <Grant>
+                            <GrantID>R24 HL117756</GrantID>
+                            <Acronym>HL</Acronym>
+                            <Agency>NHLBI NIH HHS</Agency>
+                            <Country>United States</Country>
+                        </Grant>
+                        <Grant>
+                            <GrantID>T32 HL098049</GrantID>
+                            <Acronym>HL</Acronym>
+                            <Agency>NHLBI NIH HHS</Agency>
+                            <Country>United States</Country>
+                        </Grant>
+                        <Grant>
+                            <GrantID>K99 HL121177</GrantID>
+                            <Acronym>HL</Acronym>
+                            <Agency>NHLBI NIH HHS</Agency>
+                            <Country>United States</Country>
+                        </Grant>
+                        <Grant>
+                            <GrantID>R00 HL121177</GrantID>
+                            <Acronym>HL</Acronym>
+                            <Agency>NHLBI NIH HHS</Agency>
+                            <Country>United States</Country>
+                        </Grant>
+                    </GrantList>
+                    <PublicationTypeList>
+                        <PublicationType UI="D016428">Journal Article</PublicationType>
+                        <PublicationType UI="D052061">Research Support, N.I.H., Extramural</PublicationType>
+                        <PublicationType UI="D013485">Research Support, Non-U.S. Gov't</PublicationType>
+                    </PublicationTypeList>
+                    <ArticleDate DateType="Electronic">
+                        <Year>2014</Year>
+                        <Month>06</Month>
+                        <Day>15</Day>
+                    </ArticleDate>
+                </Article>
+                <MedlineJournalInfo>
+                    <Country>United States</Country>
+                    <MedlineTA>Nat Methods</MedlineTA>
+                    <NlmUniqueID>101215604</NlmUniqueID>
+                    <ISSNLinking>1548-7091</ISSNLinking>
+                </MedlineJournalInfo>
+                <ChemicalList>
+                    <Chemical>
+                        <RegistryNumber>0</RegistryNumber>
+                        <NameOfSubstance UI="D003470">Culture Media</NameOfSubstance>
+                    </Chemical>
+                </ChemicalList>
+                <CitationSubset>IM</CitationSubset>
+                <MeshHeadingList>
+                    <MeshHeading>
+                        <DescriptorName UI="D002454" MajorTopicYN="N">Cell Differentiation</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D003470" MajorTopicYN="N">Culture Media</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D057026" MajorTopicYN="N">Induced Pluripotent Stem Cells</DescriptorName>
+                        <QualifierName UI="Q000166" MajorTopicYN="N">cytology</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D032383" MajorTopicYN="N">Myocytes, Cardiac</DescriptorName>
+                        <QualifierName UI="Q000166" MajorTopicYN="Y">cytology</QualifierName>
+                    </MeshHeading>
+                </MeshHeadingList>
+            </MedlineCitation>
+            <PubmedData>
+                <History>
+                    <PubMedPubDate PubStatus="received">
+                        <Year>2013</Year>
+                        <Month>10</Month>
+                        <Day>15</Day>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="accepted">
+                        <Year>2014</Year>
+                        <Month>05</Month>
+                        <Day>06</Day>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="entrez">
+                        <Year>2014</Year>
+                        <Month>6</Month>
+                        <Day>16</Day>
+                        <Hour>6</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="pubmed">
+                        <Year>2014</Year>
+                        <Month>6</Month>
+                        <Day>16</Day>
+                        <Hour>6</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="medline">
+                        <Year>2014</Year>
+                        <Month>9</Month>
+                        <Day>30</Day>
+                        <Hour>6</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                </History>
+                <PublicationStatus>ppublish</PublicationStatus>
+                <ArticleIdList>
+                    <ArticleId IdType="pubmed">24930130</ArticleId>
+                    <ArticleId IdType="pii">nmeth.2999</ArticleId>
+                    <ArticleId IdType="doi">10.1038/nmeth.2999</ArticleId>
+                    <ArticleId IdType="pmc">PMC4169698</ArticleId>
+                    <ArticleId IdType="mid">NIHMS599769</ArticleId>
+                </ArticleIdList>
+                <ReferenceList>
+                    <Reference>
+                        <Citation>Nature. 2013 Aug 8;500(7461):222-6</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">23812591</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Cell Res. 2011 Mar;21(3):518-29</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">21243013</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Cell Stem Cell. 2012 Jan 6;10(1):16-28</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">22226352</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Cell Stem Cell. 2011 Feb 4;8(2):228-40</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">21295278</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Protoc. 2008;3(5):768-76</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">18451785</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>BMC Dev Biol. 2010;10:60</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">20525219</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Methods. 2011 May;8(5):409-12</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">21460823</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Biotechnol. 2007 Sep;25(9):1015-24</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">17721512</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>PLoS One. 2011;6(8):e23657</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">21876760</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Cytotechnology. 2010 Jan;62(1):1-16</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">20373019</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Tissue Eng Part C Methods. 2011 Feb;17(2):193-207</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">20726687</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nature. 2008 May 22;453(7194):524-8</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">18432194</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Cell Stem Cell. 2013 Jan 3;12(1):127-37</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">23168164</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Science. 1998 Nov 6;282(5391):1145-7</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">9804556</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>PLoS One. 2011;6(4):e18293</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">21494607</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Cell Res. 2011 Apr;21(4):579-87</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">21102549</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>JAMA. 1967 Feb 20;199(8):519-24</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">4960081</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Cell Rep. 2012 Nov 29;2(5):1448-60</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">23103164</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Stem Cells. 2007 Apr;25(4):929-38</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">17185609</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Dev Dyn. 2006 Jul;235(7):1994-2002</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">16649168</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Cell Stem Cell. 2012 Aug 3;11(2):242-52</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">22862949</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>J Biol Chem. 1981 Jan 25;256(2):964-8</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">7451483</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>PLoS One. 2012;7(12):e52405</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">23300662</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>PLoS One. 2010;5(6):e11134</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">20559569</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Am J Physiol Cell Physiol. 2010 Dec;299(6):C1234-49</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">20844252</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Biotechnol. 2010 Jun;28(6):606-10</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">20512120</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Proc Jpn Acad Ser B Phys Biol Sci. 2009;85(8):348-62</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">19838014</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Stem Cells Dev. 2012 Apr 10;21(6):977-86</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">22182484</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Brain Res. 1989 Aug 7;494(1):65-74</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">2765923</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Stem Cells. 2010 Apr;28(4):713-20</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">20201064</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Cardiovasc Res. 2003 May 1;58(2):423-34</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">12757876</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Differentiation. 2008 Apr;76(4):357-70</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">18021257</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Commun. 2012;3:1236</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">23212365</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>J Mol Histol. 2004 Jun;35(5):463-70</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">15571324</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Cell Res. 2012 Jan;22(1):219-36</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">22143566</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nature. 2011 May 19;473(7347):326-35</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">21593865</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Stem Cells. 2008 Sep;26(9):2257-65</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">18599809</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Annu Rev Cell Dev Biol. 2012;28:523-53</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">23057746</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Methods. 2011 May;8(5):424-9</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">21478862</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Proc Natl Acad Sci U S A. 2012 Jul 3;109(27):E1848-57</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">22645348</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Circulation. 2003 Apr 15;107(14):1912-6</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">12668514</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Commun. 2014;5:3195</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">24463987</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Methods. 2011 Dec;8(12):1037-40</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">22020065</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Can J Physiol Pharmacol. 2006 Aug-Sep;84(8-9):935-41</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">17111039</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Circ Res. 2012 Oct 12;111(9):1125-36</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">22912385</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Nanotechnol. 2012 Mar;7(3):185-90</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">22327876</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Commun. 2014;5:3206</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">24487777</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Biotechnol. 2010 Jun;28(6):611-5</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">20512123</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Stem Cells Dev. 2013 Aug 15;22(16):2315-25</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">23517131</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                </ReferenceList>
+            </PubmedData>
+        </PubmedArticle>
+
+        </PubmedArticleSet>
+    http_version:
+  recorded_at: Tue, 19 Mar 2019 21:06:17 GMT
+recorded_with: VCR 4.0.0

--- a/fixtures/vcr_cassettes/PubmedHarvester/_search_all_sources_by_pmid/searches_Pubmed_by_pmid_when_not_found_locally_and_returns_a_pubhash.yml
+++ b/fixtures/vcr_cassettes/PubmedHarvester/_search_all_sources_by_pmid/searches_Pubmed_by_pmid_when_not_found_locally_and_returns_a_pubhash.yml
@@ -1,0 +1,162 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=a_fake_pubmed_key&db=pubmed&retmode=xml
+    body:
+      encoding: UTF-8
+      string: "&id=10487815"
+    headers:
+      User-Agent:
+      - stanford-library-sul-pub
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Tue, 19 Mar 2019 21:23:28 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 19 Mar 2019 21:23:29 GMT
+      Server:
+      - Finatra
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Ratelimit-Remaining:
+      - '9'
+      Ncbi-Phid:
+      - 939B06706F9C03E50000211867CAF270.1.1.m_3
+      Cache-Control:
+      - private
+      L5d-Success-Class:
+      - '1.0'
+      Ncbi-Sid:
+      - 115549D6AE0DF373_00F9SID
+      Content-Encoding:
+      - gzip
+      X-Ratelimit-Limit:
+      - '10'
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Set-Cookie:
+      - ncbi_sid=115549D6AE0DF373_00F9SID; domain=.nih.gov; path=/; expires=Thu, 19
+        Mar 2020 21:23:30 GMT
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" ?>
+        <!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2019//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_190101.dtd">
+        <PubmedArticleSet>
+        <PubmedArticle>
+            <MedlineCitation Status="PubMed-not-MEDLINE" Owner="NLM">
+                <PMID Version="1">10487815</PMID>
+                <DateCompleted>
+                    <Year>2012</Year>
+                    <Month>10</Month>
+                    <Day>02</Day>
+                </DateCompleted>
+                <DateRevised>
+                    <Year>2011</Year>
+                    <Month>06</Month>
+                    <Day>16</Day>
+                </DateRevised>
+                <Article PubModel="Print">
+                    <Journal>
+                        <ISSN IssnType="Print">0002-9122</ISSN>
+                        <JournalIssue CitedMedium="Print">
+                            <Volume>86</Volume>
+                            <Issue>9</Issue>
+                            <PubDate>
+                                <Year>1999</Year>
+                                <Month>Sep</Month>
+                            </PubDate>
+                        </JournalIssue>
+                        <Title>American journal of botany</Title>
+                        <ISOAbbreviation>Am. J. Bot.</ISOAbbreviation>
+                    </Journal>
+                    <ArticleTitle>Convergence and correlations among leaf size and function in seed plants: a comparative test using independent contrasts.</ArticleTitle>
+                    <Pagination>
+                        <MedlinePgn>1272-81</MedlinePgn>
+                    </Pagination>
+                    <Abstract>
+                        <AbstractText>Prior studies of a broad array of seed plants have reported strong correlations among leaf life span, specific leaf area, nitrogen concentration, and carbon assimilation rates, which have been interpreted as evidence of coordinated leaf physiological strategies. However, it is not known whether these relationships reflect patterns of evolutionary convergence, or whether they are due to contrasting characteristics of major seed plant lineages. We reevaluated a published data set for these seven traits measured in over 100 species, using phylogenetic independent contrasts calculated over a range of alternative seed plant phylogenies derived from recent molecular systematic analyses. In general, pairwise correlations among these seven traits were similar with and without consideration of phylogeny, and results were robust over a range of alternative phylogenies. We also evaluated relationships between these seven traits and lamina area, another important aspect of leaf function, and found moderate correlations with specific leaf area (0.64), mass-based photosynthesis (0.54), area-based nitrogen (-0.56), and leaf life span (-0.42). However, several of these correlations were markedly reduced using independent contrasts; for example, the correlation between leaf life span and lamina area was reduced to close to zero. This change reflects the large differences in both these traits between conifers and angiosperms and the absence of a relationship between the traits within these groups. This analysis illustrates that most interspecific relationships among leaf functional traits, considered across a broad range of seed plant taxa, reflect significant patterns of correlated evolutionary change, lending further support to the adaptive interpretation of these relationships.</AbstractText>
+                    </Abstract>
+                    <AuthorList CompleteYN="Y">
+                        <Author ValidYN="Y">
+                            <LastName>Ackerly</LastName>
+                            <ForeName>D D</ForeName>
+                            <Initials>DD</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>Department of Biological Sciences, Stanford University, Stanford, California 94305; and.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Reich</LastName>
+                            <ForeName>P B</ForeName>
+                            <Initials>PB</Initials>
+                        </Author>
+                    </AuthorList>
+                    <Language>eng</Language>
+                    <PublicationTypeList>
+                        <PublicationType UI="D016428">Journal Article</PublicationType>
+                    </PublicationTypeList>
+                </Article>
+                <MedlineJournalInfo>
+                    <Country>United States</Country>
+                    <MedlineTA>Am J Bot</MedlineTA>
+                    <NlmUniqueID>0370467</NlmUniqueID>
+                    <ISSNLinking>0002-9122</ISSNLinking>
+                </MedlineJournalInfo>
+            </MedlineCitation>
+            <PubmedData>
+                <History>
+                    <PubMedPubDate PubStatus="pubmed">
+                        <Year>1999</Year>
+                        <Month>9</Month>
+                        <Day>17</Day>
+                        <Hour>0</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="medline">
+                        <Year>1999</Year>
+                        <Month>9</Month>
+                        <Day>17</Day>
+                        <Hour>0</Hour>
+                        <Minute>1</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="entrez">
+                        <Year>1999</Year>
+                        <Month>9</Month>
+                        <Day>17</Day>
+                        <Hour>0</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                </History>
+                <PublicationStatus>ppublish</PublicationStatus>
+                <ArticleIdList>
+                    <ArticleId IdType="pubmed">10487815</ArticleId>
+                    <ArticleId IdType="pii">86/9/1272</ArticleId>
+                </ArticleIdList>
+            </PubmedData>
+        </PubmedArticle>
+
+        </PubmedArticleSet>
+    http_version:
+  recorded_at: Tue, 19 Mar 2019 21:23:29 GMT
+recorded_with: VCR 4.0.0

--- a/fixtures/vcr_cassettes/Pubmed_Fetcher/_fetch_remote_pubmed/WOS_enabled/searches_WoS_if_not_found_in_pubmed_first.yml
+++ b/fixtures/vcr_cassettes/Pubmed_Fetcher/_fetch_remote_pubmed/WOS_enabled/searches_WoS_if_not_found_in_pubmed_first.yml
@@ -1,0 +1,1161 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://search.webofknowledge.com/esti/wokmws/ws/WOKMWSAuthenticate?wsdl
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.5.1 (2018-03-29))
+      Accept:
+      - "*/*"
+      Date:
+      - Thu, 04 Apr 2019 21:48:33 GMT
+      Authorization:
+      - Basic Settings.WOS.AUTH_CODE
+      Soapaction:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 04 Apr 2019 21:48:34 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Content-Length:
+      - '8705'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version='1.0' encoding='UTF-8'?><wsdl:definitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="http://auth.cxf.wokmws.thomsonreuters.com" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" name="WOKMWSAuthenticateService" targetNamespace="http://auth.cxf.wokmws.thomsonreuters.com">
+          <wsdl:types>
+        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://auth.cxf.wokmws.thomsonreuters.com" targetNamespace="http://auth.cxf.wokmws.thomsonreuters.com" version="1.0">
+        <xs:element name="AuthenticationException" type="tns:AuthenticationException"/>
+        <xs:element name="ESTIWSException" type="tns:ESTIWSException"/>
+        <xs:element name="InternalServerException" type="tns:InternalServerException"/>
+        <xs:element name="InvalidInputException" type="tns:InvalidInputException"/>
+        <xs:element name="QueryException" type="tns:QueryException"/>
+        <xs:element name="SessionException" type="tns:SessionException"/>
+        <xs:element name="authenticate" type="tns:authenticate"/>
+        <xs:element name="authenticateResponse" type="tns:authenticateResponse"/>
+        <xs:element name="closeSession" type="tns:closeSession"/>
+        <xs:element name="closeSessionResponse" type="tns:closeSessionResponse"/>
+        <xs:complexType name="closeSession">
+            <xs:sequence/>
+          </xs:complexType>
+        <xs:complexType name="closeSessionResponse">
+            <xs:sequence/>
+          </xs:complexType>
+        <xs:complexType name="QueryException">
+            <xs:sequence/>
+          </xs:complexType>
+        <xs:complexType name="ESTIWSException">
+            <xs:sequence/>
+          </xs:complexType>
+        <xs:complexType name="InvalidInputException">
+            <xs:sequence/>
+          </xs:complexType>
+        <xs:complexType name="InternalServerException">
+            <xs:sequence/>
+          </xs:complexType>
+        <xs:complexType name="SessionException">
+            <xs:sequence/>
+          </xs:complexType>
+        <xs:complexType name="AuthenticationException">
+            <xs:sequence/>
+          </xs:complexType>
+        <xs:complexType name="authenticate">
+            <xs:sequence/>
+          </xs:complexType>
+        <xs:complexType name="authenticateResponse">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="return" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:schema>
+          </wsdl:types>
+          <wsdl:message name="closeSession">
+            <wsdl:part element="tns:closeSession" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="QueryException_Exception">
+            <wsdl:part element="tns:QueryException" name="QueryException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="ESTIWSException_Exception">
+            <wsdl:part element="tns:ESTIWSException" name="ESTIWSException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="InvalidInputException_Exception">
+            <wsdl:part element="tns:InvalidInputException" name="InvalidInputException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="InternalServerException_Exception">
+            <wsdl:part element="tns:InternalServerException" name="InternalServerException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="SessionException_Exception">
+            <wsdl:part element="tns:SessionException" name="SessionException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="authenticate">
+            <wsdl:part element="tns:authenticate" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="closeSessionResponse">
+            <wsdl:part element="tns:closeSessionResponse" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="authenticateResponse">
+            <wsdl:part element="tns:authenticateResponse" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="AuthenticationException_Exception">
+            <wsdl:part element="tns:AuthenticationException" name="AuthenticationException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:portType name="WOKMWSAuthenticate">
+            <wsdl:operation name="closeSession">
+              <wsdl:input message="tns:closeSession" name="closeSession">
+            </wsdl:input>
+              <wsdl:output message="tns:closeSessionResponse" name="closeSessionResponse">
+            </wsdl:output>
+              <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="authenticate">
+              <wsdl:input message="tns:authenticate" name="authenticate">
+            </wsdl:input>
+              <wsdl:output message="tns:authenticateResponse" name="authenticateResponse">
+            </wsdl:output>
+              <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+            </wsdl:operation>
+          </wsdl:portType>
+          <wsdl:binding name="WOKMWSAuthenticateServiceSoapBinding" type="tns:WOKMWSAuthenticate">
+            <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+            <wsdl:operation name="closeSession">
+              <soap:operation soapAction="" style="document"/>
+              <wsdl:input name="closeSession">
+                <soap:body use="literal"/>
+              </wsdl:input>
+              <wsdl:output name="closeSessionResponse">
+                <soap:body use="literal"/>
+              </wsdl:output>
+              <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+              </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="authenticate">
+              <soap:operation soapAction="" style="document"/>
+              <wsdl:input name="authenticate">
+                <soap:body use="literal"/>
+              </wsdl:input>
+              <wsdl:output name="authenticateResponse">
+                <soap:body use="literal"/>
+              </wsdl:output>
+              <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+              </wsdl:fault>
+            </wsdl:operation>
+          </wsdl:binding>
+          <wsdl:service name="WOKMWSAuthenticateService">
+            <wsdl:port binding="tns:WOKMWSAuthenticateServiceSoapBinding" name="WOKMWSAuthenticatePort">
+              <soap:address location="http://search.webofknowledge.com/esti/wokmws/ws/WOKMWSAuthenticate"/>
+            </wsdl:port>
+          </wsdl:service>
+        </wsdl:definitions>
+    http_version: 
+  recorded_at: Thu, 04 Apr 2019 21:48:33 GMT
+- request:
+    method: post
+    uri: http://search.webofknowledge.com/esti/wokmws/ws/WOKMWSAuthenticate
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://auth.cxf.wokmws.thomsonreuters.com"
+        xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Body><tns:authenticate></tns:authenticate></soapenv:Body></soapenv:Envelope>
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.5.1 (2018-03-29))
+      Accept:
+      - "*/*"
+      Date:
+      - Thu, 04 Apr 2019 21:48:33 GMT
+      Authorization:
+      - Basic Settings.WOS.AUTH_CODE
+      Soapaction:
+      - ''
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Content-Length:
+      - '352'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Date:
+      - Thu, 04 Apr 2019 21:48:33 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Set-Cookie:
+      - SID=8FCIV1g2UET7mzLzrUj
+      Content-Length:
+      - '252'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><ns2:authenticateResponse
+        xmlns:ns2="http://auth.cxf.wokmws.thomsonreuters.com"><return>8FCIV1g2UET7mzLzrUj</return></ns2:authenticateResponse></soap:Body></soap:Envelope>
+    http_version: 
+  recorded_at: Thu, 04 Apr 2019 21:48:34 GMT
+- request:
+    method: get
+    uri: http://search.webofknowledge.com/esti/wokmws/ws/WokSearch?wsdl
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.5.1 (2018-03-29))
+      Accept:
+      - "*/*"
+      Date:
+      - Thu, 04 Apr 2019 21:48:34 GMT
+      Cookie:
+      - SID="8FCIV1g2UET7mzLzrUj"
+      Soapaction:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 04 Apr 2019 21:48:34 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Content-Length:
+      - '32204'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version='1.0' encoding='UTF-8'?><wsdl:definitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="http://woksearch.v3.wokmws.thomsonreuters.com" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" name="WokSearchService" targetNamespace="http://woksearch.v3.wokmws.thomsonreuters.com">
+          <wsdl:types>
+        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://woksearch.v3.wokmws.thomsonreuters.com" targetNamespace="http://woksearch.v3.wokmws.thomsonreuters.com" version="1.0">
+        <xs:element name="AuthenticationException" type="tns:AuthenticationException"/>
+        <xs:element name="ESTIWSException" type="tns:ESTIWSException"/>
+        <xs:element name="InternalServerException" type="tns:InternalServerException"/>
+        <xs:element name="InvalidInputException" type="tns:InvalidInputException"/>
+        <xs:element name="QueryException" type="tns:QueryException"/>
+        <xs:element name="SessionException" type="tns:SessionException"/>
+        <xs:element name="citedReferences" type="tns:citedReferences"/>
+        <xs:element name="citedReferencesResponse" type="tns:citedReferencesResponse"/>
+        <xs:element name="citedReferencesRetrieve" type="tns:citedReferencesRetrieve"/>
+        <xs:element name="citedReferencesRetrieveResponse" type="tns:citedReferencesRetrieveResponse"/>
+        <xs:element name="citingArticles" type="tns:citingArticles"/>
+        <xs:element name="citingArticlesResponse" type="tns:citingArticlesResponse"/>
+        <xs:element name="relatedRecords" type="tns:relatedRecords"/>
+        <xs:element name="relatedRecordsResponse" type="tns:relatedRecordsResponse"/>
+        <xs:element name="retrieve" type="tns:retrieve"/>
+        <xs:element name="retrieveById" type="tns:retrieveById"/>
+        <xs:element name="retrieveByIdResponse" type="tns:retrieveByIdResponse"/>
+        <xs:element name="retrieveResponse" type="tns:retrieveResponse"/>
+        <xs:element name="search" type="tns:search"/>
+        <xs:element name="searchResponse" type="tns:searchResponse"/>
+        <xs:complexType name="citedReferences">
+            <xs:sequence>
+              <xs:element name="databaseId" type="xs:string"/>
+              <xs:element name="uid" type="xs:string"/>
+              <xs:element name="queryLanguage" type="xs:string"/>
+              <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="retrieveParameters">
+            <xs:sequence>
+              <xs:element name="firstRecord" type="xs:int"/>
+              <xs:element name="count" type="xs:int"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="sortField" nillable="true" type="tns:sortField"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="viewField" nillable="true" type="tns:viewField"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="option" nillable="true" type="tns:keyValuePair"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="sortField">
+            <xs:sequence>
+              <xs:element name="name" type="xs:string"/>
+              <xs:element name="sort" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="viewField">
+            <xs:sequence>
+              <xs:element name="collectionName" type="xs:string"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="fieldName" nillable="true" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="keyValuePair">
+            <xs:sequence>
+              <xs:element name="key" type="xs:string"/>
+              <xs:element name="value" nillable="true" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="citedReferencesResponse">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="return" type="tns:citedReferencesSearchResults"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="citedReferencesSearchResults">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="queryId" type="xs:string"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="references" nillable="true" type="tns:citedReference"/>
+              <xs:element name="recordsFound" type="xs:int"/>
+              <xs:element name="recordsSearched" type="xs:long"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="citedReference">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="uid" type="xs:string"/>
+              <xs:element minOccurs="0" name="docid" type="xs:string"/>
+              <xs:element minOccurs="0" name="articleId" type="xs:string"/>
+              <xs:element minOccurs="0" name="citedAuthor" type="xs:string"/>
+              <xs:element minOccurs="0" name="timesCited" type="xs:string"/>
+              <xs:element minOccurs="0" name="year" type="xs:string"/>
+              <xs:element minOccurs="0" name="page" type="xs:string"/>
+              <xs:element minOccurs="0" name="volume" type="xs:string"/>
+              <xs:element minOccurs="0" name="citedTitle" type="xs:string"/>
+              <xs:element minOccurs="0" name="citedWork" type="xs:string"/>
+              <xs:element minOccurs="0" name="hot" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="QueryException">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
+              <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="FaultInformation">
+            <xs:sequence>
+              <xs:element name="code" type="xs:string"/>
+              <xs:element minOccurs="0" name="message" type="xs:string"/>
+              <xs:element minOccurs="0" name="reason" type="xs:string"/>
+              <xs:element minOccurs="0" name="causeType" type="xs:string"/>
+              <xs:element minOccurs="0" name="cause" type="xs:string"/>
+              <xs:element minOccurs="0" name="supportingWebServiceException" type="tns:SupportingWebServiceException"/>
+              <xs:element minOccurs="0" name="remedy" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="SupportingWebServiceException">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="remoteNamespace" type="xs:string"/>
+              <xs:element minOccurs="0" name="remoteOperation" type="xs:string"/>
+              <xs:element minOccurs="0" name="remoteCode" type="xs:string"/>
+              <xs:element minOccurs="0" name="remoteReason" type="xs:string"/>
+              <xs:element minOccurs="0" name="handshakeCauseId" type="xs:string"/>
+              <xs:element minOccurs="0" name="handshakeCause" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="RawFaultInformation">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="rawFaultstring" type="xs:string"/>
+              <xs:element minOccurs="0" name="rawMessage" type="xs:string"/>
+              <xs:element minOccurs="0" name="rawReason" type="xs:string"/>
+              <xs:element minOccurs="0" name="rawCause" type="xs:string"/>
+              <xs:element minOccurs="0" name="rawRemedy" type="xs:string"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="messageData" nillable="true" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="InvalidInputException">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
+              <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="ESTIWSException">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
+              <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="InternalServerException">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
+              <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="AuthenticationException">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
+              <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="SessionException">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="faultInformation" type="tns:FaultInformation"/>
+              <xs:element minOccurs="0" name="rawFaultInformation" type="tns:RawFaultInformation"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="citedReferencesRetrieve">
+            <xs:sequence>
+              <xs:element name="queryId" type="xs:string"/>
+              <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="citedReferencesRetrieveResponse">
+            <xs:sequence>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="return" type="tns:citedReference"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="relatedRecords">
+            <xs:sequence>
+              <xs:element name="databaseId" type="xs:string"/>
+              <xs:element name="uid" type="xs:string"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="editions" nillable="true" type="tns:editionDesc"/>
+              <xs:element minOccurs="0" name="timeSpan" type="tns:timeSpan"/>
+              <xs:element name="queryLanguage" type="xs:string"/>
+              <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="editionDesc">
+            <xs:sequence>
+              <xs:element name="collection" type="xs:string"/>
+              <xs:element name="edition" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="timeSpan">
+            <xs:sequence>
+              <xs:element name="begin" type="xs:string"/>
+              <xs:element name="end" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="relatedRecordsResponse">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="return" type="tns:fullRecordSearchResults"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="fullRecordSearchResults">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="queryId" type="xs:string"/>
+              <xs:element name="recordsFound" type="xs:int"/>
+              <xs:element name="recordsSearched" type="xs:long"/>
+              <xs:element minOccurs="0" name="parent" type="xs:string"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="optionValue" nillable="true" type="tns:labelValuesPair"/>
+              <xs:element minOccurs="0" name="records" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="labelValuesPair">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="label" type="xs:string"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="value" nillable="true" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="retrieveById">
+            <xs:sequence>
+              <xs:element name="databaseId" type="xs:string"/>
+              <xs:element maxOccurs="unbounded" name="uid" type="xs:string"/>
+              <xs:element name="queryLanguage" type="xs:string"/>
+              <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="retrieveByIdResponse">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="return" type="tns:fullRecordSearchResults"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="retrieve">
+            <xs:sequence>
+              <xs:element name="queryId" type="xs:string"/>
+              <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="retrieveResponse">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="return" type="tns:fullRecordData"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="fullRecordData">
+            <xs:sequence>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="optionValue" nillable="true" type="tns:labelValuesPair"/>
+              <xs:element minOccurs="0" name="records" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="search">
+            <xs:sequence>
+              <xs:element name="queryParameters" type="tns:queryParameters"/>
+              <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="queryParameters">
+            <xs:sequence>
+              <xs:element name="databaseId" type="xs:string"/>
+              <xs:element name="userQuery" type="xs:string"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="editions" nillable="true" type="tns:editionDesc"/>
+              <xs:element minOccurs="0" name="symbolicTimeSpan" type="xs:string"/>
+              <xs:element minOccurs="0" name="timeSpan" type="tns:timeSpan"/>
+              <xs:element name="queryLanguage" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="searchResponse">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="return" type="tns:fullRecordSearchResults"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="citingArticles">
+            <xs:sequence>
+              <xs:element name="databaseId" type="xs:string"/>
+              <xs:element name="uid" type="xs:string"/>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="editions" nillable="true" type="tns:editionDesc"/>
+              <xs:element minOccurs="0" name="timeSpan" type="tns:timeSpan"/>
+              <xs:element name="queryLanguage" type="xs:string"/>
+              <xs:element name="retrieveParameters" type="tns:retrieveParameters"/>
+            </xs:sequence>
+          </xs:complexType>
+        <xs:complexType name="citingArticlesResponse">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="return" type="tns:fullRecordSearchResults"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:schema>
+          </wsdl:types>
+          <wsdl:message name="relatedRecordsResponse">
+            <wsdl:part element="tns:relatedRecordsResponse" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="relatedRecords">
+            <wsdl:part element="tns:relatedRecords" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="retrieveById">
+            <wsdl:part element="tns:retrieveById" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="retrieveResponse">
+            <wsdl:part element="tns:retrieveResponse" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="ESTIWSException_Exception">
+            <wsdl:part element="tns:ESTIWSException" name="ESTIWSException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="InternalServerException_Exception">
+            <wsdl:part element="tns:InternalServerException" name="InternalServerException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="retrieve">
+            <wsdl:part element="tns:retrieve" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="searchResponse">
+            <wsdl:part element="tns:searchResponse" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="citingArticlesResponse">
+            <wsdl:part element="tns:citingArticlesResponse" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="AuthenticationException_Exception">
+            <wsdl:part element="tns:AuthenticationException" name="AuthenticationException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="retrieveByIdResponse">
+            <wsdl:part element="tns:retrieveByIdResponse" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="search">
+            <wsdl:part element="tns:search" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="citingArticles">
+            <wsdl:part element="tns:citingArticles" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="citedReferences">
+            <wsdl:part element="tns:citedReferences" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="citedReferencesRetrieve">
+            <wsdl:part element="tns:citedReferencesRetrieve" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="citedReferencesRetrieveResponse">
+            <wsdl:part element="tns:citedReferencesRetrieveResponse" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="QueryException_Exception">
+            <wsdl:part element="tns:QueryException" name="QueryException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="InvalidInputException_Exception">
+            <wsdl:part element="tns:InvalidInputException" name="InvalidInputException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="citedReferencesResponse">
+            <wsdl:part element="tns:citedReferencesResponse" name="parameters">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:message name="SessionException_Exception">
+            <wsdl:part element="tns:SessionException" name="SessionException_Exception">
+            </wsdl:part>
+          </wsdl:message>
+          <wsdl:portType name="WokSearch">
+            <wsdl:operation name="citedReferences">
+              <wsdl:input message="tns:citedReferences" name="citedReferences">
+            </wsdl:input>
+              <wsdl:output message="tns:citedReferencesResponse" name="citedReferencesResponse">
+            </wsdl:output>
+              <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="citedReferencesRetrieve">
+              <wsdl:input message="tns:citedReferencesRetrieve" name="citedReferencesRetrieve">
+            </wsdl:input>
+              <wsdl:output message="tns:citedReferencesRetrieveResponse" name="citedReferencesRetrieveResponse">
+            </wsdl:output>
+              <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="relatedRecords">
+              <wsdl:input message="tns:relatedRecords" name="relatedRecords">
+            </wsdl:input>
+              <wsdl:output message="tns:relatedRecordsResponse" name="relatedRecordsResponse">
+            </wsdl:output>
+              <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="retrieveById">
+              <wsdl:input message="tns:retrieveById" name="retrieveById">
+            </wsdl:input>
+              <wsdl:output message="tns:retrieveByIdResponse" name="retrieveByIdResponse">
+            </wsdl:output>
+              <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="retrieve">
+              <wsdl:input message="tns:retrieve" name="retrieve">
+            </wsdl:input>
+              <wsdl:output message="tns:retrieveResponse" name="retrieveResponse">
+            </wsdl:output>
+              <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="search">
+              <wsdl:input message="tns:search" name="search">
+            </wsdl:input>
+              <wsdl:output message="tns:searchResponse" name="searchResponse">
+            </wsdl:output>
+              <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="citingArticles">
+              <wsdl:input message="tns:citingArticles" name="citingArticles">
+            </wsdl:input>
+              <wsdl:output message="tns:citingArticlesResponse" name="citingArticlesResponse">
+            </wsdl:output>
+              <wsdl:fault message="tns:SessionException_Exception" name="SessionException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:AuthenticationException_Exception" name="AuthenticationException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InvalidInputException_Exception" name="InvalidInputException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:ESTIWSException_Exception" name="ESTIWSException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:InternalServerException_Exception" name="InternalServerException_Exception">
+            </wsdl:fault>
+              <wsdl:fault message="tns:QueryException_Exception" name="QueryException_Exception">
+            </wsdl:fault>
+            </wsdl:operation>
+          </wsdl:portType>
+          <wsdl:binding name="WokSearchServiceSoapBinding" type="tns:WokSearch">
+            <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+            <wsdl:operation name="citedReferences">
+              <soap:operation soapAction="" style="document"/>
+              <wsdl:input name="citedReferences">
+                <soap:body use="literal"/>
+              </wsdl:input>
+              <wsdl:output name="citedReferencesResponse">
+                <soap:body use="literal"/>
+              </wsdl:output>
+              <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+              </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="citedReferencesRetrieve">
+              <soap:operation soapAction="" style="document"/>
+              <wsdl:input name="citedReferencesRetrieve">
+                <soap:body use="literal"/>
+              </wsdl:input>
+              <wsdl:output name="citedReferencesRetrieveResponse">
+                <soap:body use="literal"/>
+              </wsdl:output>
+              <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+              </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="relatedRecords">
+              <soap:operation soapAction="" style="document"/>
+              <wsdl:input name="relatedRecords">
+                <soap:body use="literal"/>
+              </wsdl:input>
+              <wsdl:output name="relatedRecordsResponse">
+                <soap:body use="literal"/>
+              </wsdl:output>
+              <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+              </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="retrieveById">
+              <soap:operation soapAction="" style="document"/>
+              <wsdl:input name="retrieveById">
+                <soap:body use="literal"/>
+              </wsdl:input>
+              <wsdl:output name="retrieveByIdResponse">
+                <soap:body use="literal"/>
+              </wsdl:output>
+              <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+              </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="retrieve">
+              <soap:operation soapAction="" style="document"/>
+              <wsdl:input name="retrieve">
+                <soap:body use="literal"/>
+              </wsdl:input>
+              <wsdl:output name="retrieveResponse">
+                <soap:body use="literal"/>
+              </wsdl:output>
+              <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+              </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="search">
+              <soap:operation soapAction="" style="document"/>
+              <wsdl:input name="search">
+                <soap:body use="literal"/>
+              </wsdl:input>
+              <wsdl:output name="searchResponse">
+                <soap:body use="literal"/>
+              </wsdl:output>
+              <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+              </wsdl:fault>
+            </wsdl:operation>
+            <wsdl:operation name="citingArticles">
+              <soap:operation soapAction="" style="document"/>
+              <wsdl:input name="citingArticles">
+                <soap:body use="literal"/>
+              </wsdl:input>
+              <wsdl:output name="citingArticlesResponse">
+                <soap:body use="literal"/>
+              </wsdl:output>
+              <wsdl:fault name="SessionException_Exception">
+                <soap:fault name="SessionException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="AuthenticationException_Exception">
+                <soap:fault name="AuthenticationException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InvalidInputException_Exception">
+                <soap:fault name="InvalidInputException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="ESTIWSException_Exception">
+                <soap:fault name="ESTIWSException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="InternalServerException_Exception">
+                <soap:fault name="InternalServerException_Exception" use="literal"/>
+              </wsdl:fault>
+              <wsdl:fault name="QueryException_Exception">
+                <soap:fault name="QueryException_Exception" use="literal"/>
+              </wsdl:fault>
+            </wsdl:operation>
+          </wsdl:binding>
+          <wsdl:service name="WokSearchService">
+            <wsdl:port binding="tns:WokSearchServiceSoapBinding" name="WokSearchPort">
+              <soap:address location="http://search.webofknowledge.com/esti/wokmws/ws/WokSearch"/>
+            </wsdl:port>
+          </wsdl:service>
+        </wsdl:definitions>
+    http_version: 
+  recorded_at: Thu, 04 Apr 2019 21:48:34 GMT
+- request:
+    method: post
+    uri: http://search.webofknowledge.com/esti/wokmws/ws/WokSearch
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://woksearch.v3.wokmws.thomsonreuters.com"
+        xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Body><tns:retrieveById><databaseId>WOK</databaseId><uid>MEDLINE:24930130</uid><queryLanguage>en</queryLanguage><retrieveParameters><firstRecord>1</firstRecord><count>100</count><option><key>RecordIDs</key><value>On</value></option><option><key>targetNamespace</key><value>http://scientific.thomsonreuters.com/schema/wok5.4/public/FullRecord</value></option></retrieveParameters></tns:retrieveById></soapenv:Body></soapenv:Envelope>
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.5.1 (2018-03-29))
+      Accept:
+      - "*/*"
+      Date:
+      - Thu, 04 Apr 2019 21:48:34 GMT
+      Cookie:
+      - SID="8FCIV1g2UET7mzLzrUj"
+      Soapaction:
+      - ''
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Content-Length:
+      - '711'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Date:
+      - Thu, 04 Apr 2019 21:48:34 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Content-Length:
+      - '13130'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><ns2:retrieveByIdResponse
+        xmlns:ns2="http://woksearch.v3.wokmws.thomsonreuters.com"><return><queryId>1</queryId><recordsFound>1</recordsFound><recordsSearched>81070508</recordsSearched><optionValue><label>RecordIDs</label><value>MEDLINE:24930130</value></optionValue><records>&lt;records
+        xmlns="http://scientific.thomsonreuters.com/schema/wok5.4/public/FullRecord">&lt;REC
+        r_id_disclaimer="ResearcherID data provided by Clarivate Analytics">&lt;UID>MEDLINE:24930130&lt;/UID>&lt;static_data>&lt;summary>&lt;EWUID>&lt;WUID
+        coll_id="MEDLINE">&lt;/WUID>&lt;edition value="MEDLINE.MEDLINE">&lt;/edition>&lt;/EWUID>&lt;pub_info
+        sortdate="2014-08-01" pubyear="2014" pubmonth="Aug" coverdate="2014-Aug" edate="2014-06-15"
+        vol="11" issue="8" pubtype="Journal" medium="Internet" model="Print-Electronic"
+        has_abstract="Y">&lt;page begin="855" end="60">855-60&lt;/page>&lt;/pub_info>&lt;titles
+        count="4">&lt;title type="item">Chemically defined generation of human cardiomyocytes.&lt;/title>&lt;title
+        type="source">Nature methods&lt;/title>&lt;title type="abbrev_iso">Nat. Methods&lt;/title>&lt;title
+        type="source_abbrev">Nat Methods&lt;/title>&lt;/titles>&lt;names count="15">&lt;name
+        seq_no="1" role="author" display="Y">&lt;display_name>Burridge, Paul W&lt;/display_name>&lt;full_name>Burridge,
+        Paul W&lt;/full_name>&lt;initials>PW&lt;/initials>&lt;/name>&lt;name seq_no="2"
+        role="author" display="Y">&lt;display_name>Matsa, Elena&lt;/display_name>&lt;full_name>Matsa,
+        Elena&lt;/full_name>&lt;initials>E&lt;/initials>&lt;/name>&lt;name seq_no="3"
+        role="author" display="Y">&lt;display_name>Shukla, Praveen&lt;/display_name>&lt;full_name>Shukla,
+        Praveen&lt;/full_name>&lt;initials>P&lt;/initials>&lt;/name>&lt;name seq_no="4"
+        role="author" display="Y">&lt;display_name>Lin, Ziliang C&lt;/display_name>&lt;full_name>Lin,
+        Ziliang C&lt;/full_name>&lt;initials>ZC&lt;/initials>&lt;/name>&lt;name seq_no="5"
+        role="author" display="Y">&lt;display_name>Churko, Jared M&lt;/display_name>&lt;full_name>Churko,
+        Jared M&lt;/full_name>&lt;initials>JM&lt;/initials>&lt;/name>&lt;name seq_no="6"
+        role="author" display="Y">&lt;display_name>Ebert, Antje D&lt;/display_name>&lt;full_name>Ebert,
+        Antje D&lt;/full_name>&lt;initials>AD&lt;/initials>&lt;/name>&lt;name seq_no="7"
+        role="author" display="Y">&lt;display_name>Lan, Feng&lt;/display_name>&lt;full_name>Lan,
+        Feng&lt;/full_name>&lt;initials>F&lt;/initials>&lt;/name>&lt;name seq_no="8"
+        role="author" display="Y">&lt;display_name>Diecke, Sebastian&lt;/display_name>&lt;full_name>Diecke,
+        Sebastian&lt;/full_name>&lt;initials>S&lt;/initials>&lt;/name>&lt;name seq_no="9"
+        role="author" display="Y">&lt;display_name>Huber, Bruno&lt;/display_name>&lt;full_name>Huber,
+        Bruno&lt;/full_name>&lt;initials>B&lt;/initials>&lt;/name>&lt;name seq_no="10"
+        role="author" display="Y">&lt;display_name>Mordwinkin, Nicholas M&lt;/display_name>&lt;full_name>Mordwinkin,
+        Nicholas M&lt;/full_name>&lt;initials>NM&lt;/initials>&lt;/name>&lt;name seq_no="11"
+        role="author" display="Y">&lt;display_name>Plews, Jordan R&lt;/display_name>&lt;full_name>Plews,
+        Jordan R&lt;/full_name>&lt;initials>JR&lt;/initials>&lt;/name>&lt;name seq_no="12"
+        role="author" display="Y">&lt;display_name>Abilez, Oscar J&lt;/display_name>&lt;full_name>Abilez,
+        Oscar J&lt;/full_name>&lt;initials>OJ&lt;/initials>&lt;/name>&lt;name seq_no="13"
+        role="author" display="Y">&lt;display_name>Cui, Bianxiao&lt;/display_name>&lt;full_name>Cui,
+        Bianxiao&lt;/full_name>&lt;initials>B&lt;/initials>&lt;/name>&lt;name seq_no="14"
+        role="author" display="Y">&lt;display_name>Gold, Joseph D&lt;/display_name>&lt;full_name>Gold,
+        Joseph D&lt;/full_name>&lt;initials>JD&lt;/initials>&lt;/name>&lt;name seq_no="15"
+        role="author" display="Y">&lt;display_name>Wu, Joseph C&lt;/display_name>&lt;full_name>Wu,
+        Joseph C&lt;/full_name>&lt;initials>JC&lt;/initials>&lt;/name>&lt;/names>&lt;doctypes
+        count="3">&lt;doctype>Journal Article&lt;/doctype>&lt;doctype>Research Support,
+        N.I.H., Extramural&lt;/doctype>&lt;doctype>Research Support, Non-U.S. Gov&amp;apos;t&lt;/doctype>&lt;/doctypes>&lt;/summary>&lt;fullrecord_metadata>&lt;languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/languages>&lt;normalized_languages
+        count="1">&lt;language type="primary">English&lt;/language>&lt;/normalized_languages>&lt;normalized_doctypes
+        count="2">&lt;doctype>Article&lt;/doctype>&lt;doctype>Other&lt;/doctype>&lt;/normalized_doctypes>&lt;addresses
+        count="4">&lt;address_name>&lt;address_spec addr_no="1">&lt;full_address>1]
+        Stanford Cardiovascular Institute, Stanford University School of Medicine,
+        Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative
+        Medicine, Stanford University School of Medicine, Stanford, California, USA.
+        [3] Department of Medicine, Division of Cardiology, Stanford University School
+        of Medicine, Stanford, California, USA.&lt;/full_address>&lt;/address_spec>&lt;/address_name>&lt;address_name>&lt;address_spec
+        addr_no="2">&lt;full_address>Department of Applied Physics, Stanford University
+        School of Medicine, Stanford, California, USA.&lt;/full_address>&lt;/address_spec>&lt;/address_name>&lt;address_name>&lt;address_spec
+        addr_no="3">&lt;full_address>Department of Chemistry, Stanford University
+        School of Medicine, Stanford, California, USA.&lt;/full_address>&lt;/address_spec>&lt;/address_name>&lt;address_name>&lt;address_spec
+        addr_no="4">&lt;full_address>Stanford Cardiovascular Institute, Stanford University
+        School of Medicine, Stanford, California, USA.&lt;/full_address>&lt;/address_spec>&lt;/address_name>&lt;/addresses>&lt;category_info>&lt;headings
+        count="1">&lt;heading>Science &amp;amp; Technology&lt;/heading>&lt;/headings>&lt;subheadings
+        count="1">&lt;subheading>Life Sciences &amp;amp; Biomedicine&lt;/subheading>&lt;/subheadings>&lt;subjects
+        count="2">&lt;subject ascatype="traditional" code="DR">CELL BIOLOGY&lt;/subject>&lt;subject
+        ascatype="extended">Cell Biology&lt;/subject>&lt;/subjects>&lt;/category_info>&lt;fund_ack>&lt;grants
+        count="7" complete="Y">&lt;grant>&lt;grant_agency>NHLBI NIH HHS&lt;/grant_agency>&lt;grant_ids
+        count="1">&lt;grant_id>R01 HL113006&lt;/grant_id>&lt;/grant_ids>&lt;country>United
+        States&lt;/country>&lt;acronym>HL&lt;/acronym>&lt;/grant>&lt;grant>&lt;grant_agency>NIBIB
+        NIH HHS&lt;/grant_agency>&lt;grant_ids count="1">&lt;grant_id>T32 EB009035&lt;/grant_id>&lt;/grant_ids>&lt;country>United
+        States&lt;/country>&lt;acronym>EB&lt;/acronym>&lt;/grant>&lt;grant>&lt;grant_agency>NHLBI
+        NIH HHS&lt;/grant_agency>&lt;grant_ids count="1">&lt;grant_id>U01 HL099776&lt;/grant_id>&lt;/grant_ids>&lt;country>United
+        States&lt;/country>&lt;acronym>HL&lt;/acronym>&lt;/grant>&lt;grant>&lt;grant_agency>NHLBI
+        NIH HHS&lt;/grant_agency>&lt;grant_ids count="1">&lt;grant_id>R24 HL117756&lt;/grant_id>&lt;/grant_ids>&lt;country>United
+        States&lt;/country>&lt;acronym>HL&lt;/acronym>&lt;/grant>&lt;grant>&lt;grant_agency>NHLBI
+        NIH HHS&lt;/grant_agency>&lt;grant_ids count="1">&lt;grant_id>T32 HL098049&lt;/grant_id>&lt;/grant_ids>&lt;country>United
+        States&lt;/country>&lt;acronym>HL&lt;/acronym>&lt;/grant>&lt;grant>&lt;grant_agency>NHLBI
+        NIH HHS&lt;/grant_agency>&lt;grant_ids count="1">&lt;grant_id>K99 HL121177&lt;/grant_id>&lt;/grant_ids>&lt;country>United
+        States&lt;/country>&lt;acronym>HL&lt;/acronym>&lt;/grant>&lt;grant>&lt;grant_agency>NHLBI
+        NIH HHS&lt;/grant_agency>&lt;grant_ids count="1">&lt;grant_id>R00 HL121177&lt;/grant_id>&lt;/grant_ids>&lt;country>United
+        States&lt;/country>&lt;acronym>HL&lt;/acronym>&lt;/grant>&lt;/grants>&lt;/fund_ack>&lt;abstracts
+        count="1">&lt;abstract>&lt;abstract_text>&lt;p>Existing methods for human
+        induced pluripotent stem cell (hiPSC) cardiac differentiation are efficient
+        but require complex, undefined medium constituents that hinder further elucidation
+        of the molecular mechanisms of cardiomyogenesis. Using hiPSCs derived under
+        chemically defined conditions on synthetic matrices, we systematically developed
+        an optimized cardiac differentiation strategy, using a chemically defined
+        medium consisting of just three components: the basal medium RPMI 1640, L-ascorbic
+        acid 2-phosphate and rice-derived recombinant human albumin. Along with small
+        molecule-based induction of differentiation, this protocol produced contractile
+        sheets of up to 95% TNNT2(+) cardiomyocytes at a yield of up to 100 cardiomyocytes
+        for every input pluripotent cell and was effective in 11 hiPSC lines tested.
+        This chemically defined platform for cardiac specification of hiPSCs will
+        allow the elucidation of cardiomyocyte macromolecular and metabolic requirements
+        and will provide a minimal system for the study of maturation and subtype
+        specification. &lt;/p>&lt;/abstract_text>&lt;/abstract>&lt;/abstracts>&lt;/fullrecord_metadata>&lt;item
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Owner="NLM" Status="MEDLINE"
+        xsi:type="itemType_medline" coll_id="MEDLINE">&lt;MedlineJournalInfo>&lt;Country>United
+        States&lt;/Country>&lt;NlmUniqueID>101215604&lt;/NlmUniqueID>&lt;ISSNLinking>1548-7091&lt;/ISSNLinking>&lt;/MedlineJournalInfo>&lt;DateCompleted>2014-09-29&lt;/DateCompleted>&lt;DateRevised>2018-12-18&lt;/DateRevised>&lt;Affiliation>1]
+        Stanford Cardiovascular Institute, Stanford University School of Medicine,
+        Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative
+        Medicine, Stanford University School of Medicine, Stanford, California, USA.
+        [3] Department of Medicine, Division of Cardiology, Stanford University School
+        of Medicine, Stanford, California, USA.&lt;/Affiliation>&lt;ChemicalList>&lt;Chemical>&lt;RegistryNumber>0&lt;/RegistryNumber>&lt;NameOfSubstance
+        UI="D003470">Culture Media&lt;/NameOfSubstance>&lt;/Chemical>&lt;/ChemicalList>&lt;CitationSubset>IM&lt;/CitationSubset>&lt;MeshHeadingList>&lt;MeshHeading>&lt;DescriptorName
+        MajorTopicYN="N" UI="D002454">Cell Differentiation&lt;/DescriptorName>&lt;TreeCodeList>&lt;TreeCode
+        MajorTopicYN="N">G04.299.151&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;MeshHeading>&lt;DescriptorName
+        MajorTopicYN="N" UI="D003470">Culture Media&lt;/DescriptorName>&lt;TreeCodeList>&lt;TreeCode
+        MajorTopicYN="N">D27.720.470.305&lt;/TreeCode>&lt;TreeCode MajorTopicYN="N">E07.206&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;MeshHeading>&lt;DescriptorName
+        MajorTopicYN="N" UI="D006801">Humans&lt;/DescriptorName>&lt;TreeCodeList>&lt;TreeCode
+        MajorTopicYN="N">B01.050.150.900.649.801.400.112.400.400&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;MeshHeading>&lt;DescriptorName
+        MajorTopicYN="N" UI="D057026">Induced Pluripotent Stem Cells&lt;/DescriptorName>&lt;QualifierName
+        MajorTopicYN="N" UI="Q000166">cytology&lt;/QualifierName>&lt;TreeCodeList>&lt;TreeCode
+        MajorTopicYN="N">A11.872.040.500&lt;/TreeCode>&lt;TreeCode MajorTopicYN="N">A11.872.700.500&lt;/TreeCode>&lt;TreeCode
+        MajorTopicYN="N">Y02.020&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;MeshHeading>&lt;DescriptorName
+        MajorTopicYN="N" UI="D032383">Myocytes, Cardiac&lt;/DescriptorName>&lt;QualifierName
+        MajorTopicYN="Y" UI="Q000166">cytology&lt;/QualifierName>&lt;TreeCodeList>&lt;TreeCode
+        MajorTopicYN="N">A07.541.704.570&lt;/TreeCode>&lt;TreeCode MajorTopicYN="N">A10.690.552.750.570&lt;/TreeCode>&lt;TreeCode
+        MajorTopicYN="N">A11.620.500&lt;/TreeCode>&lt;TreeCode MajorTopicYN="Y">Y02.020&lt;/TreeCode>&lt;/TreeCodeList>&lt;/MeshHeading>&lt;/MeshHeadingList>&lt;/item>&lt;contributors
+        count="4">&lt;contributor>&lt;name seq_no="1" role="researcher_id" r_id="I-2023-2012"
+        orcid_id="0000-0002-9038-4014">&lt;display_name>Lan, Feng&lt;/display_name>&lt;full_name>Lan,
+        Feng&lt;/full_name>&lt;first_name>Feng&lt;/first_name>&lt;last_name>Lan&lt;/last_name>&lt;/name>&lt;/contributor>&lt;contributor>&lt;name
+        seq_no="2" role="researcher_id" r_id="B-5014-2012" orcid_id="0000-0002-9991-400X">&lt;display_name>Abilez,
+        Oscar&lt;/display_name>&lt;full_name>Abilez, Oscar&lt;/full_name>&lt;first_name>Oscar&lt;/first_name>&lt;last_name>Abilez&lt;/last_name>&lt;/name>&lt;/contributor>&lt;contributor>&lt;name
+        seq_no="3" role="researcher_id" r_id="D-2336-2015">&lt;display_name>Matsa,
+        Elena&lt;/display_name>&lt;full_name>Matsa, Elena&lt;/full_name>&lt;first_name>Elena&lt;/first_name>&lt;last_name>Matsa&lt;/last_name>&lt;/name>&lt;/contributor>&lt;contributor>&lt;name
+        seq_no="4" role="researcher_id" orcid_id="0000-0002-3019-0170">&lt;display_name>Mordwinkin,
+        Nicholas&lt;/display_name>&lt;full_name>Mordwinkin, Nicholas&lt;/full_name>&lt;first_name>Nicholas&lt;/first_name>&lt;last_name>Mordwinkin&lt;/last_name>&lt;/name>&lt;/contributor>&lt;/contributors>&lt;/static_data>&lt;dynamic_data>&lt;citation_related>&lt;tc_list>&lt;silo_tc
+        coll_id="MEDLINE" local_count="0">&lt;/silo_tc>&lt;/tc_list>&lt;/citation_related>&lt;cluster_related>&lt;identifiers>&lt;identifier
+        type="doi" value="10.1038/nmeth.2999">&lt;/identifier>&lt;identifier type="eissn"
+        value="1548-7105">&lt;/identifier>&lt;identifier type="pmid" value="MEDLINE:24930130">&lt;/identifier>&lt;/identifiers>&lt;/cluster_related>&lt;/dynamic_data>&lt;/REC>&lt;/records></records></return></ns2:retrieveByIdResponse></soap:Body></soap:Envelope>'
+    http_version: 
+  recorded_at: Thu, 04 Apr 2019 21:48:34 GMT
+recorded_with: VCR 4.0.0

--- a/fixtures/vcr_cassettes/Pubmed_Fetcher/_fetch_remote_pubmed/WOS_enabled/still_searches_pubmed_first_by_default.yml
+++ b/fixtures/vcr_cassettes/Pubmed_Fetcher/_fetch_remote_pubmed/WOS_enabled/still_searches_pubmed_first_by_default.yml
@@ -1,0 +1,657 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=Settings.PUBMED.API_KEY&db=pubmed&retmode=xml
+    body:
+      encoding: UTF-8
+      string: "&id=24930130"
+    headers:
+      User-Agent:
+      - stanford-library-sul-pub
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 04 Apr 2019 21:45:31 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Apr 2019 21:45:31 GMT
+      Server:
+      - Finatra
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Ratelimit-Remaining:
+      - '9'
+      Ncbi-Phid:
+      - 939B43EE8516427500002804753FCFD0.1.1.m_3
+      Cache-Control:
+      - private
+      L5d-Success-Class:
+      - '1.0'
+      Ncbi-Sid:
+      - B31D59A64B6037C5_8E6FSID
+      Content-Encoding:
+      - gzip
+      X-Ratelimit-Limit:
+      - '10'
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Set-Cookie:
+      - ncbi_sid=B31D59A64B6037C5_8E6FSID; domain=.nih.gov; path=/; expires=Sat, 04
+        Apr 2020 21:45:32 GMT
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" ?>
+        <!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2019//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_190101.dtd">
+        <PubmedArticleSet>
+        <PubmedArticle>
+            <MedlineCitation Status="MEDLINE" Owner="NLM">
+                <PMID Version="1">24930130</PMID>
+                <DateCompleted>
+                    <Year>2014</Year>
+                    <Month>09</Month>
+                    <Day>29</Day>
+                </DateCompleted>
+                <DateRevised>
+                    <Year>2018</Year>
+                    <Month>12</Month>
+                    <Day>18</Day>
+                </DateRevised>
+                <Article PubModel="Print-Electronic">
+                    <Journal>
+                        <ISSN IssnType="Electronic">1548-7105</ISSN>
+                        <JournalIssue CitedMedium="Internet">
+                            <Volume>11</Volume>
+                            <Issue>8</Issue>
+                            <PubDate>
+                                <Year>2014</Year>
+                                <Month>Aug</Month>
+                            </PubDate>
+                        </JournalIssue>
+                        <Title>Nature methods</Title>
+                        <ISOAbbreviation>Nat. Methods</ISOAbbreviation>
+                    </Journal>
+                    <ArticleTitle>Chemically defined generation of human cardiomyocytes.</ArticleTitle>
+                    <Pagination>
+                        <MedlinePgn>855-60</MedlinePgn>
+                    </Pagination>
+                    <ELocationID EIdType="doi" ValidYN="Y">10.1038/nmeth.2999</ELocationID>
+                    <Abstract>
+                        <AbstractText>Existing methods for human induced pluripotent stem cell (hiPSC) cardiac differentiation are efficient but require complex, undefined medium constituents that hinder further elucidation of the molecular mechanisms of cardiomyogenesis. Using hiPSCs derived under chemically defined conditions on synthetic matrices, we systematically developed an optimized cardiac differentiation strategy, using a chemically defined medium consisting of just three components: the basal medium RPMI 1640, L-ascorbic acid 2-phosphate and rice-derived recombinant human albumin. Along with small molecule-based induction of differentiation, this protocol produced contractile sheets of up to 95% TNNT2(+) cardiomyocytes at a yield of up to 100 cardiomyocytes for every input pluripotent cell and was effective in 11 hiPSC lines tested. This chemically defined platform for cardiac specification of hiPSCs will allow the elucidation of cardiomyocyte macromolecular and metabolic requirements and will provide a minimal system for the study of maturation and subtype specification. </AbstractText>
+                    </Abstract>
+                    <AuthorList CompleteYN="Y">
+                        <Author ValidYN="Y">
+                            <LastName>Burridge</LastName>
+                            <ForeName>Paul W</ForeName>
+                            <Initials>PW</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Matsa</LastName>
+                            <ForeName>Elena</ForeName>
+                            <Initials>E</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Shukla</LastName>
+                            <ForeName>Praveen</ForeName>
+                            <Initials>P</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Lin</LastName>
+                            <ForeName>Ziliang C</ForeName>
+                            <Initials>ZC</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>Department of Applied Physics, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Churko</LastName>
+                            <ForeName>Jared M</ForeName>
+                            <Initials>JM</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Ebert</LastName>
+                            <ForeName>Antje D</ForeName>
+                            <Initials>AD</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Lan</LastName>
+                            <ForeName>Feng</ForeName>
+                            <Initials>F</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Diecke</LastName>
+                            <ForeName>Sebastian</ForeName>
+                            <Initials>S</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Huber</LastName>
+                            <ForeName>Bruno</ForeName>
+                            <Initials>B</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Mordwinkin</LastName>
+                            <ForeName>Nicholas M</ForeName>
+                            <Initials>NM</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Plews</LastName>
+                            <ForeName>Jordan R</ForeName>
+                            <Initials>JR</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Abilez</LastName>
+                            <ForeName>Oscar J</ForeName>
+                            <Initials>OJ</Initials>
+                            <Identifier Source="ORCID">000000029991400X</Identifier>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Cui</LastName>
+                            <ForeName>Bianxiao</ForeName>
+                            <Initials>B</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>Department of Chemistry, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Gold</LastName>
+                            <ForeName>Joseph D</ForeName>
+                            <Initials>JD</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                        <Author ValidYN="Y">
+                            <LastName>Wu</LastName>
+                            <ForeName>Joseph C</ForeName>
+                            <Initials>JC</Initials>
+                            <AffiliationInfo>
+                                <Affiliation>1] Stanford Cardiovascular Institute, Stanford University School of Medicine, Stanford, California, USA. [2] Institute for Stem Cell Biology and Regenerative Medicine, Stanford University School of Medicine, Stanford, California, USA. [3] Department of Medicine, Division of Cardiology, Stanford University School of Medicine, Stanford, California, USA.</Affiliation>
+                            </AffiliationInfo>
+                        </Author>
+                    </AuthorList>
+                    <Language>eng</Language>
+                    <GrantList CompleteYN="Y">
+                        <Grant>
+                            <GrantID>R01 HL113006</GrantID>
+                            <Acronym>HL</Acronym>
+                            <Agency>NHLBI NIH HHS</Agency>
+                            <Country>United States</Country>
+                        </Grant>
+                        <Grant>
+                            <GrantID>T32 EB009035</GrantID>
+                            <Acronym>EB</Acronym>
+                            <Agency>NIBIB NIH HHS</Agency>
+                            <Country>United States</Country>
+                        </Grant>
+                        <Grant>
+                            <GrantID>U01 HL099776</GrantID>
+                            <Acronym>HL</Acronym>
+                            <Agency>NHLBI NIH HHS</Agency>
+                            <Country>United States</Country>
+                        </Grant>
+                        <Grant>
+                            <GrantID>R24 HL117756</GrantID>
+                            <Acronym>HL</Acronym>
+                            <Agency>NHLBI NIH HHS</Agency>
+                            <Country>United States</Country>
+                        </Grant>
+                        <Grant>
+                            <GrantID>T32 HL098049</GrantID>
+                            <Acronym>HL</Acronym>
+                            <Agency>NHLBI NIH HHS</Agency>
+                            <Country>United States</Country>
+                        </Grant>
+                        <Grant>
+                            <GrantID>K99 HL121177</GrantID>
+                            <Acronym>HL</Acronym>
+                            <Agency>NHLBI NIH HHS</Agency>
+                            <Country>United States</Country>
+                        </Grant>
+                        <Grant>
+                            <GrantID>R00 HL121177</GrantID>
+                            <Acronym>HL</Acronym>
+                            <Agency>NHLBI NIH HHS</Agency>
+                            <Country>United States</Country>
+                        </Grant>
+                    </GrantList>
+                    <PublicationTypeList>
+                        <PublicationType UI="D016428">Journal Article</PublicationType>
+                        <PublicationType UI="D052061">Research Support, N.I.H., Extramural</PublicationType>
+                        <PublicationType UI="D013485">Research Support, Non-U.S. Gov't</PublicationType>
+                    </PublicationTypeList>
+                    <ArticleDate DateType="Electronic">
+                        <Year>2014</Year>
+                        <Month>06</Month>
+                        <Day>15</Day>
+                    </ArticleDate>
+                </Article>
+                <MedlineJournalInfo>
+                    <Country>United States</Country>
+                    <MedlineTA>Nat Methods</MedlineTA>
+                    <NlmUniqueID>101215604</NlmUniqueID>
+                    <ISSNLinking>1548-7091</ISSNLinking>
+                </MedlineJournalInfo>
+                <ChemicalList>
+                    <Chemical>
+                        <RegistryNumber>0</RegistryNumber>
+                        <NameOfSubstance UI="D003470">Culture Media</NameOfSubstance>
+                    </Chemical>
+                </ChemicalList>
+                <CitationSubset>IM</CitationSubset>
+                <MeshHeadingList>
+                    <MeshHeading>
+                        <DescriptorName UI="D002454" MajorTopicYN="N">Cell Differentiation</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D003470" MajorTopicYN="N">Culture Media</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D057026" MajorTopicYN="N">Induced Pluripotent Stem Cells</DescriptorName>
+                        <QualifierName UI="Q000166" MajorTopicYN="N">cytology</QualifierName>
+                    </MeshHeading>
+                    <MeshHeading>
+                        <DescriptorName UI="D032383" MajorTopicYN="N">Myocytes, Cardiac</DescriptorName>
+                        <QualifierName UI="Q000166" MajorTopicYN="Y">cytology</QualifierName>
+                    </MeshHeading>
+                </MeshHeadingList>
+            </MedlineCitation>
+            <PubmedData>
+                <History>
+                    <PubMedPubDate PubStatus="received">
+                        <Year>2013</Year>
+                        <Month>10</Month>
+                        <Day>15</Day>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="accepted">
+                        <Year>2014</Year>
+                        <Month>05</Month>
+                        <Day>06</Day>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="entrez">
+                        <Year>2014</Year>
+                        <Month>6</Month>
+                        <Day>16</Day>
+                        <Hour>6</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="pubmed">
+                        <Year>2014</Year>
+                        <Month>6</Month>
+                        <Day>16</Day>
+                        <Hour>6</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="medline">
+                        <Year>2014</Year>
+                        <Month>9</Month>
+                        <Day>30</Day>
+                        <Hour>6</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                </History>
+                <PublicationStatus>ppublish</PublicationStatus>
+                <ArticleIdList>
+                    <ArticleId IdType="pubmed">24930130</ArticleId>
+                    <ArticleId IdType="pii">nmeth.2999</ArticleId>
+                    <ArticleId IdType="doi">10.1038/nmeth.2999</ArticleId>
+                    <ArticleId IdType="pmc">PMC4169698</ArticleId>
+                    <ArticleId IdType="mid">NIHMS599769</ArticleId>
+                </ArticleIdList>
+                <ReferenceList>
+                    <Reference>
+                        <Citation>Nature. 2013 Aug 8;500(7461):222-6</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">23812591</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Cell Res. 2011 Mar;21(3):518-29</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">21243013</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Cell Stem Cell. 2012 Jan 6;10(1):16-28</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">22226352</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Cell Stem Cell. 2011 Feb 4;8(2):228-40</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">21295278</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Protoc. 2008;3(5):768-76</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">18451785</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>BMC Dev Biol. 2010;10:60</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">20525219</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Methods. 2011 May;8(5):409-12</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">21460823</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Biotechnol. 2007 Sep;25(9):1015-24</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">17721512</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>PLoS One. 2011;6(8):e23657</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">21876760</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Cytotechnology. 2010 Jan;62(1):1-16</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">20373019</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Tissue Eng Part C Methods. 2011 Feb;17(2):193-207</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">20726687</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nature. 2008 May 22;453(7194):524-8</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">18432194</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Cell Stem Cell. 2013 Jan 3;12(1):127-37</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">23168164</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Science. 1998 Nov 6;282(5391):1145-7</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">9804556</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>PLoS One. 2011;6(4):e18293</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">21494607</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Cell Res. 2011 Apr;21(4):579-87</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">21102549</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>JAMA. 1967 Feb 20;199(8):519-24</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">4960081</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Cell Rep. 2012 Nov 29;2(5):1448-60</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">23103164</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Stem Cells. 2007 Apr;25(4):929-38</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">17185609</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Dev Dyn. 2006 Jul;235(7):1994-2002</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">16649168</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Cell Stem Cell. 2012 Aug 3;11(2):242-52</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">22862949</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>J Biol Chem. 1981 Jan 25;256(2):964-8</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">7451483</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>PLoS One. 2012;7(12):e52405</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">23300662</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>PLoS One. 2010;5(6):e11134</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">20559569</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Am J Physiol Cell Physiol. 2010 Dec;299(6):C1234-49</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">20844252</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Biotechnol. 2010 Jun;28(6):606-10</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">20512120</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Proc Jpn Acad Ser B Phys Biol Sci. 2009;85(8):348-62</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">19838014</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Stem Cells Dev. 2012 Apr 10;21(6):977-86</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">22182484</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Brain Res. 1989 Aug 7;494(1):65-74</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">2765923</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Stem Cells. 2010 Apr;28(4):713-20</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">20201064</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Cardiovasc Res. 2003 May 1;58(2):423-34</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">12757876</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Differentiation. 2008 Apr;76(4):357-70</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">18021257</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Commun. 2012;3:1236</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">23212365</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>J Mol Histol. 2004 Jun;35(5):463-70</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">15571324</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Cell Res. 2012 Jan;22(1):219-36</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">22143566</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nature. 2011 May 19;473(7347):326-35</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">21593865</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Stem Cells. 2008 Sep;26(9):2257-65</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">18599809</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Annu Rev Cell Dev Biol. 2012;28:523-53</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">23057746</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Methods. 2011 May;8(5):424-9</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">21478862</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Proc Natl Acad Sci U S A. 2012 Jul 3;109(27):E1848-57</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">22645348</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Circulation. 2003 Apr 15;107(14):1912-6</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">12668514</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Commun. 2014;5:3195</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">24463987</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Methods. 2011 Dec;8(12):1037-40</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">22020065</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Can J Physiol Pharmacol. 2006 Aug-Sep;84(8-9):935-41</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">17111039</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Circ Res. 2012 Oct 12;111(9):1125-36</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">22912385</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Nanotechnol. 2012 Mar;7(3):185-90</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">22327876</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Commun. 2014;5:3206</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">24487777</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Nat Biotechnol. 2010 Jun;28(6):611-5</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">20512123</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                    <Reference>
+                        <Citation>Stem Cells Dev. 2013 Aug 15;22(16):2315-25</Citation>
+                        <ArticleIdList>
+                            <ArticleId IdType="pubmed">23517131</ArticleId>
+                        </ArticleIdList>
+                    </Reference>
+                </ReferenceList>
+            </PubmedData>
+        </PubmedArticle>
+
+        </PubmedArticleSet>
+    http_version: 
+  recorded_at: Thu, 04 Apr 2019 21:45:32 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
Seems odd that WoS is the preferred source over Pubmed when searching manually by PMID. This would swap the preferred order, though without specific stakeholder guidance, reluctant to push forward.

Would be good to validate this approach with the Profiles team.  Perhaps we want WoS first since most publications are WoS in the database?  Still seems odd.