### PR TITLE
log all_sources harvesting into own log file

### DIFF
--- a/app/jobs/author_harvest_job.rb
+++ b/app/jobs/author_harvest_job.rb
@@ -9,7 +9,7 @@ class AuthorHarvestJob < ActiveJob::Base
     author = Author.find_by(cap_profile_id: cap_profile_id)
     author ||= Author.fetch_from_cap_and_create(cap_profile_id)
     raise "Could not find or fetch author: #{cap_profile_id}" unless author.is_a?(Author)
-    AllSources::Harvester.new.process_author(author)
+    AllSources.harvester.process_author(author)
     log_pubs(author)
   rescue => e
     msg = "AuthorHarvestJob.perform(#{cap_profile_id})"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -68,6 +68,7 @@ DOI:
   BASE_URI: https://doi.org/
 
 HARVESTER:
+  LOG: log/all_sources_harvester.log
   USE_MIDDLE_NAME: true
   USE_FIRST_INITIAL: false
   USE_AUTHOR_IDENTITIES: false

--- a/lib/all_sources.rb
+++ b/lib/all_sources.rb
@@ -1,0 +1,16 @@
+# rubocop:disable Style/ClassVars
+
+# All Sources harvesting utilities
+module AllSources
+
+  # @return [AllSources::Harvester]
+  def self.harvester
+    @@harvester ||= AllSources::Harvester.new
+  end
+
+  def self.logger
+    @@logger ||= Logger.new(Settings.HARVESTER.LOG)
+  end
+
+end
+# rubocop:enable Style/ClassVars

--- a/lib/all_sources/harvester.rb
+++ b/lib/all_sources/harvester.rb
@@ -12,5 +12,8 @@ module AllSources
     rescue StandardError => err
       NotificationManager.error(err, "#{self.class} - harvest all sources failed for author #{author.id}", self)
     end
+
+    delegate :logger, to: :AllSources
+
   end
 end

--- a/lib/cap/authors_poller.rb
+++ b/lib/cap/authors_poller.rb
@@ -58,10 +58,10 @@ module Cap
         relDate: Settings.PUBMED.update_timeframe
       }
       Author.where(id: @new_authors_to_harvest_queue).find_in_batches(batch_size: 250) do |authors|
-        AllSources::Harvester.new.harvest(authors, new_author_options)
+        AllSources.harvester.harvest(authors, new_author_options)
       end
       Author.where(id: @changed_authors_to_harvest_queue).find_in_batches(batch_size: 250) do |authors|
-        AllSources::Harvester.new.harvest(authors, update_author_options)
+        AllSources.harvester.harvest(authors, update_author_options)
       end
     end
 

--- a/lib/harvester/base.rb
+++ b/lib/harvester/base.rb
@@ -62,5 +62,15 @@ module Harvester
       def logger
         @logger ||= Rails.logger
       end
+
+      # Consistent log prefix for status updates
+      # @param author [Author]
+      # @param [String] message
+      # @return [void]
+      def log_info(author, message)
+        prefix = self.class.to_s
+        prefix += " - author #{author.id}" if author.is_a?(Author)
+        logger.info "#{prefix} - #{message}"
+      end
   end
 end

--- a/lib/pubmed/harvester.rb
+++ b/lib/pubmed/harvester.rb
@@ -54,16 +54,6 @@ module Pubmed
         matched
       end
 
-      # Consistent log prefix for status updates
-      # @param author [Author]
-      # @param [String] message
-      # @return [void]
-      def log_info(author, message)
-        prefix = self.class.to_s
-        prefix += " - author #{author.id}" if author.is_a?(Author)
-        logger.info "#{prefix} - #{message}"
-      end
-
       # Process a pubmed records
       # @param author [Author]
       # @param pmid [String]

--- a/lib/tasks/harvest.rake
+++ b/lib/tasks/harvest.rake
@@ -1,7 +1,7 @@
 namespace :harvest do
   desc 'Harvest from all sources, for all authors, for all time'
   task all_authors: :environment do
-    AllSources::Harvester.new.harvest_all
+    AllSources.harvester.harvest_all
   end
 
   desc 'Update harvest from all sources, for all authors, using default update timeframes'
@@ -10,14 +10,14 @@ namespace :harvest do
       symbolicTimeSpan: Settings.WOS.regular_harvest_timeframe,
       relDate: Settings.PUBMED.regular_harvest_timeframe
     }
-    AllSources::Harvester.new.harvest_all(options)
+    AllSources.harvester.harvest_all(options)
   end
 
   desc 'Harvest from all sources for single author, for all time'
   task :author, [:cap_profile_id] => :environment do |_t, args|
     author = Author.find_by(cap_profile_id: args[:cap_profile_id])
     raise "Could not find Author by cap_profile_id: #{args[:cap_profile_id]}." if author.nil?
-    AllSources::Harvester.new.process_author(author)
+    AllSources.harvester.process_author(author)
   end
 
   desc 'Harvest from all sources for single author, using default update timeframes'
@@ -28,6 +28,6 @@ namespace :harvest do
       symbolicTimeSpan: Settings.WOS.regular_harvest_timeframe,
       relDate: Settings.PUBMED.regular_harvest_timeframe
     }
-    AllSources::Harvester.new.process_author(author, options)
+    AllSources.harvester.process_author(author, options)
   end
 end

--- a/lib/web_of_science/harvester.rb
+++ b/lib/web_of_science/harvester.rb
@@ -61,16 +61,6 @@ module WebOfScience
         end
       end
 
-      # Consistent log prefix for status updates
-      # @param author [Author]
-      # @param [String] message
-      # @return [void]
-      def log_info(author, message)
-        prefix = self.class.to_s
-        prefix += " - author #{author.id}" if author.is_a?(Author)
-        logger.info "#{prefix} - #{message}"
-      end
-
       # Process records retrieved by any means
       # @param author [Author]
       # @param retriever [WebOfScience::Retriever]


### PR DESCRIPTION
otherwise all sources info gets logged into default rails logger which is very noisy

also, this makes the all_sources harvester analogous to the WoS and Pubmed harvester in the way it is called.

also move log_info method to the base harvester class to avoid duplication