### PR TITLE
fix issue with our content-type response being incorrect

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  protect_from_forgery
+  protect_from_forgery # skipped in API only controllers (which happens to be all as of April 2019)
 
   def check_authorization
     return head :unauthorized if request.env['HTTP_CAPKEY'].nil?

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -1,6 +1,7 @@
 class AuthorsController < ApplicationController
   before_action :check_authorization
   before_action :ensure_json_request
+  skip_forgery_protection # this controller only has API calls from profiles
 
   # request an immediate harvest of this user's profile
   # POST /authors/:cap_profile_id/harvest.json

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -4,6 +4,7 @@ class PublicationsController < ApplicationController
   before_action :check_authorization
   before_action :ensure_json_request, except: [:index]
   before_action :ensure_request_body_exists, only: [:create, :update]
+  skip_forgery_protection # this controller only has API calls from profiles
 
   # Retreive publications for a specific profile ID, optionally in a given time period
   # GET /publications.json                                        # all publications


### PR DESCRIPTION
- two API calls convereted from grape to rails were incorrectly responding with content-type:text/plain instead of application/json causing a production issue with profiles
- don't need to protect from forgery for API only controllers (causing warnings in logs)