### PR TITLE
saving the pub should come outside the find_or_create_by block

### DIFF
--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -171,9 +171,9 @@ class Author < ActiveRecord::Base
         cap_profile_id: cap_profile_id,
         featured: false, status: 'new', visibility: 'private'
       )
-      pub.pubhash_needs_update! # Add to pub_hash[:authorship]
-      pub.save! # contrib.save! not needed
     end
+    pub.pubhash_needs_update! # Add to pub_hash[:authorship]
+    pub.save! # contrib.save! not needed
   end
 
   private

--- a/spec/factories/publication.rb
+++ b/spec/factories/publication.rb
@@ -52,4 +52,16 @@ FactoryBot.define do
              identifier_value: '10048354')
     end
   end
+
+  factory :publication_without_author, parent: :publication do
+    pub_hash do
+      {
+        title: title,
+        type: publication_type,
+        year: year,
+        author: [],
+        authorship: []
+      }
+    end
+  end
 end

--- a/spec/models/author_spec.rb
+++ b/spec/models/author_spec.rb
@@ -177,4 +177,22 @@ describe Author do
       expect(subject).not_to be_harvestable
     end
   end
+
+  describe '#assign_pub' do
+    let(:pub) { create :publication_without_author }
+
+    it 'creates contrib and updates pubhash' do
+      expect(subject.publications.count).to eq(0)
+      expect(subject.contributions.count).to eq(0)
+      expect(Publication.find(pub.id).pub_hash[:authorship].length).to eq(0)
+
+      subject.assign_pub(pub)
+      expect(subject.publications.count).to eq(1)
+      expect(subject.contributions.count).to eq(1)
+
+      # Verify that author added to publication
+      # See https://github.com/sul-dlss/sul_pub/issues/1052
+      expect(Publication.find(pub.id).pub_hash[:authorship].length).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
fixes #1052 

When creating new publications, the `Author#assign_pub` method doesn't correctly update the pub_hash due to the save calls being inside the `find_or_create_by` contribution block.  I have confirmed this on my laptop manually by testing the Pubmed harvesting code with the change in this PR (it creates the authorship block in the pub_hash correctly) and without this change (it fails to add authorship just like in prod).

This isn't a problem with WoS harvesting since the creation of new publications occurs in a different point in the code and doesn't rely on the `Author#assign_pub` method:
https://github.com/sul-dlss/sul_pub/blob/master/lib/web_of_science/process_records.rb#L93-L108

- [ ] need a test for this?