### PR TITLE
do not throw an exception when attempting to assign a blank publication

### DIFF
--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -165,6 +165,10 @@ class Author < ActiveRecord::Base
   # @param [Publication]
   # @return [Contribution]
   def assign_pub(pub)
+    unless pub # do not attempt to assign if no pub provided
+        logger.warn "nil publication assignment for author id #{id}"
+        return
+    end
     raise 'Author must be saved before association' unless persisted?
     pub.contributions.find_or_create_by!(author_id: id) do |contrib|
       contrib.assign_attributes(

--- a/spec/models/author_spec.rb
+++ b/spec/models/author_spec.rb
@@ -194,5 +194,15 @@ describe Author do
       # See https://github.com/sul-dlss/sul_pub/issues/1052
       expect(Publication.find(pub.id).pub_hash[:authorship].length).to eq(1)
     end
+
+    it 'does not attempt to assign a blank publication and does not throw an exception' do
+      expect(subject.publications.count).to eq(0)
+      expect(subject.contributions.count).to eq(0)
+
+      subject.assign_pub(nil)
+
+      expect(subject.publications.count).to eq(0)
+      expect(subject.contributions.count).to eq(0)
+    end
   end
 end


### PR DESCRIPTION
When a PMID returned from our harvesting does not actually return a valid publication when we query on that ID (possibly bad data from pubmed), we don't need to throw an exception, but should instead continue with processing that author's publications.

fixes #1054 

