### PR TITLE
cleanup task to remove pubs and contribs harvested after a date

### DIFF
--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -27,10 +27,10 @@ class Publication < ActiveRecord::Base
     self.wos_uid ||= web_of_science_source_record.uid if web_of_science_source_record.present?
   end
 
-  has_one :batch_uploaded_source_record
-  has_one :web_of_science_source_record, autosave: true
+  has_one :batch_uploaded_source_record, dependent: :destroy
+  has_one :web_of_science_source_record, dependent: :destroy, autosave: true
 
-  has_many :user_submitted_source_records
+  has_many :user_submitted_source_records, dependent: :destroy
 
   has_many :publication_identifiers,
     autosave: true,


### PR DESCRIPTION
- proposed cleanup task for bad harvest (run per author)
- log the pub ids we deleted so we can provide to profiles team
- destroy dependent models when we delete a publication (which is very rare and only happens in remediations like this, but if we don't destroy the associated WebOfScienceSourceRecord for example, mysql will throw a unique key constraint violation)

see https://github.com/sul-dlss/sul_pub/issues/1057#issuecomment-492480310 for logic 