### PR TITLE
pubmed harvest disable option; tweak to search by pmid in pub model first

### DIFF
--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -67,9 +67,10 @@ class Publication < ActiveRecord::Base
   end
 
   def self.find_by_pmid_pub_id(pmid)
-    Publication.includes(:publication_identifiers)
-               .where("publication_identifiers.identifier_type": 'pmid', "publication_identifiers.identifier_value": pmid)
-               .find_by('wos_uid IS NOT null OR sciencewire_id IS NOT NULL OR pmid IS NOT null')
+    find_by_pmid(pmid) ||
+      Publication.includes(:publication_identifiers)
+                 .where("publication_identifiers.identifier_type": 'pmid', "publication_identifiers.identifier_value": pmid)
+                 .find_by('wos_uid IS NOT null OR sciencewire_id IS NOT NULL OR pmid IS NOT null')
   end
 
   # Queries publication_identifiers (like the poorly-named find_by_xxx methods above)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -29,6 +29,7 @@ CAP:
 ## PubMed Auth Config
 PUBMED:
   LOG: log/pubmed.log
+  harvest_enabled: true # this only enables/disables regular harvests, it will still allow manual entries via pubmed and record augmentation
   FETCH_PATH: /entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml
   SEARCH_PATH: /entrez/eutils/esearch.fcgi?db=pubmed&retmode=xml&retmax=100000
   API_KEY: a_fake_pubmed_key
@@ -41,7 +42,6 @@ PUBMED:
 
 ## Sciencewire Auth Config
 SCIENCEWIRE:
-  enabled: false
   LOG: log/sciencewire.log
   BASE_URI: https://sciencewirerest.discoverylogic.com
   HOST: stg.sciencewirerest.discoverylogic.com
@@ -51,7 +51,7 @@ SCIENCEWIRE:
 
 ## Web Of Science Auth Config
 WOS:
-  enabled: true
+  enabled: true # this enables/disables the entire client (harvesting and record fetching)
   ACCEPTED_DBS:
     - WOS
     - MEDLINE

--- a/lib/all_sources/harvester.rb
+++ b/lib/all_sources/harvester.rb
@@ -8,7 +8,7 @@ module AllSources
     def process_author(author, options = {})
       raise(ArgumentError, 'author must be an Author') unless author.is_a? Author
       WebOfScience.harvester.process_author(author, options) if Settings.WOS.enabled
-      Pubmed.harvester.process_author(author, options)
+      Pubmed.harvester.process_author(author, options) if Settings.PUBMED.harvest_enabled
     rescue StandardError => err
       NotificationManager.error(err, "#{self.class} - harvest all sources failed for author #{author.id}", self)
     end

--- a/lib/pubmed/harvester.rb
+++ b/lib/pubmed/harvester.rb
@@ -9,6 +9,7 @@ module Pubmed
     # @param [Hash] _options
     # @return [Array<String>] pmids that create Publications
     def process_author(author, options = {})
+      return unless Settings.PUBMED.harvest_enabled
       raise(ArgumentError, 'author must be an Author') unless author.is_a? Author
       log_info(author, "processing author #{author.id}")
       pmids = process_pmids(author, Pubmed::QueryAuthor.new(author, options).pmids)

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -101,6 +101,8 @@ namespace :cleanup do
     start_date = Time.parse(start_timeframe) # start date to go back to look for new contributions (when we started WoS harvesting)
     end_date = Time.parse(end_timeframe) # end date to go back to look for new contributions (when we stopped harvesting with first initial)
 
+    pub_ids_worked_on_dump_file = "log/pubids_for_#{cap_profile_id}_#{provenance}.dump"
+
     contributions = author.contributions.where('status = ? and visibility = ? and created_at > ? and created_at < ?', 'new', 'private', start_date, end_date)
 
     total = contributions.size
@@ -124,6 +126,7 @@ namespace :cleanup do
         contribution.destroy
       end
 
+      File.open(pub_ids_worked_on_dump_file, 'w') { |f| f.write(YAML.dump(pub_ids)) }
       total_pub_ids = pub_ids.count
       puts 'updating publications...'
       # either rebuild the publications that were removed from the profile, or delete them if they have no contributions left

--- a/spec/jobs/author_harvest_job_spec.rb
+++ b/spec/jobs/author_harvest_job_spec.rb
@@ -26,6 +26,7 @@ describe AuthorHarvestJob, type: :job do
   context 'WebOfScience is disabled' do
     it 'executes perform without calling WoS but still calls Pubmed' do
       allow(Settings.WOS).to receive(:enabled).and_return(false)
+      allow(Settings.PUBMED).to receive(:harvest_enabled).and_return(true)
       expect(WebOfScience.harvester).not_to receive(:process_author).with(author, {})
       expect(Pubmed.harvester).to receive(:process_author).with(author, {})
       perform_enqueued_jobs { job }
@@ -35,8 +36,19 @@ describe AuthorHarvestJob, type: :job do
   context 'WebOfScience is enabled' do
     it 'executes perform calling WoS and Pubmed' do
       allow(Settings.WOS).to receive(:enabled).and_return(true)
+      allow(Settings.PUBMED).to receive(:harvest_enabled).and_return(true)
       expect(WebOfScience.harvester).to receive(:process_author).with(author, {})
       expect(Pubmed.harvester).to receive(:process_author).with(author, {})
+      perform_enqueued_jobs { job }
+    end
+  end
+
+  context 'Pubmed is disabled' do
+    it 'executes perform calling only WoS' do
+      allow(Settings.WOS).to receive(:enabled).and_return(true)
+      allow(Settings.PUBMED).to receive(:harvest_enabled).and_return(false)
+      expect(WebOfScience.harvester).to receive(:process_author).with(author, {})
+      expect(Pubmed.harvester).not_to receive(:process_author).with(author, {})
       perform_enqueued_jobs { job }
     end
   end

--- a/spec/lib/all_sources/harvester_spec.rb
+++ b/spec/lib/all_sources/harvester_spec.rb
@@ -5,9 +5,10 @@ describe AllSources::Harvester do
     let(:options) { { some_options: 'here' } }
     let(:author) { create :author }
 
-    context 'wos enabled' do
+    context 'wos and pubmed enabled' do
       it 'calls both pubmed and wos harvester for the author' do
         allow(Settings.WOS).to receive(:enabled).and_return(true)
+        allow(Settings.PUBMED).to receive(:harvest_enabled).and_return(true)
         expect(WebOfScience.harvester).to receive(:process_author).with(author, options)
         expect(Pubmed.harvester).to receive(:process_author).with(author, options)
         harvester.process_author(author, options)
@@ -17,8 +18,19 @@ describe AllSources::Harvester do
     context 'wos disabled' do
       it 'calls only the pubmed harvester for the author' do
         allow(Settings.WOS).to receive(:enabled).and_return(false)
+        allow(Settings.PUBMED).to receive(:harvest_enabled).and_return(true)
         expect(WebOfScience.harvester).not_to receive(:process_author).with(author, options)
         expect(Pubmed.harvester).to receive(:process_author).with(author, options)
+        harvester.process_author(author, options)
+      end
+    end
+
+    context 'pubmed disabled' do
+      it 'calls only the wos harvester for the author' do
+        allow(Settings.WOS).to receive(:enabled).and_return(true)
+        allow(Settings.PUBMED).to receive(:harvest_enabled).and_return(false)
+        expect(WebOfScience.harvester).to receive(:process_author).with(author, options)
+        expect(Pubmed.harvester).not_to receive(:process_author).with(author, options)
         harvester.process_author(author, options)
       end
     end

--- a/spec/lib/cap/authors_poller_spec.rb
+++ b/spec/lib/cap/authors_poller_spec.rb
@@ -249,13 +249,23 @@ describe Cap::AuthorsPoller, :vcr do
 
     it 'does not harvest from WoS if WoS client is disabled, but still harvests from Pubmed' do
       allow(Settings.WOS).to receive(:enabled).and_return(false)
+      allow(Settings.PUBMED).to receive(:harvest_enabled).and_return(true)
       expect(WebOfScience.harvester).not_to receive(:process_author)
       expect(Pubmed.harvester).to receive(:process_author).twice
       subject.do_harvest
     end
 
+    it 'does not harvest from Pubmed if Pubmed is disabled, but still harvests from WoS' do
+      allow(Settings.WOS).to receive(:enabled).and_return(true)
+      allow(Settings.PUBMED).to receive(:harvest_enabled).and_return(false)
+      expect(WebOfScience.harvester).to receive(:process_author).twice
+      expect(Pubmed.harvester).not_to receive(:process_author)
+      subject.do_harvest
+    end
+
     it 'adds separate timeframes for harvests for new and updated authors' do
       allow(Settings.WOS).to receive(:enabled).and_return(true)
+      allow(Settings.PUBMED).to receive(:harvest_enabled).and_return(true)
       expect(WebOfScience.harvester).to receive(:process_author).with(author, new_author_options)
       expect(WebOfScience.harvester).to receive(:process_author).with(other_author, update_author_options)
       expect(Pubmed.harvester).to receive(:process_author).with(author, new_author_options)


### PR DESCRIPTION
- allow Pubmed harvesting to be disabled with a setting flag (default to true, override in specific environment as needed)
- when searching for existing pubmed pubs via pmid, search pmid column in publication model directly first to improve performance and ensure we find pubs that may not have the associated publication_identifiers values (legacy pubs)
- small tweak to remediation task to store pmids we are processing before starting to delete them in case something timesout in the middle and crashes
- remove now unused sciencewire enabled flag

If accepted and deployed, we should temporarily override the new `PUBMED.harvest_enabled` option and set to `false` in both -prod and -stage settings.yml on https://github.com/sul-dlss/shared_configs until we can find why pubmed harvests produced so many new publications
