### PR TITLE
set page size of cap API to reflect reality

### DIFF
--- a/lib/cap/authors_poller.rb
+++ b/lib/cap/authors_poller.rb
@@ -18,7 +18,7 @@ module Cap
       @new_authors_to_harvest_queue = []
       @changed_authors_to_harvest_queue = []
       page_count = 0
-      page_size = 1000
+      page_size = 100 # 100 seems to be the maximum page size supported by the CAP API
       @total_records = cap_authors_count(days_ago)
       logger.info "#{@total_records} authors to process"
       loop do


### PR DESCRIPTION
i noticed the CAP API doesn't return more than 100 records per page, so setting the number bigger has no effect...may as well reflect reality in our code