### PR TITLE
do not save publications if not needed when assigning a publication

### DIFF
--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -170,14 +170,17 @@ class Author < ActiveRecord::Base
         return
     end
     raise 'Author must be saved before association' unless persisted?
-    pub.contributions.find_or_create_by!(author_id: id) do |contrib|
+
+    contribution = pub.contributions.find_or_initialize_by(author_id: id) do |contrib|
       contrib.assign_attributes(
         cap_profile_id: cap_profile_id,
         featured: false, status: 'new', visibility: 'private'
       )
     end
-    pub.pubhash_needs_update! # Add to pub_hash[:authorship]
-    pub.save! # contrib.save! not needed
+    return true unless contribution.new_record?
+    contribution.save!
+    pub.pubhash_needs_update!
+    pub.save!
   end
 
   private

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -177,10 +177,11 @@ class Author < ActiveRecord::Base
         featured: false, status: 'new', visibility: 'private'
       )
     end
-    return true unless contribution.new_record?
+    return contribution unless contribution.new_record?
     contribution.save!
     pub.pubhash_needs_update!
     pub.save!
+    contribution
   end
 
   private

--- a/spec/models/author_spec.rb
+++ b/spec/models/author_spec.rb
@@ -196,13 +196,14 @@ describe Author do
     end
 
     it 'does not create contrib or save publication when not needed' do
-      # assign a pub
+      # assign a pub, expect the pub to save as it updates
+      expect(pub).to receive(:save!)
       subject.assign_pub(pub)
       expect(subject.contributions.count).to eq(1)
-      # assign it again, pub should not change!
+      # assign the pub again, but this time the pub should not save/change!
+      expect(pub).not_to receive(:save!)
       subject.assign_pub(pub)
       expect(subject.contributions.count).to eq(1)
-      expect(pub).not_to be_changed
     end
 
     it 'does not attempt to assign a blank publication and does not throw an exception' do

--- a/spec/models/author_spec.rb
+++ b/spec/models/author_spec.rb
@@ -195,6 +195,16 @@ describe Author do
       expect(Publication.find(pub.id).pub_hash[:authorship].length).to eq(1)
     end
 
+    it 'does not create contrib or save publication when not needed' do
+      # assign a pub
+      subject.assign_pub(pub)
+      expect(subject.contributions.count).to eq(1)
+      # assign it again, pub should not change!
+      subject.assign_pub(pub)
+      expect(subject.contributions.count).to eq(1)
+      expect(pub).not_to be_changed
+    end
+
     it 'does not attempt to assign a blank publication and does not throw an exception' do
       expect(subject.publications.count).to eq(0)
       expect(subject.contributions.count).to eq(0)


### PR DESCRIPTION
fixes #1071 	