### PR TITLE
there is not always an exception that includes a backtrace

### DIFF
--- a/lib/notification_manager.rb
+++ b/lib/notification_manager.rb
@@ -47,7 +47,7 @@ class NotificationManager
     def log_exception(logger, message, e)
       logger.error message
       logger.error e.inspect
-      logger.error e.backtrace.join("\n") if e.backtrace.present?
+      logger.error e.backtrace.join("\n") if e.respond_to?(:backtrace) && e.backtrace.present?
     end
   end
 end


### PR DESCRIPTION
note in the rails logs that some exceptions were not making it to honeybadger, e.g. when a StandardError was raised, and it doesn't define `backtrace`	