### PR TITLE
require at least one letter in the first name when generating queries

### DIFF
--- a/lib/pubmed/query_author.rb
+++ b/lib/pubmed/query_author.rb
@@ -29,8 +29,8 @@ module Pubmed
 
     def term
       author_identities = [author].concat(author.author_identities.to_a)
-      name_term = author_identities.collect { |identity| "(#{identity.last_name} #{identity.first_name}[Author])" }
-                                   .uniq.join(' OR ')
+      name_term = author_identities.collect { |identity| "(#{identity.last_name} #{identity.first_name}[Author])" if identity.first_name =~ /[a-zA-Z]+/ }
+                                   .compact.uniq.join(' OR ')
       affiliation_term = author_identities.collect { |identity| affiliation_terms(identity.institution) if identity.institution }
                                           .compact.uniq.join(' OR ')
       "(#{name_term}) AND (#{affiliation_term})"

--- a/lib/web_of_science/query_author.rb
+++ b/lib/web_of_science/query_author.rb
@@ -29,12 +29,14 @@ module WebOfScience
 
       def names
         identities.map do |ident|
-          Agent::AuthorName.new(
-            ident.last_name,
-            ident.first_name,
-            Settings.HARVESTER.USE_MIDDLE_NAME ? ident.middle_name : ''
-          ).text_search_terms
-        end.flatten.uniq
+          if ident.first_name =~ /[a-zA-Z]+/
+            Agent::AuthorName.new(
+              ident.last_name,
+              ident.first_name,
+              Settings.HARVESTER.USE_MIDDLE_NAME ? ident.middle_name : ''
+            )
+          end.text_search_terms
+        end.flatten.compact.uniq
       end
 
       def institutions

--- a/spec/lib/pubmed/query_author_spec.rb
+++ b/spec/lib/pubmed/query_author_spec.rb
@@ -117,5 +117,53 @@ describe Pubmed::QueryAuthor do
         expect(query_author.send(:term)).to eq('((Altman Russ[Author]) OR (Altman R[Author])) AND (Stanford University[Affiliation] OR Texas A andM[Affiliation])')
       end
     end
+
+    context 'with a user with just a period for first name' do
+      before do
+        AuthorIdentity.create(
+          author: author,
+          first_name: '.',
+          middle_name: 'B',
+          last_name: 'Altman',
+          institution: 'Texas A &M'
+        )
+      end
+
+      it 'generates the correct term string' do
+        expect(query_author.send(:term)).to eq('((Altman Russ[Author]) OR (Altman R[Author])) AND (Stanford University[Affiliation] OR Texas A andM[Affiliation])')
+      end
+    end
+
+    context 'with a user with no first name' do
+      before do
+        AuthorIdentity.create(
+          author: author,
+          first_name: '',
+          middle_name: 'B',
+          last_name: 'Altman',
+          institution: 'Texas A &M'
+        )
+      end
+
+      it 'generates the correct term string' do
+        expect(query_author.send(:term)).to eq('((Altman Russ[Author]) OR (Altman R[Author])) AND (Stanford University[Affiliation] OR Texas A andM[Affiliation])')
+      end
+    end
+
+    context 'with a nil first name' do
+      before do
+        AuthorIdentity.create(
+          author: author,
+          first_name: nil,
+          middle_name: 'B',
+          last_name: 'Altman',
+          institution: 'Texas A &M'
+        )
+      end
+
+      it 'generates the correct term string' do
+        expect(query_author.send(:term)).to eq('((Altman Russ[Author]) OR (Altman R[Author])) AND (Stanford University[Affiliation] OR Texas A andM[Affiliation])')
+      end
+    end
   end
 end


### PR DESCRIPTION
fixes #1078 	