### PR TITLE
do not remove middle name variants from the query when the user has a middle name entered

### DIFF
--- a/spec/lib/web_of_science/query_author_spec.rb
+++ b/spec/lib/web_of_science/query_author_spec.rb
@@ -124,8 +124,8 @@ describe WebOfScience::QueryAuthor, :vcr do
 
       it 'ignores the bad alternate identity data' do
         expect(author_one_identity.author_identities.first.first_name).to eq '.' # bad first name
-        # we get three name variants out (we would have more if we allowed the bad name variant)
-        expect(described_class.new(author_one_identity).send(:names)).to eq %w[Edler,Alice Edler,Alice,Jim Edler,Alice,J]
+        # we get two name variants out (we would have more if we allowed the bad name variant)
+        expect(described_class.new(author_one_identity).send(:names)).to eq %w[Edler,Alice,Jim Edler,Alice,J]
       end
     end
   end


### PR DESCRIPTION
See #840 for a different approach to query alteration.  They both touch the same code.

Possible option for #1081 	

Rather than blindly remove the middle name variant for all queries, let's only remove if the user really has not entered a middle name.  It should improve results for users with middle names.

Requires some coordination with Profiles team to validate the approach