### PR TITLE
add new deploy targets for Profiles team to test against

### DIFF
--- a/config/deploy/cap-dev-a.rb
+++ b/config/deploy/cap-dev-a.rb
@@ -1,0 +1,11 @@
+# This will become the new CAP-DEV server (currently called `cap-dev`).  It will initially be used by the Profiles
+#   team for testing their Oracle upgrade against.  Later we will remove the `cap-dev` host and deploy target and keep this in its place.
+#   We should then rename it back to `cap-dev` to match what it used to be.
+# Oct 30 2019, P Mangiafico
+server 'sul-pub-cap-dev-a.stanford.edu', user: 'pub', roles: %w(web db harvester_dev app)
+
+Capistrano::OneTimeKey.generate_one_time_key!
+
+set :rails_env, 'production'
+
+set :bundle_without, %w(development test).join(' ')

--- a/config/deploy/cap-dev-a.rb
+++ b/config/deploy/cap-dev-a.rb
@@ -2,7 +2,7 @@
 #   team for testing their Oracle upgrade against.  Later we will remove the `cap-dev` host and deploy target and keep this in its place.
 #   We should then rename it back to `cap-dev` to match what it used to be.
 # Oct 30 2019, P Mangiafico
-server 'sul-pub-cap-dev-a.stanford.edu', user: 'pub', roles: %w(web db harvester_dev app)
+server 'sul-pub-cap-dev-a.stanford.edu', user: 'pub', roles: %w(web db app)
 
 Capistrano::OneTimeKey.generate_one_time_key!
 

--- a/config/deploy/cap-uat.rb
+++ b/config/deploy/cap-uat.rb
@@ -1,7 +1,7 @@
 # This will become the new UAT server (currently called `cap-qa`).  It will initially be used by the Profiles
 #   team for testing their Oracle upgrade against.  Later we will remove the `cap-qa` host and deploy target and keep this in its place.
 # Oct 30 2019, P Mangiafico
-server 'sul-pub-cap-uat.stanford.edu', user: 'pub', roles: %w(web db app harvester_qa external_monitor)
+server 'sul-pub-cap-uat.stanford.edu', user: 'pub', roles: %w(web db app external_monitor)
 
 Capistrano::OneTimeKey.generate_one_time_key!
 

--- a/config/deploy/cap-uat.rb
+++ b/config/deploy/cap-uat.rb
@@ -1,0 +1,12 @@
+# This will become the new UAT server (currently called `cap-qa`).  It will initially be used by the Profiles
+#   team for testing their Oracle upgrade against.  Later we will remove the `cap-qa` host and deploy target and keep this in its place.
+# Oct 30 2019, P Mangiafico
+server 'sul-pub-cap-uat.stanford.edu', user: 'pub', roles: %w(web db app harvester_qa external_monitor)
+
+Capistrano::OneTimeKey.generate_one_time_key!
+
+set :rails_env, 'production'
+
+set :bundle_without, %w(test development).join(' ')
+
+set :log_level, :info


### PR DESCRIPTION
Based on the new VMs created here: https://github.com/sul-dlss/operations-tasks/issues/2061

Will be used by the Profiles team for testing their Oracle upgrade against while we maintain the current stack of VMs.  Later we can pull down these two instances/targets and use these new ones instead: `sul-pub-cap-dev` and `sul-pub-cap-qa`