### PR TITLE
enable cron jobs on new dev and uat servers; rename qa role to…

### DIFF
--- a/config/deploy/cap-dev-a.rb
+++ b/config/deploy/cap-dev-a.rb
@@ -2,7 +2,7 @@
 #   team for testing their Oracle upgrade against.  Later we will remove the `cap-dev` host and deploy target and keep this in its place.
 #   We should then rename it back to `cap-dev` to match what it used to be.
 # Oct 30 2019, P Mangiafico
-server 'sul-pub-cap-dev-a.stanford.edu', user: 'pub', roles: %w(web db app)
+server 'sul-pub-cap-dev-a.stanford.edu', user: 'pub', roles: %w(web db harvester_dev_a app)
 
 Capistrano::OneTimeKey.generate_one_time_key!
 

--- a/config/deploy/cap-uat.rb
+++ b/config/deploy/cap-uat.rb
@@ -1,7 +1,7 @@
 # This will become the new UAT server (currently called `cap-qa`).  It will initially be used by the Profiles
 #   team for testing their Oracle upgrade against.  Later we will remove the `cap-qa` host and deploy target and keep this in its place.
 # Oct 30 2019, P Mangiafico
-server 'sul-pub-cap-uat.stanford.edu', user: 'pub', roles: %w(web db app external_monitor)
+server 'sul-pub-cap-uat.stanford.edu', user: 'pub', roles: %w(web db app harvester_uat external_monitor)
 
 Capistrano::OneTimeKey.generate_one_time_key!
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -17,8 +17,8 @@ every "0 17 1,5,9,13,17,21,25,29 * *", roles: [:harvester_prod] do
   rake 'harvest:all_authors_update'
 end
 
-# poll cap for new authorship information nightly at 4am-ish in both prod and qa
-every 1.day, at: stagger(4), roles: [:harvester_qa, :harvester_prod, :harvester_dev] do
+# poll cap for new authorship information nightly at 4am-ish in prod, qa and dev
+every 1.day, at: stagger(4), roles: [:harvester_qa, :harvester_prod, :harvester_dev_a] do
   rake 'cap:poll[1]'
 end
 


### PR DESCRIPTION
We need to be able to enable/disable cron jobs (nightly author updates and periodic harvesting) on the new uat and dev servers to match what is happening on the old servers or not.

Setup new roles to allow this enabling/disabling independently of current qa/dev.  Also disable current dev and enable new dev (dev-a) for testing.