### PR TITLE
Fix issue with first names; add better exception for HB

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -425,7 +425,6 @@ RSpec/LetBeforeExamples:
 RSpec/MessageChain:
   Exclude:
     - 'spec/lib/pubmed/harvester_spec.rb'
-    - 'spec/lib/web_of_science/harvester_spec.rb'
 
 # Offense count: 140
 # Configuration parameters: .

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -425,6 +425,7 @@ RSpec/LetBeforeExamples:
 RSpec/MessageChain:
   Exclude:
     - 'spec/lib/pubmed/harvester_spec.rb'
+    - 'spec/lib/web_of_science/harvester_spec.rb'
 
 # Offense count: 140
 # Configuration parameters: .

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -65,7 +65,8 @@ WOS:
   new_author_timeframe: null # default WoS symbolicTimeSpan for new authors resulting from nightly cap polling (null == for all time)
   # note, see lib/web_of_science/query_author.rb#author_query
   #   or https://github.com/sul-dlss/sul_pub/wiki/Clarivate-APIs for allowed values of symbolicTimeSpan
-
+  max_publications_per_author: 3000 # if more than this number of publications are returned for a single author, the author harvest will be aborted
+                                    #  and a HB alert will be sent
 DOI:
   BASE_URI: https://doi.org/
 

--- a/lib/harvester/base.rb
+++ b/lib/harvester/base.rb
@@ -1,6 +1,10 @@
 module Harvester
   # An iota of abstraction for things a harvester must do.
   # The starting point is always one or more Authors.
+
+  # Exception for reporting issues that occur during harvesting
+  class Error < StandardError; end
+
   class Base
     # @param [Hash] options
     # @return [void]

--- a/lib/pubmed/harvester.rb
+++ b/lib/pubmed/harvester.rb
@@ -24,6 +24,7 @@ module Pubmed
           pmids
         end
       else
+        NotificationManager.error(StandardError, "#{self.class} - An invalid author query was detected for author id #{author.id} and was aborted", self)
         []
       end
     rescue StandardError => err

--- a/lib/pubmed/harvester.rb
+++ b/lib/pubmed/harvester.rb
@@ -12,14 +12,19 @@ module Pubmed
       return unless Settings.PUBMED.harvest_enabled
       raise(ArgumentError, 'author must be an Author') unless author.is_a? Author
       log_info(author, "processing author #{author.id}")
-      pmids_from_query = Pubmed::QueryAuthor.new(author, options).pmids
-      if pmids_from_query.size >= Settings.PUBMED.max_publications_per_author
-        NotificationManager.error(StandardError, "#{self.class} - Pubmed harvest returned more than #{Settings.PUBMED.max_publications_per_author} for author #{author.id} and was aborted", self)
-        []
+      query_author = Pubmed::QueryAuthor.new(author, options)
+      if query_author.valid?
+        pmids_from_query = query_author.pmids
+        if pmids_from_query.size >= Settings.PUBMED.max_publications_per_author
+          NotificationManager.error(StandardError, "#{self.class} - Pubmed harvest returned more than #{Settings.PUBMED.max_publications_per_author} for author id #{author.id} and was aborted", self)
+          []
+        else
+          pmids = process_pmids(author, pmids_from_query)
+          log_info(author, "processed author #{author.id}: #{pmids.count} new publications")
+          pmids
+        end
       else
-        pmids = process_pmids(author, pmids_from_query)
-        log_info(author, "processed author #{author.id}: #{pmids.count} new publications")
-        pmids
+        []
       end
     rescue StandardError => err
       NotificationManager.error(err, "#{self.class} - Pubmed harvest failed for author #{author.id}", self)

--- a/lib/pubmed/harvester.rb
+++ b/lib/pubmed/harvester.rb
@@ -16,7 +16,7 @@ module Pubmed
       if query_author.valid?
         pmids_from_query = query_author.pmids
         if pmids_from_query.size >= Settings.PUBMED.max_publications_per_author
-          NotificationManager.error(::Harvester::Error, "#{self.class} - Pubmed harvest returned more than #{Settings.PUBMED.max_publications_per_author} for author id #{author.id} and was aborted", self)
+          NotificationManager.error(::Harvester::Error, "#{self.class} - Pubmed harvest returned more than #{Settings.PUBMED.max_publications_per_author} publications for author id #{author.id} and was aborted", self)
           []
         else
           pmids = process_pmids(author, pmids_from_query)

--- a/lib/pubmed/harvester.rb
+++ b/lib/pubmed/harvester.rb
@@ -16,7 +16,7 @@ module Pubmed
       if query_author.valid?
         pmids_from_query = query_author.pmids
         if pmids_from_query.size >= Settings.PUBMED.max_publications_per_author
-          NotificationManager.error(StandardError, "#{self.class} - Pubmed harvest returned more than #{Settings.PUBMED.max_publications_per_author} for author id #{author.id} and was aborted", self)
+          NotificationManager.error(::Harvester::Error, "#{self.class} - Pubmed harvest returned more than #{Settings.PUBMED.max_publications_per_author} for author id #{author.id} and was aborted", self)
           []
         else
           pmids = process_pmids(author, pmids_from_query)
@@ -24,7 +24,7 @@ module Pubmed
           pmids
         end
       else
-        NotificationManager.error(StandardError, "#{self.class} - An invalid author query was detected for author id #{author.id} and was aborted", self)
+        NotificationManager.error(::Harvester::Error, "#{self.class} - An invalid author query was detected for author id #{author.id} and was aborted", self)
         []
       end
     rescue StandardError => err

--- a/lib/pubmed/query_author.rb
+++ b/lib/pubmed/query_author.rb
@@ -15,15 +15,15 @@ module Pubmed
       parse_response(resp)
     end
 
+    def valid?
+      !name_term.blank?
+    end
+
     private
 
     delegate :client, to: :Pubmed
 
     attr_reader :author, :options
-
-    def valid?
-      !name_term.blank?
-    end
 
     def addl_args
       return unless options[:reldate]
@@ -37,12 +37,12 @@ module Pubmed
 
     def name_term
       author_identities.collect { |identity| "(#{identity.last_name}, #{identity.first_name}[Author])" if identity.first_name =~ /[a-zA-Z]+/ }
-                                   .compact.uniq.join(' OR ')
+                       .compact.uniq.join(' OR ')
     end
 
     def affiliation_term
       author_identities.collect { |identity| affiliation_terms(identity.institution) if identity.institution }
-                                          .compact.uniq.join(' OR ')
+                       .compact.uniq.join(' OR ')
     end
 
     def affiliation_terms(institution)

--- a/lib/web_of_science/harvester.rb
+++ b/lib/web_of_science/harvester.rb
@@ -23,6 +23,7 @@ module WebOfScience
           uids
         end
       else
+        NotificationManager.error(StandardError, "#{self.class} - An invalid author query was detected for author id #{author.id} and was aborted", self)
         []
       end
     rescue StandardError => err

--- a/lib/web_of_science/harvester.rb
+++ b/lib/web_of_science/harvester.rb
@@ -15,7 +15,7 @@ module WebOfScience
       if query_author.valid?
         uids_from_query = query_author.uids
         if uids_from_query.size >= Settings.WOS.max_publications_per_author
-          NotificationManager.error(::Harvester::Error, "#{self.class} - WoS harvest returned more than #{Settings.WOS.max_publications_per_author} for author id #{author.id} and was aborted", self)
+          NotificationManager.error(::Harvester::Error, "#{self.class} - WoS harvest returned more than #{Settings.WOS.max_publications_per_author} publications for author id #{author.id} and was aborted", self)
           []
         else
           uids = process_uids(author, uids_from_query)

--- a/lib/web_of_science/harvester.rb
+++ b/lib/web_of_science/harvester.rb
@@ -15,7 +15,7 @@ module WebOfScience
       if query_author.valid?
         uids_from_query = query_author.uids
         if uids_from_query.size >= Settings.WOS.max_publications_per_author
-          NotificationManager.error(StandardError, "#{self.class} - WoS harvest returned more than #{Settings.WOS.max_publications_per_author} for author id #{author.id} and was aborted", self)
+          NotificationManager.error(::Harvester::Error, "#{self.class} - WoS harvest returned more than #{Settings.WOS.max_publications_per_author} for author id #{author.id} and was aborted", self)
           []
         else
           uids = process_uids(author, uids_from_query)
@@ -23,7 +23,7 @@ module WebOfScience
           uids
         end
       else
-        NotificationManager.error(StandardError, "#{self.class} - An invalid author query was detected for author id #{author.id} and was aborted", self)
+        NotificationManager.error(::Harvester::Error, "#{self.class} - An invalid author query was detected for author id #{author.id} and was aborted", self)
         []
       end
     rescue StandardError => err

--- a/lib/web_of_science/query_author.rb
+++ b/lib/web_of_science/query_author.rb
@@ -16,6 +16,10 @@ module WebOfScience
       queries.search(author_query).merged_uids
     end
 
+    def valid?
+      !names.blank?
+    end
+
     private
 
       delegate :queries, to: :WebOfScience
@@ -25,10 +29,6 @@ module WebOfScience
 
       def author
         identities.first
-      end
-
-      def valid?
-        !names.blank?
       end
 
       def names

--- a/lib/web_of_science/query_author.rb
+++ b/lib/web_of_science/query_author.rb
@@ -27,6 +27,10 @@ module WebOfScience
         identities.first
       end
 
+      def valid?
+        !names.blank?
+      end
+
       def names
         identities.map do |ident|
           if ident.first_name =~ /[a-zA-Z]+/

--- a/spec/factories/author.rb
+++ b/spec/factories/author.rb
@@ -37,10 +37,21 @@ FactoryBot.define do
     preferred_last_name { 'Edler' }
     preferred_middle_name { 'Jim' }
     emails_for_harvest { 'alice.edler@stanford.edu' }
-  end
 
-  factory :inactive_author, parent: :author do
-    active_in_cap { false }
+    trait :blank_first_name do
+      official_first_name { '' }
+      preferred_first_name { '' }
+    end
+
+    trait :space_first_name do
+      official_first_name { ' ' }
+      preferred_first_name { ' ' }
+    end
+
+    trait :period_first_name do
+      official_first_name { '.' }
+      preferred_first_name { '.' }
+    end
   end
 
   factory :author_with_alternate_identities, parent: :author do
@@ -52,32 +63,6 @@ FactoryBot.define do
         create(:author_identity, author: author)
       end
     end
-  end
-
-  factory :period_first_name_author, parent: :author do
-    active_in_cap { true }
-    cap_import_enabled { true }
-    official_first_name { '.' }
-    official_last_name { 'Dude' }
-    official_middle_name { '' }
-    preferred_first_name { '.' }
-    preferred_last_name { 'Dude' }
-    preferred_middle_name { '' }
-    email { 'bad.dude@stanford.edu' }
-    emails_for_harvest { 'bad.dude@stanford.edu' }
-  end
-
-  factory :blank_first_name_author, parent: :author do
-    active_in_cap { true }
-    cap_import_enabled { true }
-    official_first_name { '' }
-    official_last_name { 'Dude' }
-    official_middle_name { '' }
-    preferred_first_name { '' }
-    preferred_last_name { 'Dude' }
-    preferred_middle_name { '' }
-    email { 'dude@stanford.edu' }
-    emails_for_harvest { 'dude@stanford.edu' }
   end
 
   # Public data from

--- a/spec/factories/author.rb
+++ b/spec/factories/author.rb
@@ -54,6 +54,32 @@ FactoryBot.define do
     end
   end
 
+  factory :period_first_name_author, parent: :author do
+    active_in_cap { true }
+    cap_import_enabled { true }
+    official_first_name { '.' }
+    official_last_name { 'Dude' }
+    official_middle_name { '' }
+    preferred_first_name { '.' }
+    preferred_last_name { 'Dude' }
+    preferred_middle_name { '' }
+    email { 'bad.dude@stanford.edu' }
+    emails_for_harvest { 'bad.dude@stanford.edu' }
+  end
+
+  factory :blank_first_name_author, parent: :author do
+    active_in_cap { true }
+    cap_import_enabled { true }
+    official_first_name { '' }
+    official_last_name { 'Dude' }
+    official_middle_name { '' }
+    preferred_first_name { '' }
+    preferred_last_name { 'Dude' }
+    preferred_middle_name { '' }
+    email { 'dude@stanford.edu' }
+    emails_for_harvest { 'dude@stanford.edu' }
+  end
+
   # Public data from
   # - https://stanfordwho.stanford.edu
   # - https://med.stanford.edu/profiles/russ-altman

--- a/spec/lib/pubmed/harvester_spec.rb
+++ b/spec/lib/pubmed/harvester_spec.rb
@@ -35,9 +35,12 @@ describe Pubmed::Harvester do
 
     context 'when author query has too many publications' do
       let(:lotsa_pmids) { Array(1..Settings.PUBMED.max_publications_per_author) }
+      let(:query_author) { instance_double(Pubmed::QueryAuthor) }
+
       before do
-        allow(Pubmed::QueryAuthor).to receive_message_chain(:new, :pmids).and_return(lotsa_pmids)
-        allow(Pubmed::QueryAuthor).to receive_message_chain(:new, :'valid?').and_return(true)
+        allow(Pubmed::QueryAuthor).to receive(:new).with(author, {}).and_return(query_author)
+        allow(query_author).to receive(:pmids).and_return(lotsa_pmids)
+        allow(query_author).to receive('valid?').and_return(true)
       end
 
       it 'aborts the harvest and returns no pmids' do
@@ -47,8 +50,11 @@ describe Pubmed::Harvester do
     end
 
     context 'when author query is invalid' do
+      let(:query_author) { instance_double(Pubmed::QueryAuthor) }
+
       before do
-        allow(Pubmed::QueryAuthor).to receive_message_chain(:new, :'valid?').and_return(false)
+        allow(Pubmed::QueryAuthor).to receive(:new).with(author, {}).and_return(query_author)
+        allow(query_author).to receive('valid?').and_return(false)
       end
 
       it 'aborts the harvest and returns no pmids' do

--- a/spec/lib/pubmed/harvester_spec.rb
+++ b/spec/lib/pubmed/harvester_spec.rb
@@ -35,6 +35,11 @@ describe Pubmed::Harvester do
       let(:query_author) { instance_double(Pubmed::QueryAuthor, 'valid?': true, pmids: lotsa_pmids) }
 
       it 'aborts the harvest and returns no pmids' do
+        expect(NotificationManager).to receive(:error).with(
+          ::Harvester::Error,
+          "Pubmed::Harvester - Pubmed harvest returned more than #{Settings.PUBMED.max_publications_per_author} publications for author id #{author.id} and was aborted",
+          harvester
+        )
         expect(harvester.process_author(author)).to eq([])
         expect(author.contributions.size).to eq 0
       end

--- a/spec/lib/pubmed/harvester_spec.rb
+++ b/spec/lib/pubmed/harvester_spec.rb
@@ -9,6 +9,7 @@ describe Pubmed::Harvester do
     context 'when author has existing publications' do
       before do
         allow(Pubmed::QueryAuthor).to receive_message_chain(:new, :pmids).and_return([existing_pub.pmid.to_s])
+        allow(Pubmed::QueryAuthor).to receive_message_chain(:new, :'valid?').and_return(true)
       end
 
       it 'removes publications that exists and assigns the author' do
@@ -21,6 +22,7 @@ describe Pubmed::Harvester do
       let(:pmid) { '30833575' }
       before do
         allow(Pubmed::QueryAuthor).to receive_message_chain(:new, :pmids).and_return([pmid])
+        allow(Pubmed::QueryAuthor).to receive_message_chain(:new, :'valid?').and_return(true)
       end
 
       it 'removes publications that exists and assigns the author' do
@@ -35,6 +37,18 @@ describe Pubmed::Harvester do
       let(:lotsa_pmids) { Array(1..Settings.PUBMED.max_publications_per_author) }
       before do
         allow(Pubmed::QueryAuthor).to receive_message_chain(:new, :pmids).and_return(lotsa_pmids)
+        allow(Pubmed::QueryAuthor).to receive_message_chain(:new, :'valid?').and_return(true)
+      end
+
+      it 'aborts the harvest and returns no pmids' do
+        expect(harvester.process_author(author)).to eq([])
+        expect(author.contributions.size).to eq 0
+      end
+    end
+
+    context 'when author query is invalid' do
+      before do
+        allow(Pubmed::QueryAuthor).to receive_message_chain(:new, :'valid?').and_return(false)
       end
 
       it 'aborts the harvest and returns no pmids' do

--- a/spec/lib/pubmed/harvester_spec.rb
+++ b/spec/lib/pubmed/harvester_spec.rb
@@ -49,6 +49,11 @@ describe Pubmed::Harvester do
       let(:query_author) { instance_double(Pubmed::QueryAuthor, 'valid?': false) }
 
       it 'aborts the harvest and returns no pmids' do
+        expect(NotificationManager).to receive(:error).with(
+          ::Harvester::Error,
+          "Pubmed::Harvester - An invalid author query was detected for author id #{author.id} and was aborted",
+          harvester
+        )
         expect(harvester.process_author(author)).to eq([])
         expect(author.contributions.size).to eq 0
       end

--- a/spec/lib/pubmed/query_author_spec.rb
+++ b/spec/lib/pubmed/query_author_spec.rb
@@ -2,10 +2,12 @@ describe Pubmed::QueryAuthor do
   let(:query_author) { described_class.new(author, options) }
   let(:query_period_author) { described_class.new(period_author, options) }
   let(:query_space_author) { described_class.new(space_author, options) }
+  let(:query_blank_author) { described_class.new(blank_author, options) }
 
   let(:author) { create :russ_altman }
-  let(:space_author) { create :blank_first_name_author }
-  let(:period_author) { create :period_first_name_author }
+  let(:space_author) { create :author, :space_first_name }
+  let(:period_author) { create :author, :period_first_name }
+  let(:blank_author) { create :author, :blank_first_name }
 
   let(:options) { {} }
 
@@ -102,6 +104,9 @@ describe Pubmed::QueryAuthor do
       end
       it 'indicates that a name with a space for a first name is not a valid query' do
         expect(query_space_author).not_to be_valid
+      end
+      it 'indicates that a name with a blank for a first name is not a valid query' do
+        expect(query_blank_author).not_to be_valid
       end
     end
 

--- a/spec/lib/pubmed/query_author_spec.rb
+++ b/spec/lib/pubmed/query_author_spec.rb
@@ -92,16 +92,16 @@ describe Pubmed::QueryAuthor do
 
     context 'with a user with valid first names' do
       it 'indicates it is a valid query' do
-        expect(query_author.send(:'valid?')).to be_truthy
+        expect(query_author).to be_valid
       end
     end
 
     context 'with a user with no valid first names' do
       it 'indicates that name with a period for a first name is not a valid query' do
-        expect(query_period_author.send(:'valid?')).to be_falsey
+        expect(query_period_author).not_to be_valid
       end
       it 'indicates that a name with a space for a first name is not a valid query' do
-        expect(query_space_author.send(:'valid?')).to be_falsey
+        expect(query_space_author).not_to be_valid
       end
     end
 

--- a/spec/lib/pubmed/query_author_spec.rb
+++ b/spec/lib/pubmed/query_author_spec.rb
@@ -1,7 +1,11 @@
 describe Pubmed::QueryAuthor do
   let(:query_author) { described_class.new(author, options) }
+  let(:query_period_author) { described_class.new(period_author, options) }
+  let(:query_space_author) { described_class.new(space_author, options) }
 
   let(:author) { create :russ_altman }
+  let(:space_author) { create :blank_first_name_author }
+  let(:period_author) { create :period_first_name_author }
 
   let(:options) { {} }
 
@@ -83,6 +87,21 @@ describe Pubmed::QueryAuthor do
 
       it 'generates the correct term string' do
         expect(query_author.send(:term)).to eq('((Altman, Russ[Author]) OR (Altman, R[Author])) AND (Stanford University[Affiliation] OR Texas AandM[Affiliation])')
+      end
+    end
+
+    context 'with a user with valid first names' do
+      it 'indicates it is a valid query' do
+        expect(query_author.send(:'valid?')).to be_truthy
+      end
+    end
+
+    context 'with a user with no valid first names' do
+      it 'indicates that name with a period for a first name is not a valid query' do
+        expect(query_period_author.send(:'valid?')).to be_falsey
+      end
+      it 'indicates that a name with a space for a first name is not a valid query' do
+        expect(query_space_author.send(:'valid?')).to be_falsey
       end
     end
 

--- a/spec/lib/web_of_science/harvester_spec.rb
+++ b/spec/lib/web_of_science/harvester_spec.rb
@@ -139,9 +139,12 @@ describe WebOfScience::Harvester do
 
   context 'when author query has too many publications' do
     let(:lotsa_uids) { Array(1..Settings.WOS.max_publications_per_author) }
+    let(:query_author) { instance_double(WebOfScience::QueryAuthor) }
+
     before do
-      allow(WebOfScience::QueryAuthor).to receive_message_chain(:new, :uids).and_return(lotsa_uids)
-      allow(WebOfScience::QueryAuthor).to receive_message_chain(:new, :'valid?').and_return(true)
+      allow(WebOfScience::QueryAuthor).to receive(:new).with(author, {}).and_return(query_author)
+      allow(query_author).to receive(:uids).and_return(lotsa_uids)
+      allow(query_author).to receive('valid?').and_return(true)
     end
 
     it 'aborts the harvest and returns no uids' do
@@ -151,8 +154,11 @@ describe WebOfScience::Harvester do
   end
 
   context 'when author query is invalid' do
+    let(:query_author) { instance_double(WebOfScience::QueryAuthor) }
+
     before do
-      allow(WebOfScience::QueryAuthor).to receive_message_chain(:new, :'valid?').and_return(false)
+      allow(WebOfScience::QueryAuthor).to receive(:new).with(author, {}).and_return(query_author)
+      allow(query_author).to receive('valid?').and_return(false)
     end
 
     it 'aborts the harvest and returns no uids' do

--- a/spec/lib/web_of_science/harvester_spec.rb
+++ b/spec/lib/web_of_science/harvester_spec.rb
@@ -139,12 +139,10 @@ describe WebOfScience::Harvester do
 
   context 'when author query has too many publications' do
     let(:lotsa_uids) { Array(1..Settings.WOS.max_publications_per_author) }
-    let(:query_author) { instance_double(WebOfScience::QueryAuthor) }
+    let(:query_author) { instance_double(WebOfScience::QueryAuthor, uids: lotsa_uids, 'valid?': true) }
 
     before do
       allow(WebOfScience::QueryAuthor).to receive(:new).with(author, {}).and_return(query_author)
-      allow(query_author).to receive(:uids).and_return(lotsa_uids)
-      allow(query_author).to receive('valid?').and_return(true)
     end
 
     it 'aborts the harvest and returns no uids' do

--- a/spec/lib/web_of_science/harvester_spec.rb
+++ b/spec/lib/web_of_science/harvester_spec.rb
@@ -146,6 +146,11 @@ describe WebOfScience::Harvester do
     end
 
     it 'aborts the harvest and returns no uids' do
+      expect(NotificationManager).to receive(:error).with(
+        ::Harvester::Error,
+        "WebOfScience::Harvester - WoS harvest returned more than #{Settings.WOS.max_publications_per_author} publications for author id #{author.id} and was aborted",
+        harvester
+      )
       expect(harvester.process_author(author)).to eq([])
       expect(author.contributions.size).to eq 0
     end
@@ -160,6 +165,11 @@ describe WebOfScience::Harvester do
     end
 
     it 'aborts the harvest and returns no uids' do
+      expect(NotificationManager).to receive(:error).with(
+        ::Harvester::Error,
+        "WebOfScience::Harvester - An invalid author query was detected for author id #{author.id} and was aborted",
+        harvester
+      )
       expect(harvester.process_author(author)).to eq([])
       expect(author.contributions.size).to eq 0
     end

--- a/spec/lib/web_of_science/harvester_spec.rb
+++ b/spec/lib/web_of_science/harvester_spec.rb
@@ -136,4 +136,28 @@ describe WebOfScience::Harvester do
       end
     end
   end
+
+  context 'when author query has too many publications' do
+    let(:lotsa_uids) { Array(1..Settings.WOS.max_publications_per_author) }
+    before do
+      allow(WebOfScience::QueryAuthor).to receive_message_chain(:new, :uids).and_return(lotsa_uids)
+      allow(WebOfScience::QueryAuthor).to receive_message_chain(:new, :'valid?').and_return(true)
+    end
+
+    it 'aborts the harvest and returns no uids' do
+      expect(harvester.process_author(author)).to eq([])
+      expect(author.contributions.size).to eq 0
+    end
+  end
+
+  context 'when author query is invalid' do
+    before do
+      allow(WebOfScience::QueryAuthor).to receive_message_chain(:new, :'valid?').and_return(false)
+    end
+
+    it 'aborts the harvest and returns no uids' do
+      expect(harvester.process_author(author)).to eq([])
+      expect(author.contributions.size).to eq 0
+    end
+  end
 end

--- a/spec/lib/web_of_science/query_author_spec.rb
+++ b/spec/lib/web_of_science/query_author_spec.rb
@@ -1,7 +1,11 @@
 describe WebOfScience::QueryAuthor, :vcr do
   subject(:query_author) { described_class.new(author) }
+  let(:query_period_author) { described_class.new(period_author) }
+  let(:query_space_author) { described_class.new(space_author) }
 
   let(:author) { create :russ_altman }
+  let(:space_author) { create :blank_first_name_author }
+  let(:period_author) { create :period_first_name_author }
   let(:names) { query_author.send(:names) }
 
   # avoid caching Savon client across examples (affects VCR)
@@ -85,6 +89,21 @@ describe WebOfScience::QueryAuthor, :vcr do
     end
     it 'removes quotes in a name' do
       expect(query_author.send(:quote_wrap, ['peter', 'peter paul', 'peter "paul" mary'])).to eq ['"peter"', '"peter paul"', '"peter paul mary"']
+    end
+  end
+
+  context 'with a user with valid first names' do
+    it 'indicates it is a valid query' do
+      expect(query_author.send(:'valid?')).to be_truthy
+    end
+  end
+
+  context 'with a user with no valid first names' do
+    it 'indicates that name with a period for a first name is not a valid query' do
+      expect(query_period_author.send(:'valid?')).to be_falsey
+    end
+    it 'indicates that a name with a space for a first name is not a valid query' do
+      expect(query_space_author.send(:'valid?')).to be_falsey
     end
   end
 

--- a/spec/lib/web_of_science/query_author_spec.rb
+++ b/spec/lib/web_of_science/query_author_spec.rb
@@ -1,5 +1,6 @@
 describe WebOfScience::QueryAuthor, :vcr do
   subject(:query_author) { described_class.new(author) }
+
   let(:query_period_author) { described_class.new(period_author) }
   let(:query_space_author) { described_class.new(space_author) }
 
@@ -94,16 +95,16 @@ describe WebOfScience::QueryAuthor, :vcr do
 
   context 'with a user with valid first names' do
     it 'indicates it is a valid query' do
-      expect(query_author.send(:'valid?')).to be_truthy
+      expect(query_author).to be_valid
     end
   end
 
   context 'with a user with no valid first names' do
     it 'indicates that name with a period for a first name is not a valid query' do
-      expect(query_period_author.send(:'valid?')).to be_falsey
+      expect(query_period_author).not_to be_valid
     end
     it 'indicates that a name with a space for a first name is not a valid query' do
-      expect(query_space_author.send(:'valid?')).to be_falsey
+      expect(query_space_author).not_to be_valid
     end
   end
 

--- a/spec/lib/web_of_science/query_author_spec.rb
+++ b/spec/lib/web_of_science/query_author_spec.rb
@@ -3,10 +3,12 @@ describe WebOfScience::QueryAuthor, :vcr do
 
   let(:query_period_author) { described_class.new(period_author) }
   let(:query_space_author) { described_class.new(space_author) }
+  let(:query_blank_author) { described_class.new(blank_author) }
 
   let(:author) { create :russ_altman }
-  let(:space_author) { create :blank_first_name_author }
-  let(:period_author) { create :period_first_name_author }
+  let(:space_author) { create :author, :space_first_name }
+  let(:period_author) { create :author, :period_first_name }
+  let(:blank_author) { create :author, :blank_first_name }
   let(:names) { query_author.send(:names) }
 
   # avoid caching Savon client across examples (affects VCR)
@@ -105,6 +107,9 @@ describe WebOfScience::QueryAuthor, :vcr do
     end
     it 'indicates that a name with a space for a first name is not a valid query' do
       expect(query_space_author).not_to be_valid
+    end
+    it 'indicates that a name with a blank for a first name is not a valid query' do
+      expect(query_blank_author).not_to be_valid
     end
   end
 


### PR DESCRIPTION
## Why was this change made?

fixes #1149 and #1150

Basically we want to guard against invalid queries when harvesting so we don't create too many publications.

This PR also adds a guard against too many publications for WoS harvesting the same way we currently guard against too many publications for pubmed harvesting (just in case we are missing other edge cases that would generate too many publications).

Basically, look at the name query for any given authors, and if's blank call it invalid, and then skip over the author when harvesting.

It also adds a new exception class for harvesting errors so its easier to see what the actual exception is in HB (previously an error from harvesting was reported as "StandardError" and you had to dig down into the "context" to see what actually was being reported, which is easy to miss).

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?



## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
