### PR TITLE
pin mysql2 to version that works on our servers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,8 @@ gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '~> 4.1'
 
-gem 'mysql2', '~> 0.5'
+# pinning myql2 since 0.5.3 is currently not compatible with our version of CentOS and Ruby (as of Apr 2020)
+gem 'mysql2', '~> 0.5', '< 0.5.3'
 
 gem 'nokogiri', '>= 1.7.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,7 +249,7 @@ GEM
     minitest (5.14.0)
     msgpack (1.3.3)
     multipart-post (2.1.1)
-    mysql2 (0.5.3)
+    mysql2 (0.5.2)
     namae (1.0.1)
     net-scp (2.0.0)
       net-ssh (>= 2.6.5, < 6.0.0)
@@ -473,7 +473,7 @@ DEPENDENCIES
   jquery-rails
   kaminari
   listen (>= 3.0.5, < 3.2)
-  mysql2 (~> 0.5)
+  mysql2 (~> 0.5, < 0.5.3)
   nokogiri (>= 1.7.1)
   okcomputer
   paper_trail


### PR DESCRIPTION
## Why was this change made?

mysql2 0.5.3 is not currently compatible with some of our servers centos/ruby combos

it fails the build on our jenkins box ... this pins to less than 0.5.3 as recommended in #software-developers channel


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

n/a

## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.

n/a
