### PR TITLE
add ruby 2.7.1 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.5.3 # deployed
+  - 2.5.3 # deployed to current servers
+  - 2.7.1 # proposed on new servers
 services: mysql
 before_install:
   - gem update --system


### PR DESCRIPTION
## Why was this change made?

Planning to upgrade to ruby 2.7.1 on the new CentOS servers, add 2.7.1 as a test target

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

n/a

## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.

n/a