### PR TITLE
check for manual publication before updating instead of ids

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -189,7 +189,7 @@ Metrics/AbcSize:
 # Configuration parameters: CountComments, ExcludedMethods.
 # ExcludedMethods: refine
 Metrics/BlockLength:
-  Max: 590
+  Max: 595
 
 # Offense count: 1
 # Configuration parameters: CountBlocks.

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -101,8 +101,8 @@ class PublicationsController < ApplicationController
       head :gone
       return
     end
-    if old_pub.sciencewire_id.present? || old_pub.pmid.present? || old_pub.wos_uid.present?
-      render json: { "error": 'This record may not be modified.  If you had originally entered details for the record, it has been superceded by a central record.' }, status: :forbidden, format: 'json'
+    if old_pub.harvested_pub? # only manually entered (i.e. non-harvested) publications may be updated with this method
+      render json: { "error": "This record SulPubID #{old_pub.id} may not be modified.  If you had originally entered details for the record, it has been superceded by a central record." }, status: :forbidden, format: 'json'
       return
     elsif !validate_or_create_authors(new_pub[:authorship])
       render json: { "error": 'You have not supplied a valid authorship record.' }, status: :not_acceptable, format: 'json'

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -230,15 +230,19 @@ class Publication < ActiveRecord::Base
   end
 
   def sciencewire_pub?
-    provenance == 'sciencewire'
+    provenance == Settings.sciencewire_source
   end
 
   def pubmed_pub?
-    provenance == 'pubmed'
+    provenance == Settings.pubmed_source
   end
 
   def wos_pub?
-    provenance == 'wos'
+    provenance == Settings.wos_source
+  end
+
+  def harvested_pub?
+    provenance != Settings.cap_provenance
   end
 
   def authoritative_pmid_source?

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -108,7 +108,6 @@ sul_doc_types:
 
 batch_source: batch
 cap_provenance: cap
-manual_source: manual
 pubmed_source: pubmed
 sciencewire_source: sciencewire
 wos_source: wos

--- a/spec/factories/publication.rb
+++ b/spec/factories/publication.rb
@@ -26,6 +26,26 @@ FactoryBot.define do
     publication_type { 'article' }
   end
 
+  factory :manual_publication, parent: :publication do
+    pub_hash do
+      {
+        provenance: 'cap',
+        identifier: [
+          { type: 'isbn', id: '1177188188181' },
+          { type: 'doi', id: '18819910019', url: 'http://doi:18819910019' }
+        ]
+      }
+    end
+  end
+
+  factory :wos_publication, parent: :publication do
+    pub_hash do
+      {
+        provenance: 'wos'
+      }
+    end
+  end
+
   factory :publication_with_contributions, parent: :publication do
     transient do
       contributions_count { 15 }

--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -40,7 +40,7 @@ describe Publication do
       expect(subject.pub_hash[:identifier].length).to be > 0
       expect(subject.pub_hash[:sulpubid]).to eq(subject.id.to_s)
       expect(subject.pub_hash[:identifier]).to include(type: 'SULPubId', id: subject.id.to_s, url: "#{Settings.SULPUB_ID.PUB_URI}/#{subject.id}")
-      expect(subject.pub_hash[:identifier]).to_not include(type: 'SULPubId', url: "#{Settings.SULPUB_ID.PUB_URI}/")
+      expect(subject.pub_hash[:identifier]).not_to include(type: 'SULPubId', url: "#{Settings.SULPUB_ID.PUB_URI}/")
       expect(subject.pub_hash[:identifier]).to include(type: 'x', id: 'y', url: 'z')
     end
   end
@@ -120,7 +120,7 @@ describe Publication do
       expect do
         publication.send(:sync_identifiers_in_pub_hash)
         publication.save!
-      end.to_not change(publication, :publication_identifiers)
+      end.not_to change(publication, :publication_identifiers)
     end
 
     it 'updates existing ids with new values' do
@@ -293,7 +293,7 @@ describe Publication do
           { type: 'SULPubId', id: publication.id.to_s, url: "http://sulcap.stanford.edu/publications/#{publication.id}" }
         ]
       )
-      expect(publication.pmid).to_not be_nil
+      expect(publication.pmid).not_to be_nil
       expect(publication.update_from_pubmed).to be true
       expect(publication.pub_hash[:title]).to eq 'How I learned Rails'
       expect(publication.pub_hash[:identifier]).to eq(
@@ -410,16 +410,21 @@ describe Publication do
     it "returns true if the pub has a provenance of 'pubmed'" do
       pub.pub_hash = { provenance: 'pubmed' }
       expect(pub).to be_authoritative_pmid_source
+      expect(pub).to be_pubmed_pub
+      expect(pub).to be_harvested_pub
     end
 
     it "returns true if the pub has a provenance of 'sciencewire'" do
       pub.pub_hash = { provenance: 'sciencewire' }
       expect(pub).to be_authoritative_pmid_source
+      expect(pub).to be_sciencewire_pub
+      expect(pub).to be_harvested_pub
     end
 
     it "returns false if the pub does not have a provanance of 'pubmed' or 'sciencewire'" do
       pub.pub_hash = { provenance: 'cap' }
-      expect(pub).to_not be_authoritative_pmid_source
+      expect(pub).not_to be_authoritative_pmid_source
+      expect(pub).not_to be_harvested_pub
     end
   end
 


### PR DESCRIPTION
## Why was this change made?

Fixes #1184 

Some users cannot update their manual publications because our guard cause was looking at identifiers in the record instead of the provenance.  We later allowed model record level identifiers to be added to a publication, which was confusing our logic about which publications could be updated (and refusing to allow a legit manual publication to be updated).

Also discovered that the tests related to updating manual publications were not working as we expected.  We thought we were using a POST to generate a publication before updating it, but this was in fact not actually happening, and that POST was returning a 406, but our tests just happened to be crafted in a way that it worked anyway.  I changed the tests to use a factory to setup the test data instead of a POST within the test itself, and then confirmed the data was changed as expected in the test.  I also added a new test for this change.

## How was this change tested?

Added a new test, and refactored existing related tests.

## Which documentation and/or configurations were updated?

None.

