### PR TITLE
add ability to search for authors by orcid and override timespan

### DIFF
--- a/spec/fixtures/reports/input.csv
+++ b/spec/fixtures/reports/input.csv
@@ -1,6 +1,7 @@
-sunetid,cap_profile_id,first_name,middle_name,last_name,institutions
+sunetid,cap_profile_id,first_name,middle_name,last_name,institutions,orcid
 altman,
 bogus,
 ,92885
 ,,bill,a,clinton,"stanford,princeton"
 ,,d,,duck,
+,,,,,,0000-0002-1859-6354

--- a/spec/lib/smci_report_spec.rb
+++ b/spec/lib/smci_report_spec.rb
@@ -25,6 +25,7 @@ describe SMCIReport do
 
     before do
       allow(WebOfScience::QueryAuthor).to receive(:new).and_return(query_author)
+      allow(WebOfScience.queries).to receive(:search).and_return(wos_orcid_retriever)
       allow(query_author).to receive(:author_query).and_return('the query')
       allow(wos_retriever).to receive(:'next_batch?').and_return(false)
     end
@@ -34,6 +35,7 @@ describe SMCIReport do
     context 'when wos returns more than the max number of publications for an author' do
       let(:lotsa_uids) { Array(1..Settings.WOS.max_publications_per_author) }
       let(:query_author) { instance_double(WebOfScience::QueryAuthor, uids: lotsa_uids, 'valid?': true) }
+      let(:wos_orcid_retriever) { instance_double(WebOfScience::Retriever, merged_uids: lotsa_uids) }
 
       it 'runs with no dates specified' do
         author.contributions << contribution
@@ -60,6 +62,7 @@ describe SMCIReport do
     context 'when wos returns less than the max number of publications for an author' do
       let(:uids) { [1, 2] }
       let(:query_author) { instance_double(WebOfScience::QueryAuthor, uids: uids, 'valid?': true) }
+      let(:wos_orcid_retriever) { instance_double(WebOfScience::Retriever, merged_uids: uids) }
 
       before do
         allow(WebOfScience.queries).to receive(:retrieve_by_id)


### PR DESCRIPTION
## Why was this change made?

Update the custom report 

1. to allow for searching for non-Profiles authors by Orcid in addition to by name
2. to allow for overriding the symbolic timespan per author by adding a column to the input csv

## How was this change tested?

Unit tests and manual run


## Which documentation and/or configurations were updated?

Will update wiki page if approved (https://github.com/sul-dlss/sul_pub/wiki/Common-Support-Tasks)


