### PR TITLE
add links to wiki page with info on deploy environments

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,3 +1,4 @@
+# see https://github.com/sul-dlss/sul_pub/wiki/Servers-Deployment-environment
 set :application, 'sul-pub'
 set :repo_url, "git@github.com:sul-dlss/sul_pub.git"
 set :ssh_options,   keys: [Capistrano::OneTimeKey.temporary_ssh_private_key_path],

--- a/config/deploy/cap-dev-a.rb
+++ b/config/deploy/cap-dev-a.rb
@@ -1,7 +1,4 @@
-# This will become the new CAP-DEV server (currently called `cap-dev`).  It will initially be used by the Profiles
-#   team for testing their Oracle upgrade against.  Later we will remove the `cap-dev` host and deploy target and keep this in its place.
-#   We should then rename it back to `cap-dev` to match what it used to be.
-# Oct 30 2019, P Mangiafico
+# see https://github.com/sul-dlss/sul_pub/wiki/Servers-Deployment-environment
 server 'sul-pub-cap-dev-a.stanford.edu', user: 'pub', roles: %w(web db harvester_dev_a app)
 
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/cap-dev.rb
+++ b/config/deploy/cap-dev.rb
@@ -1,3 +1,4 @@
+# see https://github.com/sul-dlss/sul_pub/wiki/Servers-Deployment-environment
 server 'sul-pub-cap-dev.stanford.edu', user: 'pub', roles: %w(web db harvester_dev app)
 
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/cap-uat.rb
+++ b/config/deploy/cap-uat.rb
@@ -1,6 +1,4 @@
-# This will become the new UAT server (currently called `cap-qa`).  It will initially be used by the Profiles
-#   team for testing their Oracle upgrade against.  Later we will remove the `cap-qa` host and deploy target and keep this in its place.
-# Oct 30 2019, P Mangiafico
+# see https://github.com/sul-dlss/sul_pub/wiki/Servers-Deployment-environment
 server 'sul-pub-cap-uat.stanford.edu', user: 'pub', roles: %w(web db app harvester_uat external_monitor)
 
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,3 +1,4 @@
+# see https://github.com/sul-dlss/sul_pub/wiki/Servers-Deployment-environment
 server 'sul-pub-prod.stanford.edu', user: 'pub', roles: %w(web db app harvester_prod external_monitor)
 
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,3 +1,4 @@
+# see https://github.com/sul-dlss/sul_pub/wiki/Servers-Deployment-environment
 server 'sul-pub-cap-qa.stanford.edu', user: 'pub', roles: %w(web db app harvester_qa external_monitor)
 
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,3 +1,4 @@
+# see https://github.com/sul-dlss/sul_pub/wiki/Servers-Deployment-environment
 server 'sul-pub-stage.stanford.edu', user: 'pub', roles: %w(web db app)
 
 Capistrano::OneTimeKey.generate_one_time_key!


### PR DESCRIPTION
## Why was this change made?

Add links to server deploy environment wiki pages instead of embedding specific comments in the deploy files themselves