### PR TITLE
start cron jobs on new qa and dev servers and stop on old

### DIFF
--- a/config/deploy/cap-dev-a.rb
+++ b/config/deploy/cap-dev-a.rb
@@ -1,5 +1,5 @@
 # see https://github.com/sul-dlss/sul_pub/wiki/Servers-Deployment-environment
-server 'sul-pub-cap-dev-a.stanford.edu', user: 'pub', roles: %w(web db harvester_dev_a app)
+server 'sul-pub-cap-dev-a.stanford.edu', user: 'pub', roles: %w(web db harvester_dev app)
 
 Capistrano::OneTimeKey.generate_one_time_key!
 

--- a/config/deploy/cap-dev.rb
+++ b/config/deploy/cap-dev.rb
@@ -1,5 +1,5 @@
 # see https://github.com/sul-dlss/sul_pub/wiki/Servers-Deployment-environment
-server 'sul-pub-cap-dev.stanford.edu', user: 'pub', roles: %w(web db harvester_dev app)
+server 'sul-pub-cap-dev.stanford.edu', user: 'pub', roles: %w(web db app)
 
 Capistrano::OneTimeKey.generate_one_time_key!
 

--- a/config/deploy/cap-uat.rb
+++ b/config/deploy/cap-uat.rb
@@ -1,5 +1,5 @@
 # see https://github.com/sul-dlss/sul_pub/wiki/Servers-Deployment-environment
-server 'sul-pub-cap-uat.stanford.edu', user: 'pub', roles: %w(web db app harvester_uat external_monitor)
+server 'sul-pub-cap-uat.stanford.edu', user: 'pub', roles: %w(web db app harvester_qa external_monitor)
 
 Capistrano::OneTimeKey.generate_one_time_key!
 

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,5 +1,5 @@
 # see https://github.com/sul-dlss/sul_pub/wiki/Servers-Deployment-environment
-server 'sul-pub-cap-qa.stanford.edu', user: 'pub', roles: %w(web db app harvester_qa external_monitor)
+server 'sul-pub-cap-qa.stanford.edu', user: 'pub', roles: %w(web db app external_monitor)
 
 Capistrano::OneTimeKey.generate_one_time_key!
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -18,7 +18,7 @@ every "0 17 1,5,9,13,17,21,25,29 * *", roles: [:harvester_prod] do
 end
 
 # poll cap for new authorship information nightly at 4am-ish in prod, qa and dev
-every 1.day, at: stagger(4), roles: [:harvester_qa, :harvester_prod] do
+every 1.day, at: stagger(4), roles: [:harvester_dev, :harvester_qa, :harvester_prod] do
   rake 'cap:poll[1]'
 end
 


### PR DESCRIPTION
## Why was this change made?

~~HOLD for green light from Profiles team~~  green light received

Now that the new Profiles servers are online, we need to switch over the cron jobs to use the new Profiles servers.

Later, we will decommission the no longer needed servers and then we can remove the extra deploy targets as well (work in #1245)

Full checklist for the Profiles upgrade work in https://github.com/sul-dlss/operations-tasks/issues/2512

Notes:
- the current host name of the new dev server is `cap-dev-a` but will be referred to with the name `cap-dev` in the roles capistrano files since we once we decommission the old `cap-dev`, `cap-dev-a` will be accessible as `cap-dev`

## How was this change tested?



## Which documentation and/or configurations were updated?



