### PR TITLE
add authors.cap_visibility to schema, populate from retrieved CAP authorship data

### DIFF
--- a/db/migrate/20210511164010_add_cap_visibility_to_authors.rb
+++ b/db/migrate/20210511164010_add_cap_visibility_to_authors.rb
@@ -1,0 +1,5 @@
+class AddCapVisibilityToAuthors < ActiveRecord::Migration[6.0]
+  def change
+    add_column :authors, :cap_visibility, :string
+  end
+end

--- a/db/migrate/20210512190856_add_index_to_authors_cap_visibility.rb
+++ b/db/migrate/20210512190856_add_index_to_authors_cap_visibility.rb
@@ -1,0 +1,5 @@
+class AddIndexToAuthorsCapVisibility < ActiveRecord::Migration[6.0]
+  def change
+    add_index :authors, :cap_visibility
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_10_164019) do
+ActiveRecord::Schema.define(version: 2021_05_12_190856) do
 
   create_table "author_identities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.integer "author_id", null: false
@@ -47,9 +47,11 @@ ActiveRecord::Schema.define(version: 2021_05_10_164019) do
     t.boolean "cap_import_enabled"
     t.string "emails_for_harvest"
     t.string "orcidid"
+    t.string "cap_visibility"
     t.index ["active_in_cap"], name: "index_authors_on_active_in_cap"
     t.index ["california_physician_license"], name: "index_authors_on_california_physician_license"
     t.index ["cap_profile_id"], name: "index_authors_on_cap_profile_id", unique: true
+    t.index ["cap_visibility"], name: "index_authors_on_cap_visibility"
     t.index ["sunetid"], name: "index_authors_on_sunetid"
     t.index ["university_id"], name: "index_authors_on_university_id"
   end

--- a/spec/models/author_spec.rb
+++ b/spec/models/author_spec.rb
@@ -65,6 +65,7 @@ describe Author do
       expect(subject.cap_profile_id).to eq(auth_hash['profileId'])
       expect(subject.cap_last_name).to eq(auth_hash['profile']['names']['preferred']['lastName'])
       expect(subject.sunetid).to eq(auth_hash['profile']['uid'])
+      expect(subject.cap_visibility).to eq(auth_hash['visibility'])
       # ...
     end
 
@@ -145,6 +146,16 @@ describe Author do
 
       expect(subject.publications.count).to eq(0)
       expect(subject.contributions.count).to eq(0)
+    end
+  end
+
+  describe '#cap_visibility=' do
+    before { auth_hash['visibility'] = 'translucent' }
+
+    it 'validates that cap_visibility is set to a valid value' do
+      subject.update_from_cap_authorship_profile_hash(auth_hash)
+      expect(subject).to be_invalid
+      expect(subject.errors[:cap_visibility]).to eq ['is not included in the list']
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

closes #1251 

## How was this change tested?

- [x] unit tests
- [x] deploy to qa and run `rake cap:poll` with a large value for its one param, `days_ago` (e.g. 365?), to see if actual visibility data fits the validation constraints imposed by this code change.

## Which documentation and/or configurations were updated?

n/a