### PR TITLE
Loosened rubocop defaults.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,6 +48,7 @@ Layout/LineLength:
     - "spec/lib/bibtex_ingester_spec.rb"
 
 Metrics/AbcSize:
+  Max: 35
   Exclude:
     - "spec/controllers/publications_controller_spec.rb"
     - "script/*"
@@ -62,18 +63,20 @@ Metrics/BlockLength:
     - "spec/**/*"
 
 Metrics/CyclomaticComplexity:
+  Max: 12
   Exclude:
     - "script/*"
 
 Metrics/ClassLength:
+  Max: 120
   Exclude:
-    - "lib/bibtex_ingester.rb"
     - "app/controllers/authorships_controller.rb"
     - "app/controllers/publications_controller.rb"
     - "app/models/author.rb"
     - "app/models/publication.rb"
     - "app/models/pubmed_source_record.rb"
     - "app/models/sciencewire_source_record.rb"
+    - "lib/bibtex_ingester.rb"
     - "lib/cap/authors_poller.rb"
     - "lib/science_wire_publication.rb"
     - "lib/smci_report.rb"
@@ -81,37 +84,18 @@ Metrics/ClassLength:
     - "script/*"
 
 Metrics/MethodLength:
+  Max: 45
   Exclude:
-    - "app/controllers/authorships_controller.rb"
-    - "app/controllers/publications_controller.rb"
-    - "app/models/author.rb"
-    - "app/models/publication.rb"
     - "app/models/pubmed_source_record.rb"
     - "app/models/sciencewire_source_record.rb"
-    - "lib/bibtex_identifiers.rb"
     - "lib/bibtex_ingester.rb"
-    - "lib/cap/authors_poller.rb"
-    - "lib/cap/profile_id_rewriter.rb"
-    - "lib/cap/client.rb"
     - "lib/csl/mapper.rb"
-    - "lib/csl/role_mapper.rb"
-    - "lib/harvester/base.rb"
-    - "lib/notification_manager.rb"
-    - "lib/pubmed/client.rb"
-    - "lib/pubmed/harvester.rb"
     - "lib/smci_report.rb"
-    - "lib/web_of_science/harvester.rb"
-    - "lib/web_of_science/identifiers.rb"
-    - "lib/web_of_science/map_names.rb"
-    - "lib/web_of_science/map_pub_hash.rb"
-    - "lib/web_of_science/map_publisher.rb"
-    - "lib/web_of_science/process_pubmed.rb"
-    - "lib/web_of_science/process_records.rb"
-    - "lib/web_of_science/record.rb"
     - "script/*"
     - "spec/**/*"
 
 Metrics/PerceivedComplexity:
+  Max: 13
   Exclude:
     - "script/*"
 
@@ -122,9 +106,6 @@ Naming/VariableNumber:
   Exclude:
     - "spec/**/*"
     - "script/**/*"
-
-#Rails/Blank:
-#  UnlessPresent: false
 
 RSpec/NestedGroups:
   Max: 5

--- a/app/controllers/authorships_controller.rb
+++ b/app/controllers/authorships_controller.rb
@@ -157,7 +157,6 @@ class AuthorshipsController < ApplicationController
   # Publication.pub_hash field, breaking the elegant design of a RDBMS.
   # @return [Hash] the entire pub_hash, not just the contribution
   # @note contribution should be in the pub_hash[:authorship] array
-  # rubocop:disable Metrics/AbcSize
   def create_or_update_and_return_pub_hash(pub, author, authorship)
     contrib = pub.contributions.find_or_initialize_by(author_id: author.id)
     contrib.assign_attributes(authorship.merge(cap_profile_id: author.cap_profile_id, author_id: author.id))
@@ -176,7 +175,6 @@ class AuthorshipsController < ApplicationController
     end
     pub.pub_hash
   end
-  # rubocop:enable Metrics/AbcSize
 
   def get_cap_author!(cap_profile_id)
     author = Author.find_by(cap_profile_id: cap_profile_id) || Author.fetch_from_cap_and_create(cap_profile_id)

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -14,8 +14,6 @@ class PublicationsController < ApplicationController
   # GET /publications.json?capProfileId=1&changedSince=2018-01-01 # publications on this profile since that date
   # GET /publications.json?capActive=true                         # all publicatins for users active in cap
   # rubocop:disable Metrics/AbcSize
-  # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/PerceivedComplexity
   def index
     msg = 'Getting publications'
     msg += " for profile #{params[:capProfileId]}" if params[:capProfileId]
@@ -53,10 +51,8 @@ class PublicationsController < ApplicationController
       end
     end
   end
-  # rubocop:enable Metrics/AbcSize
-  # rubocop:enable Metrics/CyclomaticComplexity
-  # rubocop:enable Metrics/PerceivedComplexity
 
+  # rubocop:enable Metrics/AbcSize
   # return a specific publication
   # GET /publications/399607
   def show
@@ -73,7 +69,6 @@ class PublicationsController < ApplicationController
 
   # create a new manual publication by posting BibJSON (in body)
   # POST /publications
-  # rubocop:disable Metrics/AbcSize
   def create
     logger.info('POST Create:')
     logger.info(request_body)
@@ -96,7 +91,6 @@ class PublicationsController < ApplicationController
       render json: pub.pub_hash, status: :created
     end
   end
-  # rubocop:enable Metrics/AbcSize
 
   # update a publication by putting BibJSON (in body)
   # PUT /publications/1234

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -70,7 +70,6 @@ class Author < ApplicationRecord
 
   # Transforms an import setting to attributes.
   # @param [Hash] import_setting from the CAP API
-  # rubocop:disable Metrics/AbcSize
   def import_setting_to_attribs(import_setting)
     # required attributes
     attribs = {
@@ -85,7 +84,6 @@ class Author < ApplicationRecord
     attribs[:end_date] = import_setting['endDate']['value'] if import_setting['endDate'].present?
     attribs
   end
-  # rubocop:enable Metrics/AbcSize
 
   # Returns a string representing an author identity that can be compared another author identity.
   # @param [String] first_name First name of the author.
@@ -119,8 +117,6 @@ class Author < ApplicationRecord
   # @param [Hash<String => [String, Hash]>] auth_hash
   # @return [Hash<Symbol => String>]
   # rubocop:disable Metrics/AbcSize
-  # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/PerceivedComplexity
   def self.build_attribute_hash_from_cap_profile(auth_hash)
     # sunetid/ university id/ ca licence ---- at least one is expected
     seed_hash = {
@@ -148,10 +144,8 @@ class Author < ApplicationRecord
     seed_hash[:preferred_last_name] = seed_hash[:cap_last_name]
     seed_hash
   end
-  # rubocop:enable Metrics/AbcSize
-  # rubocop:enable Metrics/CyclomaticComplexity
-  # rubocop:enable Metrics/PerceivedComplexity
 
+  # rubocop:enable Metrics/AbcSize
   # @param [String] CAP Profile ID
   # @param [Cap::Client] cap_client
   # @return [Author] newly fetched, created and saved Author object
@@ -196,7 +190,6 @@ class Author < ApplicationRecord
   # do not match the provided attributes from an import setting.
   # @param [Hash<Symbol => String>] attribs the candidate versus `self`'s identity
   # @return [Boolean] Is this author's identity different than our current identity?
-  # rubocop:disable Metrics/AbcSize
   def author_identity_different?(attribs)
     !(
       # not the identical identity where Author is assumed to be Stanford University
@@ -208,5 +201,4 @@ class Author < ApplicationRecord
       institution.to_s.casecmp(attribs[:institution].to_s) == 0
     )
   end
-  # rubocop:enable Metrics/AbcSize
 end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -96,7 +96,6 @@ class Publication < ApplicationRecord
   end
 
   # @return [self]
-  # rubocop:disable Metrics/AbcSize
   def update_manual_pub_from_pub_hash(incoming_pub_hash, original_source_string)
     self.pub_hash = incoming_pub_hash.merge(provenance: Settings.cap_provenance)
     match = UserSubmittedSourceRecord.find_by_source_data(original_source_string)
@@ -113,7 +112,6 @@ class Publication < ApplicationRecord
     pubhash_needs_update! if persisted?
     self
   end
-  # rubocop:enable Metrics/AbcSize
 
   # @return [self]
   # @deprecated
@@ -275,8 +273,6 @@ class Publication < ApplicationRecord
   # Doesn't actually write the Pub to DB, presumed to be part of before_save callback or explicit save
   # Does delete pub_ids!
   # rubocop:disable Metrics/AbcSize
-  # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/PerceivedComplexity
   def sync_identifiers_in_pub_hash
     incoming_types = Array(pub_hash[:identifier]).pluck(:type)
     publication_identifiers.each do |id|
@@ -299,14 +295,11 @@ class Publication < ApplicationRecord
     end
     pub_hash[:identifier] = publication_identifiers.map(&:identifier)
   end
-  # rubocop:enable Metrics/AbcSize
-  # rubocop:enable Metrics/CyclomaticComplexity
-  # rubocop:enable Metrics/PerceivedComplexity
 
+  # rubocop:enable Metrics/AbcSize
   # NOTE: This method is only ever called from 'build_from_sciencewire_hash'
   #  It is preserved here for historical reasons but can be considered for possible removal when we remove Sciencewire harvesting
   #  It is duplicated by and used instead of in all other cases by lib/web_of_science/process_pubmed.rb#pubmed_addition
-  # rubocop:disable Metrics/AbcSize
   def add_any_pubmed_data_to_hash
     return if pmid.blank?
 
@@ -319,11 +312,7 @@ class Publication < ApplicationRecord
     pmc_id = pubmed_hash[:identifier].detect { |id| id[:type] == 'pmc' }
     pub_hash[:identifier] << pmc_id if pmc_id
   end
-  # rubocop:enable Metrics/AbcSize
 
-  # rubocop:disable Metrics/AbcSize
-  # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/PerceivedComplexity
   def update_any_new_contribution_info_in_pub_hash_to_db
     Array(pub_hash[:authorship]).each do |contrib|
       hash_for_update = contrib.slice(:status, :visibility, :featured).each do |_k, v|
@@ -352,7 +341,4 @@ class Publication < ApplicationRecord
     end
     true
   end
-  # rubocop:enable Metrics/AbcSize
-  # rubocop:enable Metrics/CyclomaticComplexity
-  # rubocop:enable Metrics/PerceivedComplexity
 end

--- a/app/models/pubmed_source_record.rb
+++ b/app/models/pubmed_source_record.rb
@@ -42,7 +42,6 @@ class PubmedSourceRecord < ApplicationRecord
     )
   end
 
-  # rubocop:disable Metrics/AbcSize
   def self.get_and_store_records_from_pubmed(pmids)
     pmidValuesForPost = pmids.uniq.collect { |pmid| "&id=#{pmid}" }.join
     the_incoming_xml = Pubmed.client.fetch_records_for_pmid_list pmidValuesForPost
@@ -61,7 +60,6 @@ class PubmedSourceRecord < ApplicationRecord
     end
     import source_records.compact
   end
-  # rubocop:enable Metrics/AbcSize
   private_class_method :get_and_store_records_from_pubmed
 
   # Retrieve this pubmed record from PubMed and update
@@ -231,9 +229,6 @@ class PubmedSourceRecord < ApplicationRecord
   #
   # @param author [Nokogiri::XML::Element] an <Author> element
   # @return [Hash<Symbol => String>] with keys :firstname, :middlename and :lastname
-  # rubocop:disable Metrics/AbcSize
-  # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/PerceivedComplexity
   def author_to_hash(author)
     # <Author> examples provide many variations at No. 20 from
     # https://www.nlm.nih.gov/bsd/licensee/elements_descriptions.html
@@ -294,7 +289,4 @@ class PubmedSourceRecord < ApplicationRecord
     # <AffiliationInfo> was added to <AuthorList> with the 2015 DTD.
     # The <AffiliationInfo> envelope element includes <Affliliation> and <Identifier>.
   end
-  # rubocop:enable Metrics/AbcSize
-  # rubocop:enable Metrics/CyclomaticComplexity
-  # rubocop:enable Metrics/PerceivedComplexity
 end

--- a/app/models/web_of_science_source_record.rb
+++ b/app/models/web_of_science_source_record.rb
@@ -34,8 +34,6 @@ class WebOfScienceSourceRecord < ApplicationRecord
 
   # Can initialize with either source_data String or record (WebOfScience::Record)
   # rubocop:disable Metrics/AbcSize
-  # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/PerceivedComplexity
   def extract
     # assume records are active until we discover a deprecation attribute
     self.active = true if attributes.key?('active') && attributes['active'].nil?
@@ -51,6 +49,4 @@ class WebOfScienceSourceRecord < ApplicationRecord
     self.pmid ||= record.pmid if record.pmid.present?
   end
   # rubocop:enable Metrics/AbcSize
-  # rubocop:enable Metrics/CyclomaticComplexity
-  # rubocop:enable Metrics/PerceivedComplexity
 end

--- a/lib/agent/author_address.rb
+++ b/lib/agent/author_address.rb
@@ -20,7 +20,6 @@ module Agent
       @country = options[:country].to_s.strip
     end
 
-    # rubocop:disable Metrics/AbcSize
     def to_xml
       @xml ||= begin
         xml = ''
@@ -32,7 +31,6 @@ module Agent
         xml
       end
     end
-    # rubocop:enable Metrics/AbcSize
 
     def ==(other)
       line1 == other.line1 &&

--- a/lib/bibtex_identifiers.rb
+++ b/lib/bibtex_identifiers.rb
@@ -62,7 +62,6 @@ class BibtexIdentifiers
 
   # A mutable Hash of the identifiers
   # @return [Hash<String => String>]
-  # rubocop:disable Metrics/AbcSize
   def to_h
     hash = {}
     if doi.present?
@@ -83,10 +82,8 @@ class BibtexIdentifiers
     end
     hash
   end
-  # rubocop:enable Metrics/AbcSize
 
   # @return [Array<Hash>]
-  # rubocop:disable Metrics/AbcSize
   def pub_hash
     ids = []
     ids << { type: 'doi',  id: doi,  url: doi_uri  } if doi.present?
@@ -95,7 +92,6 @@ class BibtexIdentifiers
     ids << { type: 'pmid', id: pmid, url: pmid_uri } if pmid.present?
     ids
   end
-  # rubocop:enable Metrics/AbcSize
 
   private
 
@@ -103,7 +99,6 @@ class BibtexIdentifiers
 
   # @param [BibTeX::Entry] record
   # @return [void]
-  # rubocop:disable Metrics/AbcSize
   def extract_ids(record)
     @ids = {}
     doi = extract_id(record, 'doi')
@@ -116,7 +111,6 @@ class BibtexIdentifiers
     ids['pmid'] = pmid if pmid.present?
     ids.freeze
   end
-  # rubocop:enable Metrics/AbcSize
 
   # @param [BibTeX::Entry] record
   # @param [String] type

--- a/lib/bibtex_ingester.rb
+++ b/lib/bibtex_ingester.rb
@@ -9,8 +9,6 @@ class BibtexIngester
   INPROCEEDINGS_TYPE_MAPPING = %w[conference proceedings inproceedings].freeze
 
   # rubocop:disable Metrics/AbcSize
-  # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/PerceivedComplexity
   def ingest_from_source_directory(directory)
     @batch_dir = directory || Settings.BIBTEX.IMPORT.DIR
     @bibtex_import_logger = Logger.new(Settings.BIBTEX.IMPORT.LOG)
@@ -78,11 +76,8 @@ class BibtexIngester
     @bibtex_import_logger.info "#{@total_deduped_count} total records were deduplicated against sw or pubmed pubs."
     @bibtex_import_logger.info "#{@total_new_pubs} new publication records were created."
   end
-  # rubocop:enable Metrics/AbcSize
-  # rubocop:enable Metrics/CyclomaticComplexity
-  # rubocop:enable Metrics/PerceivedComplexity
 
-  # rubocop:disable Metrics/AbcSize
+  # rubocop:enable Metrics/AbcSize
   def process_bibtex_file(file_full_path, _batch_name, bibtex_file_name)
     sunet_id = File.basename(bibtex_file_name, '.*')
 
@@ -125,10 +120,7 @@ class BibtexIngester
     end
   end
 
-  # rubocop:enable Metrics/AbcSize
   # rubocop:disable Metrics/AbcSize
-  # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/PerceivedComplexity
   def process_record(record, author)
     pub = nil
 
@@ -190,11 +182,8 @@ class BibtexIngester
     @bibtex_import_logger.info "Error: #{e.message}"
     @total_faulty_record_count += 1
   end
-  # rubocop:enable Metrics/AbcSize
-  # rubocop:enable Metrics/CyclomaticComplexity
-  # rubocop:enable Metrics/PerceivedComplexity
 
-  # rubocop:disable Metrics/AbcSize
+  # rubocop:enable Metrics/AbcSize
   # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/PerceivedComplexity
   def find_existing_pub(record)
@@ -228,7 +217,6 @@ class BibtexIngester
     @total_deduped_count += 1 if pub
     pub
   end
-  # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/CyclomaticComplexity
   # rubocop:enable Metrics/PerceivedComplexity
 

--- a/lib/cap/authors_poller.rb
+++ b/lib/cap/authors_poller.rb
@@ -13,7 +13,6 @@ module Cap
       init_stats
     end
 
-    # rubocop:disable Metrics/AbcSize
     def get_authorship_data(days_ago = 1)
       @start_time = Time.zone.now
       logger.info "Started CAP authorship import - #{@start_time}"
@@ -42,7 +41,6 @@ module Cap
     rescue StandardError => e
       NotificationManager.error(e, 'Authorship import failed', self)
     end
-    # rubocop:enable Metrics/AbcSize
 
     def cap_authors_count(days_ago = 1)
       json_response = get_recent_cap_authorship(1, 10, days_ago)
@@ -92,7 +90,6 @@ module Cap
       end
     end
 
-    # rubocop:disable Metrics/AbcSize
     def update_existing_contributions(author, incoming_authorships)
       incoming_authorships.each do |authorship|
         unless Contribution.valid_fields? authorship
@@ -117,7 +114,6 @@ module Cap
         update_existing_contribution(contribs.first, authorship)
       end
     end
-    # rubocop:enable Metrics/AbcSize
 
     def update_existing_contribution(contribution, authorship)
       hash_for_update = {
@@ -178,7 +174,6 @@ module Cap
       distance_of_time_in_words(@start_time, Time.zone.now)
     end
 
-    # rubocop:disable Metrics/AbcSize
     def log_stats
       info = []
       info << 'FINAL TOTAL STATS:'
@@ -198,7 +193,6 @@ module Cap
       info << "~#{Contribution.where('created_at >= ?', @start_time).count} contributions were created."
       logger.info info.join("\n")
     end
-    # rubocop:enable Metrics/AbcSize
 
     def process_record_for_existing_author(author, record)
       logger.info "Updating Author.find_by(id: #{author.id}, cap_profile_id: #{author.cap_profile_id})"

--- a/lib/cap/client.rb
+++ b/lib/cap/client.rb
@@ -41,7 +41,6 @@ module Cap
     end
 
     # @return [String] bearer access token
-    # rubocop:disable Metrics/AbcSize
     def access_token
       @access_token = nil if @access_expiry.to_i < Time.zone.now.to_i
       @access_token ||= begin
@@ -54,8 +53,6 @@ module Cap
         "Bearer #{token}"
       end
     end
-    # rubocop:enable Metrics/AbcSize
-
     ####################################################################################
     # CAP client connection settings
     #

--- a/lib/cap/profile_id_rewriter.rb
+++ b/lib/cap/profile_id_rewriter.rb
@@ -30,7 +30,6 @@ module Cap
 
     # @param [Integer] starting the "page" of results to start from
     # @return [void]
-    # rubocop:disable Metrics/AbcSize
     def rewrite_cap_profile_ids_from_feed(starting = 0)
       logger.info "Started cap profile id rewrite at #{start_time}"
       logger.info 'CAP API client config: '
@@ -47,7 +46,6 @@ module Cap
     ensure
       write_counts_to_log
     end
-    # rubocop:enable Metrics/AbcSize
 
     private
 
@@ -83,9 +81,6 @@ module Cap
     # @param [Integer] page
     # @param [Integer] page_size
     # @return [Boolean] true when JSON response indicates 'lastPage'
-    # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/PerceivedComplexity
     def process_next_batch_of_authorship_data(page, page_size)
       json_response = client.get_batch_from_cap_api(page, page_size, nil)
       if json_response['values'].blank?
@@ -116,8 +111,5 @@ module Cap
       end
       json_response['lastPage']
     end
-    # rubocop:enable Metrics/AbcSize
-    # rubocop:enable Metrics/CyclomaticComplexity
-    # rubocop:enable Metrics/PerceivedComplexity
   end
 end

--- a/lib/csl/cap_mapper.rb
+++ b/lib/csl/cap_mapper.rb
@@ -47,7 +47,6 @@ module Csl
       private
 
       # @return [Hash] CSL publication title, abstract, date, pages, etc.
-      # rubocop:disable Metrics/AbcSize
       def extract_pub_info(pub_hash)
         map = {}
         map['title'] = pub_hash[:title] if pub_hash[:title].present?
@@ -57,7 +56,6 @@ module Csl
         map['page'] = pub_hash[:pages] if pub_hash[:pages].present?
         map
       end
-      # rubocop:enable Metrics/AbcSize
 
       # @return [Hash] CSL author, editor, and publisher data
       def extract_agents(pub_hash, authors, editors)

--- a/lib/csl/role_mapper.rb
+++ b/lib/csl/role_mapper.rb
@@ -4,7 +4,6 @@ module Csl
   class RoleMapper
     class << self
       # Parse authors
-      # rubocop:disable Metrics/AbcSize
       def authors(pub_hash)
         return [] if pub_hash[:author].blank?
 
@@ -30,7 +29,6 @@ module Csl
           parse_authors(authors)
         end
       end
-      # rubocop:enable Metrics/AbcSize
 
       # Parse editors for various provenance data:
       def editors(pub_hash)

--- a/lib/harvester/base.rb
+++ b/lib/harvester/base.rb
@@ -10,7 +10,6 @@ module Harvester
   class Base
     # @param [Hash] options
     # @return [void]
-    # rubocop:disable Metrics/AbcSize
     def harvest_all(options = {})
       total = authors_query.count
       count = 0
@@ -26,7 +25,6 @@ module Harvester
       time_taken = Time.at(end_time - start_time).utc.strftime '%e days, %H hours, %M minutes'
       logger.info "***** Ended a complete harvest for #{total} authors at #{end_time}.  Time taken: #{time_taken}"
     end
-    # rubocop:enable Metrics/AbcSize
 
     # @param [Enumerable<Author>] authors
     # @param [Hash] options

--- a/lib/pubmed/client.rb
+++ b/lib/pubmed/client.rb
@@ -4,7 +4,6 @@ module Pubmed
   class Client
     # @param [String, Array<String>] pmids PubMed ID or IDs
     # @return [String] HTTP response body
-    # rubocop:disable Metrics/AbcSize
     def fetch_records_for_pmid_list(pmids)
       pmid_list = Array(pmids)
       pmidValuesForPost = pmid_list.collect { |pmid| "&id=#{pmid}" }.join
@@ -17,7 +16,6 @@ module Pubmed
       NotificationManager.error(e, "#{e.class.name} during PubMed Fetch API call", self)
       raise
     end
-    # rubocop:enable Metrics/AbcSize
 
     # @param [String] term to search on, excluding term=
     # @return [String] HTTP response body

--- a/lib/pubmed/fetcher.rb
+++ b/lib/pubmed/fetcher.rb
@@ -19,7 +19,6 @@ module Pubmed
 
     # @param [String] pmid Pubmed ID
     # @return [Array<Hash>] pub_hashes or an empty Array
-    # rubocop:disable Metrics/AbcSize
     def self.fetch_remote_pubmed(pmid)
       # NOTE: only works because all results expected to fit inside one "batch"
       if Settings.WOS.enabled
@@ -35,7 +34,6 @@ module Pubmed
         add_citation(PubmedSourceRecord.new.source_as_hash(doc))
       end
     end
-    # rubocop:enable Metrics/AbcSize
     private_class_method :fetch_remote_pubmed
 
     # @param [Hash] pub_hash modifies passed hash to include citation k/v pairs

--- a/lib/pubmed/harvester.rb
+++ b/lib/pubmed/harvester.rb
@@ -10,7 +10,6 @@ module Pubmed
     # @param [Author] author
     # @param [Hash] _options
     # @return [Array<String>] pmids that create Publications
-    # rubocop:disable Metrics/AbcSize
     def process_author(author, options = {})
       return unless Settings.PUBMED.harvest_enabled
       raise(ArgumentError, 'author must be an Author') unless author.is_a? Author
@@ -38,7 +37,6 @@ module Pubmed
     rescue StandardError => e
       NotificationManager.error(e, "#{self.class} - Pubmed harvest failed for author #{author.id}", self)
     end
-    # rubocop:enable Metrics/AbcSize
 
     private
 

--- a/lib/web_of_science/harvester.rb
+++ b/lib/web_of_science/harvester.rb
@@ -10,7 +10,6 @@ module WebOfScience
     # @param [Author] author
     # @param [Hash] options
     # @return [Array<String>] WosUIDs that create Publications
-    # rubocop:disable Metrics/AbcSize
     def process_author(author, options = {})
       raise(ArgumentError, 'author must be an Author') unless author.is_a? Author
 
@@ -37,7 +36,6 @@ module WebOfScience
     rescue StandardError => e
       NotificationManager.error(e, "#{self.class} - WoS harvest failed for author #{author.id}", self)
     end
-    # rubocop:enable Metrics/AbcSize
 
     # Harvest WOS-UID publications for an author
     # @param author [Author]

--- a/lib/web_of_science/identifiers.rb
+++ b/lib/web_of_science/identifiers.rb
@@ -90,7 +90,6 @@ module WebOfScience
 
     # A mutable Hash of the identifiers
     # @return [Hash<String => String>]
-    # rubocop:disable Metrics/AbcSize
     def to_h
       hash = { 'WosUID' => uid }
       if doi.present?
@@ -127,7 +126,6 @@ module WebOfScience
       ids << { type: 'WosUID', id: uid }
       ids
     end
-    # rubocop:enable Metrics/AbcSize
 
     # @return [String, nil]
     def wos_item_id

--- a/lib/web_of_science/map_names.rb
+++ b/lib/web_of_science/map_names.rb
@@ -75,8 +75,6 @@ module WebOfScience
 
     # Parse the MEDLINE names and return a Hash compatible with Csl::AuthorName
     # @return [Hash]
-    # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/CyclomaticComplexity
     def medline_name(name)
       # full_name has the form "LastName, GivenName" where GivenName is space delimited
       # display_name and full_name are often, if not always, the same
@@ -94,11 +92,8 @@ module WebOfScience
       name
     end
 
-    # rubocop:enable Metrics/AbcSize
-    # rubocop:enable Metrics/CyclomaticComplexity
     # Parse the WOS names and return a Hash compatible with Csl::AuthorName
     # @return [Hash]
-    # rubocop:disable Metrics/AbcSize
     def wos_name(name)
       # look for the case where the first_name is the initials, with first and middle initials combined
       # e.g. first_name = "RB", should be first_name = "R", middle_name = "B"
@@ -119,6 +114,5 @@ module WebOfScience
       name[:name] = "#{name[:last_name] || name[:display_name] || name[:full_name]},#{name[:first_name]},#{name[:middle_name]}"
       name
     end
-    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/lib/web_of_science/map_pub_hash.rb
+++ b/lib/web_of_science/map_pub_hash.rb
@@ -17,7 +17,6 @@ module WebOfScience
 
     # Extract content from record, try not to hang onto the entire record
     # @param rec [WebOfScience::Record]
-    # rubocop:disable Metrics/AbcSize
     def extract(rec)
       @pub = WebOfScience::MapAbstract.new(rec).pub_hash
       pub.update WebOfScience::MapNames.new(rec).pub_hash
@@ -28,7 +27,6 @@ module WebOfScience
       pub.update WebOfScience::MapMesh.new(rec).pub_hash
       pub.update Csl::Citation.new(pub).citations
     end
-    # rubocop:enable Metrics/AbcSize
 
     # publication document types and categories
     def pub_hash_doctypes(rec)
@@ -46,7 +44,6 @@ module WebOfScience
     end
 
     # publication identifiers
-    # rubocop:disable Metrics/AbcSize
     def pub_hash_identifiers(rec)
       ids = rec.identifiers
       id = {
@@ -61,6 +58,5 @@ module WebOfScience
       id[:wos_item_id] = ids.wos_item_id if ids.wos_item_id.present?
       id
     end
-    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/lib/web_of_science/map_publisher.rb
+++ b/lib/web_of_science/map_publisher.rb
@@ -32,8 +32,6 @@ module WebOfScience
       country.present? ? country.text : ''
     end
 
-    # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/CyclomaticComplexity
     def extract_publishers(rec)
       publishers = rec.doc.search('static_data/summary/publishers/publisher').map do |publisher|
         # parse the publisher address(es)
@@ -55,8 +53,6 @@ module WebOfScience
       publishers.flatten
     end
 
-    # rubocop:enable Metrics/AbcSize
-    # rubocop:enable Metrics/CyclomaticComplexity
     # Extract publisher information into these fields:
     # :publisher=>"OXFORD UNIV PRESS"
     # :city=>"OXFORD"

--- a/lib/web_of_science/process_pubmed.rb
+++ b/lib/web_of_science/process_pubmed.rb
@@ -7,9 +7,7 @@ module WebOfScience
   module ProcessPubmed
     # For WOS-records with a PMID, try to enhance them with PubMed data
     # @param [Array<WebOfScience::Record>] records
-    # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/PerceivedComplexity
     def pubmed_additions(records)
       raise(ArgumentError, 'records must be Enumerable') unless records.is_a? Enumerable
       raise(ArgumentError, 'records must contain WebOfScience::Record') unless records.all? do |rec|
@@ -34,17 +32,12 @@ module WebOfScience
     rescue StandardError => e
       NotificationManager.error(e, 'pubmed_additions failed', self)
     end
-    # rubocop:enable Metrics/AbcSize
-    # rubocop:enable Metrics/CyclomaticComplexity
-    # rubocop:enable Metrics/PerceivedComplexity
 
+    # rubocop:enable Metrics/CyclomaticComplexity
     # For WOS-record that has a PMID, fetch data from PubMed and enhance the pub.pub_hash with PubMed data
     # but don't do anything if pubmed looksups are disabled.
     # @param [Publication] pub is a Publication with a .pmid value
     # @return [void]
-    # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/PerceivedComplexity
     def pubmed_addition(pub)
       raise(ArgumentError, 'pub must be Publication') unless pub.is_a? Publication
       return unless Settings.PUBMED.lookup_enabled
@@ -66,9 +59,6 @@ module WebOfScience
     rescue StandardError => e
       NotificationManager.error(e, "pubmed_addition failed for args: #{pmid}, #{pub}", self)
     end
-    # rubocop:enable Metrics/AbcSize
-    # rubocop:enable Metrics/CyclomaticComplexity
-    # rubocop:enable Metrics/PerceivedComplexity
 
     # For WOS-record that has a PMID, cleanup our data when it does not exist on PubMed;
     # but don't do anything if the Pubmed::Client is not working.

--- a/lib/web_of_science/process_records.rb
+++ b/lib/web_of_science/process_records.rb
@@ -49,9 +49,6 @@ module WebOfScience
     end
 
     # @return [Array<String>] WosUIDs that successfully create a new Publication
-    # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/PerceivedComplexity
     def create_publications
       return [] if records.empty?
 
@@ -74,14 +71,10 @@ module WebOfScience
     ensure
       pubmed_additions(records)
     end
-    # rubocop:enable Metrics/AbcSize
-    # rubocop:enable Metrics/CyclomaticComplexity
-    # rubocop:enable Metrics/PerceivedComplexity
 
     # Save new WebOfScienceSourceRecords.  This method guarantees to all subsequent processing
     # that each WOS uid in @records now has a WebOfScienceSourceRecord.
     # @return [Array<WebOfScienceSourceRecord>] all matching or created records
-    # rubocop:disable Metrics/AbcSize
     def save_wos_records
       return [] if records.empty?
 
@@ -97,7 +90,6 @@ module WebOfScience
       end
       already_fetched_recs + WebOfScienceSourceRecord.create!(batch)
     end
-    # rubocop:enable Metrics/AbcSize
 
     # Also creates Contribution and links WebOfScienceSourceRecord
     # @param [WebOfScience::Record] record

--- a/lib/web_of_science/query_author.rb
+++ b/lib/web_of_science/query_author.rb
@@ -60,7 +60,6 @@ module WebOfScience
     #     - the actual values it accepts are any value of "Nweek" for 1 <= N <= 52, or "Nyear" for 1 <= N <= 10
     #
     # @return [Hash]
-    # rubocop:disable Metrics/AbcSize
     def author_query
       params = queries.params_for_fields(empty_fields)
       params[:queryParameters][:userQuery] =
@@ -73,7 +72,6 @@ module WebOfScience
       end
       params
     end
-    # rubocop:enable Metrics/AbcSize
 
     # @param [Array<String>] terms
     # @param [Array<String>] the same terms, minus any empties or duplicates, wrapped in double quotes

--- a/lib/web_of_science/retriever.rb
+++ b/lib/web_of_science/retriever.rb
@@ -80,7 +80,6 @@ module WebOfScience
     # Fetch the first batch of results.  The first query-response is special; it's the only
     # response that contains the entire query response metadata, with query_id and records_found.
     # @return [WebOfScience::Records]
-    # rubocop:disable Metrics/AbcSize
     def batch_one
       @batch_one ||= begin
         response = client.search.call(operation, message: query)
@@ -91,7 +90,6 @@ module WebOfScience
         records
       end
     end
-    # rubocop:enable Metrics/AbcSize
 
     # The retrieve operation is different from the first query, because it uses
     # a query_id and a :retrieve operation to retrieve additional records


### PR DESCRIPTION
## Why was this change made?
* Existing settings were too restrictive for typical coding practice.
* To be consistent with dor-services-app.

Note that these were all autocorrect changes.

## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
.rubocop.yml


