### PR TITLE
remove another unused method

### DIFF
--- a/lib/agent/author_name.rb
+++ b/lib/agent/author_name.rb
@@ -50,10 +50,6 @@ module Agent
     # an 'or' conjuction is likely to generate results that mostly match this variant,
     # but additional variants might add something when using an 'ExactMatch' search.
     # @return [String] name(s) to be queried in an OR (disjunction) query
-    def text_search_query
-      text_search_terms.map { |x| "\"#{x}\"" }.join(' or ')
-    end
-
     def text_search_terms
       @text_search_terms ||=
         [first_name_query, middle_name_query].flatten.reject(&:empty?).uniq

--- a/spec/lib/agent/author_name_spec.rb
+++ b/spec/lib/agent/author_name_spec.rb
@@ -118,17 +118,6 @@ describe Agent::AuthorName do
     end
   end
 
-  describe '#text_search_query' do
-    context 'when all names are present' do
-      # additional SW specs are in publication_query_by_author_name_spec.rb
-      it 'includes first_name_query and middle_name_query elements' do
-        allow(all_names).to receive(:first_name_query).and_return(%w[abc def])
-        allow(all_names).to receive(:middle_name_query).and_return(%w[qrs xyz])
-        expect(all_names.text_search_query).to eq '"abc" or "def" or "qrs" or "xyz"'
-      end
-    end
-  end
-
   describe '#text_search_terms' do
     it 'includes first_name_query and middle_name_query elements' do
       fnames = all_names.send(:first_name_query)


### PR DESCRIPTION
## Why was this change made?

Found another unused method (only called from a unit test)

```
$ git grep text_search_query
lib/agent/author_name.rb:    def text_search_query
spec/lib/agent/author_name_spec.rb:  describe '#text_search_query' do
spec/lib/agent/author_name_spec.rb:        expect(all_names.text_search_query).to eq '"abc" or "def" or "qrs" or "xyz"'
```

## How was this change tested?



## Which documentation and/or configurations were updated?



