### PR TITLE
Document / validate pub_hash

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'identifiers', '~> 0.12'
 # To use Jbuilder templates for JSON
 gem 'jbuilder'
 gem 'jquery-rails'
+gem 'json_schemer'
 gem 'kaminari'
 gem 'okcomputer' # for monitoring
 gem 'oauth2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,6 +188,8 @@ GEM
       dry-equalizer (~> 0.2)
       dry-initializer (~> 3.0)
       dry-schema (~> 1.5, >= 1.5.2)
+    ecma-re-validator (0.3.0)
+      regexp_parser (~> 2.0)
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     erubi (1.10.0)
@@ -212,6 +214,7 @@ GEM
       activesupport (>= 4.2.0)
     gyoku (1.3.1)
       builder (>= 2.1.2)
+    hana (1.3.7)
     hashdiff (1.0.1)
     hashie (4.1.0)
     honeybadger (4.8.0)
@@ -230,6 +233,11 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    json_schemer (0.2.18)
+      ecma-re-validator (~> 0.3)
+      hana (~> 1.3)
+      regexp_parser (~> 2.0)
+      uri_template (~> 0.7)
     jwt (2.2.3)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
@@ -446,6 +454,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     unicode (0.4.4.4)
     unicode-display_width (2.0.0)
+    uri_template (0.7.0)
     urn (2.0.2)
     vcr (6.0.0)
     wasabi (3.6.1)
@@ -506,6 +515,7 @@ DEPENDENCIES
   identifiers (~> 0.12)
   jbuilder
   jquery-rails
+  json_schemer
   kaminari
   listen (>= 3.0.5, < 3.2)
   mysql2 (~> 0.5, < 0.5.3)

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class Publication < ApplicationRecord
+  include ActiveModel::Validations
+
+  validates_with PublicationValidator
+
   has_paper_trail on: [:destroy]
   scope :with_active_author, -> { joins(:authors).where('authors.active_in_cap' => true).distinct }
 

--- a/app/models/pubmed_source_record.rb
+++ b/app/models/pubmed_source_record.rb
@@ -280,7 +280,7 @@ class PubmedSourceRecord < ApplicationRecord
       firstname: fn,
       middlename: mn,
       lastname: lastname
-    }
+    }.compact
     # TODO: extract Identifier
     # <Identifier> was added to <AuthorList> with the 2010 DTD, but was not used until 2013.
     # <Identifier Source="ORCID">0000000179841889</Identifier>

--- a/app/validators/publication_validator.rb
+++ b/app/validators/publication_validator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class PublicationValidator < ActiveModel::Validator
+  def validate(record)
+    PubHashValidator.validate(record.pub_hash).each { |error| record.errors.add :pub_hash, error }
+  end
+end

--- a/lib/bibtex_ingester.rb
+++ b/lib/bibtex_ingester.rb
@@ -303,7 +303,8 @@ class BibtexIngester
 
     if record['series']
       book_series_hash = {}
-      book_series_hash[:identifier] = [issn_for_id_array]
+      book_series_identifiers = [issn_for_id_array].compact
+      book_series_hash[:identifier] = book_series_identifiers if book_series_identifiers.present?
       book_series_hash[:title] = record.series.to_s.strip  if record['series'].present?
       book_series_hash[:volume] = record.volume.to_s.strip if record['volume'].present?
       book_series_hash[:month] = record.month.to_s.strip if record['month'].present?

--- a/lib/pub_hash_validator.rb
+++ b/lib/pub_hash_validator.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'json_schemer'
+require 'yaml'
+
+# Validates a pub_hash against JSON schema.
+class PubHashValidator
+  @@schemer = JSONSchemer.schema(YAML.safe_load(File.read(Rails.root.join('pub_hash_schema.yml'))))
+
+  # @param [Hash] pub_hash
+  # @return [Boolean] true if valid
+  def self.valid?(pub_hash)
+    @@schemer.valid?(pub_hash.with_indifferent_access)
+  end
+
+  # @param [Hash] pub_hash
+  # @return [Array<String>] errors
+  def self.validate(pub_hash)
+    @@schemer.validate(pub_hash.with_indifferent_access).map do |error|
+      if error.key?('details')
+        "Invalid with details: #{error['details']}"
+      else
+        "#{error['data_pointer']} with value #{error['data']} is invalid for schema: #{error['schema_pointer']}"
+      end
+    end
+  end
+end

--- a/pub_hash_schema.yml
+++ b/pub_hash_schema.yml
@@ -1,0 +1,450 @@
+title: pub_hash
+description: Metadata for a SUL-PUB publication
+type: object
+properties:
+  abstract:
+    type: string
+  abstract_restricted:
+    type: string
+  additionalProperties: # Legacy. Not in current code.
+    type: object
+  apa_citation: # Automatically added.
+    type: string
+  articlenumber: # Legacy. Not in current code.
+    type:
+      - string
+      - "null"
+  author:
+    type: array
+    items:
+      $ref: '#/$defs/Author'
+  authorcount:
+    type:
+      - string
+      - integer
+  authorship: # Automatically added.
+    type: array
+    items:
+      $ref: '#/$defs/Authorship'
+  booktitle:
+    type: string
+  city:
+    type: string
+  chicago_citation: # Automatically added.
+    type: string
+  conference:
+    $ref: '#/$defs/Conference'
+  country:
+    type:
+      - string
+      - "null"
+  date:
+    type: string
+  documentcategory_sw: # From sciencewire, wos
+    type: string
+  documenttypes_sw: # From sciencewire, wos
+    type: array
+    items:
+      type: string
+  doi:
+    type: string
+  eissn:
+    type: string
+  etal: # Legacy. Not in current code.
+    type: boolean
+  identifier:
+    type: array
+    items:
+      $ref: '#/$defs/Identifier'
+  isbn:
+    type: string
+  issn:
+    type: string
+  journal:
+    $ref: '#/$defs/Journal'
+  last_updated: # Automatically added.
+    type: string
+  mesh_headings:
+    type: array
+    items:
+      $ref: '#/$defs/MeshHeading'
+  mla_citation: # Automatically added
+    type: string
+  pages:
+    type: string
+  pmid:
+    description: PubMed identifier
+    type: string
+  provenance:
+    description: Source of the record that the pub_hash was generated from.
+    type: string
+    enum:
+      - batch
+      - cap
+      - pubmed
+      - sciencewire
+      - wos
+  publicationSource: # Legacy. Not in current code.
+    type:
+      - string
+      - "null"
+  publicationUrl: # Legacy. Not in current code.
+    type:
+      - string
+      - "null"
+  publicationUrlLabel: # Legacy. Not in current code.
+    type:
+      - string
+      - "null"
+  publisher:
+    type: string
+  stateprovince:
+    type:
+      - string
+      - "null"
+  sulpubid:
+    description: Identifier for the publication in the SUL system.
+    type: string
+  sw_id:
+    description: ScienceWire identifier
+    type: string
+  title:
+    type: string
+  type: # Required, but missing in existing data.
+    description: Type of publication
+    type:
+      - string
+      - "null"
+    enum:
+      - article
+      - book
+      - caseStudy # Legacy. Not in current code.
+      - inproceedings
+      - inbook # Legacy. Not in current code.
+      - otherpaper # Legacy. Not in current code.
+      - otherPaper # Legacy. Not in current code.
+      - technicalReport # Legacy. Not in current code.
+      - workingPaper # Legacy. Not in current code.
+      - null # Legacy. Not in current code.
+  wos_item_id:
+    type: string
+  wos_uid:
+    type: string
+  year:
+    type: string
+  # Sciencewire-specific
+  authorcitationcountlist_sw:
+    type: string
+  keywords_sw:
+    type: array
+    items:
+      type: string
+  isobsolete_sw:
+    type: string
+  newpublicationid_sw:
+    type: string
+  normalizedrank_sw:
+    type: string
+  numberofreferences_sw:
+    type: string
+  ordinalrank_sw:
+    type: string
+  publicationimpactfactorlist_sw:
+    type: array
+    items:
+      type: string
+  publicationcategoryrankinglist_sw:
+    type: array
+    items:
+      type: string
+  rank_sw:
+    type: string
+  timenotselfcited_sw:
+    type: string
+  timescited_sw_retricted:
+    type: string
+  # Bibtex ingester specific
+  address:
+    type: string
+  allAuthors:
+    type: string
+  bibtex_type:
+    type: string
+  chapter:
+    type: string
+  edition:
+    type: string
+  editor:
+    type: string
+  howpublished:
+    type: string
+  series:
+    $ref: '#/$defs/Series'
+additionalProperties: false
+$defs:
+  Author:
+    type: object
+    properties:
+      additionalProperties: # Legacy. Not in current code.
+        type: object
+      alternate: # Legacy. Not in current code.
+        type: array
+      display_name: # From wos
+        type: string
+      first_name: # From wos
+        type: string
+      firstname: # From pubmed
+        type:
+          - string
+          - "null" # Existing data has null values.
+      full_name: # From wos
+        type:
+          - string
+          - "null" # Existing data has null values.
+      given_name: # From wos
+        type:
+          - string
+          - "null"
+      initials: # From wos
+        type: string
+      middle_name: # From wos
+        type: string
+      middlename: # From pubmed
+        type:
+          - string
+          - "null" # Existing data has null values.
+      last_name: # From wos
+        type: string
+      lastname: # From pubmed
+        type:
+          - string
+          - "null" # Existing data has null values.
+      name: # From sciencewire, wos
+        type: string
+      role: # From wos
+        type:
+          - string
+          - "null"
+    additionalProperties: false
+  Authorship:
+    description: Stanford affiliated author.
+    type: object
+    properties:
+      cap_profile_id:
+        description: Identifier for the author in the CAP system.
+        type: integer
+      sul_author_id:
+        description: Identifier for the author in the SUL system.
+        type: integer
+      featured:
+        description: Marks the publication for featured presentation.
+        type: boolean
+      status:
+        description: Marks the status of the publication. UNKNOWN indicates legacy data.
+        type:
+          - string
+          - "null"
+        enum:
+          - new
+          - approved
+          - denied
+          - unknown
+          - APPROVED # Bad value in existing data
+          - null # Bad value in existing data
+      visibility:
+        description: Indicates whether this author would like to freely display the publication, only show it at Stanford, or hide it.
+        type:
+          - string
+          - "null"
+        enum:
+          - private
+          - stanford
+          - public
+          - PRIVATE # Bad value in existing data
+          - PUBLIC # Bad value in existing data
+          - null # Bad value in existing data
+    required:
+      - featured
+      - status
+      - visibility
+    additionalProperties: false
+  Conference:
+    type: object
+    properties:
+      additionalProperties: # Legacy. Not in current code.
+        type: object
+      city:
+        type:
+          - string
+          - "null"
+      doi: # Legacy. Not in current code.
+        type:
+          - string
+          - "null"
+      enddate:
+        type:
+          - string
+          - "null"
+      location: # Legacy. Not in current code.
+        type:
+          - string
+          - "null"
+      name:
+        type:
+          - string
+          - "null"
+      number: # Legacy. Not in current code.
+        type:
+          - string
+          - "null"
+      organization: # From bibtex indexer
+        type:
+          - string
+          - "null"
+      startdate:
+        type:
+          - string
+          - "null"
+      statecountry:
+        type:
+          - string
+          - "null"
+      year:
+        type:
+          - string
+          - "null"
+    additionalProperties: false
+  Identifier:
+    type: object
+    properties:
+      id:
+        type: string
+      type:
+        type: string
+      url:
+        type: string
+    required:
+      - type
+    additionalProperties: false
+  Journal:
+    type: object
+    properties:
+      additionalProperties: # Legacy. Not in current code.
+        type: object
+      articlenumber:
+        type:
+          - string
+          - "null"
+      articleNumber: # Legacy. Not in current code.
+        type:
+          - string
+          - "null"
+          - integer
+      issue:
+        type:
+          - string
+          - "null"
+      identifier:
+        type: array
+        items:
+          $ref: '#/$defs/Identifier'
+      month: # From bibtex indexer
+        type: string
+      name:
+        type:
+          - string
+          - "null"
+      number: # Legacy. Not in current code.
+        type:
+          - string
+          - "null"
+      pages:
+        type:
+          - string
+          - "null"
+          - number # Legacy. Not in current code.
+      specialissue: # Legacy. Not in current code.
+        type:
+          - string
+          - "null"
+          - boolean
+      supplement: # Legacy. Not in current code.
+        type:
+          - string
+          - "null"
+      volume:
+        type:
+          - string
+          - "null"
+          - number # Existing bad data.
+      year: # Legacy. Not in current code.
+        type:
+          - string
+          - "null"
+    additionalProperties: false
+  MeshHeading:
+    type: object
+    properties:
+      descriptor:
+        type: array
+        items:
+          type: object
+          properties:
+            major:
+              type: string
+            name:
+              type: string
+            id:
+              type: string
+          additionalProperties: false
+      qualifier:
+        type: array
+        items:
+          type: object
+          properties:
+            major:
+              type: string
+            name:
+              type: string
+            id:
+              type: string
+          additionalProperties: false
+      treecode:
+        type: array
+        items:
+          type: object
+          properties:
+            code:
+              type: string
+            major:
+              type: string
+          additionalProperties: false
+    additionalProperties: false
+  Series:
+    type: object
+    properties:
+      identifier:
+        type: array
+        oneOf:
+          - type: array
+            items:
+              $ref: '#/$defs/Identifier'
+            minItems: 1
+          - type: array # Existing bad data.
+            items:
+              type: "null"
+            minItems: 1
+          - type: array # Existing bad data.
+            maxItems: 0
+      title:
+        type:
+          - string
+          - "null"
+      month:
+        type:
+          - string
+          - "null"
+      volume:
+        type:
+          - string
+          - "null"

--- a/spec/controllers/publications_controller_spec.rb
+++ b/spec/controllers/publications_controller_spec.rb
@@ -15,7 +15,7 @@ describe PublicationsController, :vcr do
     {
       type: 'book',
       title: 'some title',
-      year: 1938,
+      year: '1938',
       issn: '32242424',
       pages: '34-56',
       author: [{
@@ -63,7 +63,6 @@ describe PublicationsController, :vcr do
       ],
       booktitle: 'TEST Book I',
       edition: '2',
-      etal: true,
       identifier: [
         { type: 'isbn', id: '1177188188181' },
         doi_pub_id.identifier
@@ -116,7 +115,6 @@ describe PublicationsController, :vcr do
         status: 'approved',
         visibility: 'public'
       }],
-      etal: false,
       journal: {},
       last_updated: '2015-11-23T15:15Z',
       provenance: 'CAP',
@@ -352,10 +350,10 @@ describe PublicationsController, :vcr do
       context 'WOS disabled' do
         before { allow(Settings.WOS).to receive(:enabled).and_return(false) }
 
-        let(:ussr) { create :user_submitted_source_record, title: 'Men On Mars', year: 2001, source_data: '{}' }
+        let(:ussr) { create :user_submitted_source_record, title: 'Men On Mars', year: '2001', source_data: '{}' }
         let!(:pub) do
           pub = build(:publication, title: ussr.title, year: ussr.year, user_submitted_source_records: [ussr])
-          pub.pub_hash[:year] = ussr.year # values will overwrite from pub_hash
+          pub.pub_hash[:year] = ussr.year.to_s # values will overwrite from pub_hash
           pub.pub_hash[:title] = ussr.title
           pub.save!
           ussr.publication = pub # association does not automatically update ussr

--- a/spec/factories/publication.rb
+++ b/spec/factories/publication.rb
@@ -35,7 +35,8 @@ FactoryBot.define do
         identifier: [
           { type: 'isbn', id: '1177188188181' },
           { type: 'doi', id: '18819910019', url: 'http://doi:18819910019' }
-        ]
+        ],
+        type: publication_type
       }
     end
   end
@@ -43,7 +44,8 @@ FactoryBot.define do
   factory :wos_publication, parent: :publication do
     pub_hash do
       {
-        provenance: 'wos'
+        provenance: 'wos',
+        type: publication_type
       }
     end
   end

--- a/spec/lib/bibtex_ingester_spec.rb
+++ b/spec/lib/bibtex_ingester_spec.rb
@@ -81,12 +81,12 @@ describe BibtexIngester do
 
     it 'adds publication_identifier for isbn' do
       bibtex_ingester.ingest_from_source_directory(bibtex_batch_path)
-      expect(PublicationIdentifier).to exist(identifier_type: 'isbn', identifier_value: 3_233_333)
+      expect(PublicationIdentifier).to exist(identifier_type: 'isbn', identifier_value: '3233333')
     end
 
     it 'adds publication_identifier for DOI' do
       bibtex_ingester.ingest_from_source_directory(bibtex_batch_path)
-      expect(PublicationIdentifier).to exist(identifier_type: 'doi', identifier_value: 8_484_848_484)
+      expect(PublicationIdentifier).to exist(identifier_type: 'doi', identifier_value: '8484848484')
     end
 
     it "doesn't add publication_identifier for sulpubid" do
@@ -122,7 +122,7 @@ describe BibtexIngester do
     context 'when deduping by issn, year, pages' do
       let(:existing_matching_pub_issn) do
         create :publication, pmid: 3_323_434,
-                             pub_hash: { title: 'Quelque Titre', type: 'article', pmid: 3_323_434, year: 2002, pages: '295-299', issn: '234234', author: [{ name: 'Jackson, Joe' }], authorship: [{ sul_author_id: 2222, status: 'denied', visibility: 'public', featured: true }] }
+                             pub_hash: { title: 'Quelque Titre', type: 'article', pmid: '3323434', year: '2002', pages: '295-299', issn: '234234', author: [{ name: 'Jackson, Joe' }], authorship: [{ sul_author_id: 2222, status: 'denied', visibility: 'public', featured: true }] }
       end
       let(:contribution) { create :contribution, author: author_with_bibtex, publication: existing_matching_pub_issn }
 
@@ -153,7 +153,7 @@ describe BibtexIngester do
     context 'when deduping by title, year, pages' do
       let(:pub_with_same_title) do
         create :publication, pmid: 332_423_434,
-                             pub_hash: { title: 'Quality of Life Assessment Designed for Computer Inexperienced Older Adults: Multimedia Utility Elicitation for Activities of Daily Living', pmid: 3_323_434, type: 'article', year: 2002, pages: '295-299', author: [{ name: 'Jackson, Joe' }], authorship: [{ sul_author_id: 2222, status: 'denied', visibility: 'public', featured: true }] }
+                             pub_hash: { title: 'Quality of Life Assessment Designed for Computer Inexperienced Older Adults: Multimedia Utility Elicitation for Activities of Daily Living', pmid: '3323434', type: 'article', year: '2002', pages: '295-299', author: [{ name: 'Jackson, Joe' }], authorship: [{ sul_author_id: 2222, status: 'denied', visibility: 'public', featured: true }] }
       end
       let(:contribution) { create :contribution, author: author_with_bibtex, publication: pub_with_same_title }
 

--- a/spec/lib/pub_hash_validator_spec.rb
+++ b/spec/lib/pub_hash_validator_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+describe PubHashValidator do
+  let(:valid_pub_hash) do
+    {
+      title: 'Twitter Makes It Worse: Political Journalists, Gendered Echo Chambers, and the Amplification of Gender Bias',
+      type: 'article'
+    }
+  end
+
+  let(:invalid_pub_hash) do
+    {
+      title: 'Twitter Makes It Worse: Political Journalists, Gendered Echo Chambers, and the Amplification of Gender Bias',
+      type: 'article',
+      foo: 'bar'
+    }
+  end
+
+  describe '#valid?' do
+    context 'when valid' do
+      it 'returns true' do
+        expect(described_class.valid?(valid_pub_hash)).to be(true)
+      end
+    end
+
+    context 'when invalid' do
+      it 'returns false' do
+        expect(described_class.valid?(invalid_pub_hash)).to be(false)
+      end
+    end
+  end
+
+  describe '#validate' do
+    context 'when valid' do
+      it 'returns empty' do
+        expect(described_class.validate(valid_pub_hash)).to be_empty
+      end
+    end
+
+    context 'when invalid' do
+      it 'returns error' do
+        expect(described_class.validate(invalid_pub_hash)).to eq(['/foo with value bar is invalid for schema: /additionalProperties'])
+      end
+    end
+
+    context 'when missing required field' do
+      let(:invalid_pub_hash) do
+        {
+          title: 'Twitter Makes It Worse: Political Journalists, Gendered Echo Chambers, and the Amplification of Gender Bias',
+          identifier: [
+            {
+              id: 'abc123'
+            }
+          ]
+        }
+      end
+
+      it 'returns error' do
+        expect(described_class.validate(invalid_pub_hash)).to eq(['Invalid with details: {"missing_keys"=>["type"]}'])
+      end
+    end
+  end
+end

--- a/spec/lib/pubmed/fetcher_spec.rb
+++ b/spec/lib/pubmed/fetcher_spec.rb
@@ -5,13 +5,14 @@ describe Pubmed::Fetcher, :vcr do
   let(:pub_hash) do
     {
       title: 'some title',
-      year: 1938,
+      year: '1938',
       issn: '32242424',
       pages: '34-56',
       author: [{ name: 'jackson joe' }],
       authorship: [{ sul_author_id: author.id, status: 'denied', visibility: 'public', featured: true }],
       identifier: [{ type: 'x', id: 'y', url: 'z' }],
-      provenance: 'pubmed'
+      provenance: 'pubmed',
+      type: 'article'
     }
   end
 

--- a/spec/lib/web_of_science/process_records_spec.rb
+++ b/spec/lib/web_of_science/process_records_spec.rb
@@ -199,9 +199,15 @@ describe WebOfScience::ProcessRecords, :vcr do
                                                          %(<identifiers><identifier type='pmid' value='21253920'/>)))
       end
       let(:records) { WebOfScience::Records.new(records: "<records>#{wos_rec.to_xml}</records>") }
+      let(:pub_hash) do
+        {
+          type: 'article',
+          identifier: [{ type: 'pmid', id: '21253920', url: 'whatever' }, { type: 'doi', id: 'ABCXYZ', url: 'theother' }]
+        }
+      end
       let(:pub) do
         build :publication, sciencewire_id: 123, pmid: '21253920', pubhash_needs_update: true,
-                            pub_hash: { identifier: [{ type: 'pmid', id: '21253920', url: 'whatever' }, { type: 'doi', id: 'ABCXYZ', url: 'theother' }] }
+                            pub_hash: pub_hash
       end
       let(:uid) { records.first.uid }
 

--- a/spec/models/publication_identifier_spec.rb
+++ b/spec/models/publication_identifier_spec.rb
@@ -64,7 +64,7 @@ describe PublicationIdentifier do
   describe '#pub_hash_update' do
     context 'when pub_hash[:identifier] does not contain identifier' do
       before do
-        pub_id.publication.pub_hash = { identifier: [] }
+        pub_id.publication.pub_hash = pub_id.publication.pub_hash.merge(identifier: [])
         pub_id.publication.save!
       end
 
@@ -79,13 +79,13 @@ describe PublicationIdentifier do
 
     context 'when pub_hash[:identifier] contains identifier' do
       before do
-        pub_id.publication.pub_hash = { identifier: [{ type: 'doi' }] }
+        pub_id.publication.pub_hash = pub_id.publication.pub_hash.merge(identifier: [{ type: 'doi', id: 'abc123' }])
         pub_id.publication.save!
       end
 
       it 'pub_hash has a DOI identifier' do
         # double check that the publication.save! callbacks did not mess up the mock
-        expect(pub_id.publication.pub_hash[:identifier]).to include(type: 'doi')
+        expect(pub_id.publication.pub_hash[:identifier]).to include({ type: 'doi', id: 'abc123' })
       end
 
       it_behaves_like 'deletes_pub_hash'

--- a/spec/models/pubmed_source_record_spec.rb
+++ b/spec/models/pubmed_source_record_spec.rb
@@ -13,7 +13,7 @@ describe PubmedSourceRecord, :vcr do
       {
         Abrams: {
           xml: author_doc(' <Author ValidYN="Y"> <LastName>Abrams</LastName> <ForeName>Judith</ForeName> <Initials>J</Initials> </Author>'),
-          hash: { firstname: 'Judith', middlename: nil, lastname: 'Abrams' }
+          hash: { firstname: 'Judith', lastname: 'Abrams' }
         },
         Amara: {
           xml: author_doc(' <Author ValidYN="Y"> <LastName>Amara</LastName> <ForeName>Mohamed el-Walid</ForeName> <Initials>Mel- W</Initials> </Author>'),
@@ -49,7 +49,7 @@ describe PubmedSourceRecord, :vcr do
         },
         Todoroki: {
           xml: author_doc(' <Author ValidYN="Y"> <LastName>Todoroki</LastName> <ForeName>Shin-ichi</ForeName> <Initials>S</Initials> </Author>'),
-          hash: { firstname: 'Shin-ichi', middlename: nil, lastname: 'Todoroki' }
+          hash: { firstname: 'Shin-ichi', lastname: 'Todoroki' }
         }
       }
     end


### PR DESCRIPTION
## Why was this change made?
pub_hash is a critical data structure, but is neither documented or validated. This is bad and will make ORCID mapping more difficult.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
`pub_hash_schema.yml`


