### PR TITLE
Adds support for adding new work to Orcid.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
     - "spec/models/publication_spec.rb"
     - "spec/lib/pubmed/query_author_spec.rb"
     - "spec/lib/bibtex_ingester_spec.rb"
+    - "spec/lib/orcid/client_spec.rb"
 
 Metrics/AbcSize:
   Max: 35

--- a/fixtures/vcr_cassettes/Orcid_Client/_add_work/adds_work.yml
+++ b/fixtures/vcr_cassettes/Orcid_Client/_add_work/adds_work.yml
@@ -1,0 +1,76 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.orcid.org/v3.0/0000-0003-3437-349X/work
+    body:
+      encoding: UTF-8
+      string: '{"title":{"title":{"value":"Twitter Makes It Worse: Political Journalists,
+        Gendered Echo Chambers, and the Amplification of Gender Bias"},"subtitle":null,"translated-title":null},"journal-title":{"value":"The
+        International Journal of Press/Politics"},"short-description":null,"citation":{"citation-type":"bibtex","citation-value":"@article{Usher_2018,\n\tdoi
+        = {10.1177/1940161218781254},\n\turl = {https://doi.org/10.1177%2F1940161218781254},\n\tyear
+        = 2018,\n\tmonth = {jun},\n\tpublisher = {{SAGE} Publications},\n\tvolume
+        = {23},\n\tnumber = {3},\n\tpages = {324--344},\n\tauthor = {Nikki Usher and
+        Jesse Holcomb and Justin Littman},\n\ttitle = {Twitter Makes It Worse: Political
+        Journalists, Gendered Echo Chambers, and the Amplification of Gender Bias},\n\tjournal
+        = {The International Journal of Press/Politics}\n}"},"type":"journal-article","publication-date":{"year":{"value":"2018"},"month":{"value":"07"},"day":{"value":"24"}},"external-ids":{"external-id":[{"external-id-type":"doi","external-id-value":"10.1177/1940161218781254","external-id-normalized":{"value":"10.1177/1940161218781254","transient":true},"external-id-normalized-error":null,"external-id-url":{"value":"https://doi.org/10.1177/1940161218781254"},"external-id-relationship":"self"}]},"url":{"value":"https://doi.org/10.1177/1940161218781254"},"contributors":{"contributor":[{"contributor-orcid":null,"credit-name":{"value":"Nikki
+        Usher"},"contributor-email":null,"contributor-attributes":{"contributor-sequence":null,"contributor-role":"author"}},{"contributor-orcid":null,"credit-name":{"value":"Jesse
+        Holcomb"},"contributor-email":null,"contributor-attributes":{"contributor-sequence":null,"contributor-role":"author"}},{"contributor-orcid":null,"credit-name":{"value":"Justin
+        Littman"},"contributor-email":null,"contributor-attributes":{"contributor-sequence":null,"contributor-role":"author"}}]},"language-code":null,"country":null}'
+    headers:
+      User-Agent:
+      - stanford-library-sul-pub
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Tue, 18 May 2021 20:28:27 GMT
+      Authorization:
+      - Bearer private_bearer_token
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 18 May 2021 20:28:29 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Location:
+      - http://api.sandbox.orcid.org/v3.0/0000-0003-3437-349X/work/1250170
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - 0a22c3769100000d08e0114000000001
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 6517d5041d010d08-LAX
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Tue, 18 May 2021 20:28:29 GMT
+recorded_with: VCR 6.0.0

--- a/fixtures/vcr_cassettes/Orcid_Client/_add_work/adds_work_again.yml
+++ b/fixtures/vcr_cassettes/Orcid_Client/_add_work/adds_work_again.yml
@@ -1,0 +1,79 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.orcid.org/v3.0/0000-0003-3437-349X/work
+    body:
+      encoding: UTF-8
+      string: '{"title":{"title":{"value":"Twitter Makes It Worse: Political Journalists,
+        Gendered Echo Chambers, and the Amplification of Gender Bias"},"subtitle":null,"translated-title":null},"journal-title":{"value":"The
+        International Journal of Press/Politics"},"short-description":null,"citation":{"citation-type":"bibtex","citation-value":"@article{Usher_2018,\n\tdoi
+        = {10.1177/1940161218781254},\n\turl = {https://doi.org/10.1177%2F1940161218781254},\n\tyear
+        = 2018,\n\tmonth = {jun},\n\tpublisher = {{SAGE} Publications},\n\tvolume
+        = {23},\n\tnumber = {3},\n\tpages = {324--344},\n\tauthor = {Nikki Usher and
+        Jesse Holcomb and Justin Littman},\n\ttitle = {Twitter Makes It Worse: Political
+        Journalists, Gendered Echo Chambers, and the Amplification of Gender Bias},\n\tjournal
+        = {The International Journal of Press/Politics}\n}"},"type":"journal-article","publication-date":{"year":{"value":"2018"},"month":{"value":"07"},"day":{"value":"24"}},"external-ids":{"external-id":[{"external-id-type":"doi","external-id-value":"10.1177/1940161218781254","external-id-normalized":{"value":"10.1177/1940161218781254","transient":true},"external-id-normalized-error":null,"external-id-url":{"value":"https://doi.org/10.1177/1940161218781254"},"external-id-relationship":"self"}]},"url":{"value":"https://doi.org/10.1177/1940161218781254"},"contributors":{"contributor":[{"contributor-orcid":null,"credit-name":{"value":"Nikki
+        Usher"},"contributor-email":null,"contributor-attributes":{"contributor-sequence":null,"contributor-role":"author"}},{"contributor-orcid":null,"credit-name":{"value":"Jesse
+        Holcomb"},"contributor-email":null,"contributor-attributes":{"contributor-sequence":null,"contributor-role":"author"}},{"contributor-orcid":null,"credit-name":{"value":"Justin
+        Littman"},"contributor-email":null,"contributor-attributes":{"contributor-sequence":null,"contributor-role":"author"}}]},"language-code":null,"country":null}'
+    headers:
+      User-Agent:
+      - stanford-library-sul-pub
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Tue, 18 May 2021 20:32:00 GMT
+      Authorization:
+      - Bearer private_bearer_token
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 409
+      message: Conflict
+    headers:
+      Date:
+      - Tue, 18 May 2021 20:32:00 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - 0a22c6b42600000ca78723f000000001
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 6517da336ded0ca7-LAX
+    body:
+      encoding: UTF-8
+      string: '{"response-code":409,"developer-message":"409 Conflict: You have already
+        added this activity (matched by external identifiers), please see element
+        with put-code 1250170. If you are trying to edit the item, please use PUT
+        instead of POST.","user-message":"There was an error when updating the record.
+        Please try again. If the error persists, please contact Stanford University
+        for assistance.","error-code":9021,"more-info":"https://members.orcid.org/api/resources/troubleshooting"}'
+  recorded_at: Tue, 18 May 2021 20:32:00 GMT
+recorded_with: VCR 6.0.0

--- a/lib/orcid/client.rb
+++ b/lib/orcid/client.rb
@@ -7,38 +7,70 @@ module Orcid
   class Client
     # Fetch the works for a researcher.
     # Model for the response: https://pub.orcid.org/v3.0/#!/Development_Public_API_v3.0/viewWorksv3
+    # @param [string] ORCID ID for the researcher
+    # @return [Hash]
     def fetch_works(orcidid)
-      response = conn.get("/v3.0/#{orcidid[-19, 19]}/works")
+      response = conn.get("/v3.0/#{base_orcidid(orcidid)}/works")
       raise "ORCID.org API returned #{response.status}" if response.status != 200
 
       JSON.parse(response.body).with_indifferent_access
     end
 
+    # Add a new work for a researcher.
+    # @param [string] ORCID ID for the researcher
+    # @param [Hash] work in correct data structure for ORCID work
+    # @param [string] access token
+    # @return [string] put-code
+    def add_work(orcidid, work, token)
+      response = conn_with_token(token).post("/v3.0/#{base_orcidid(orcidid)}/work",
+                                             work.to_json,
+                                             'Content-Type' => 'application/json')
+
+      case response.status
+      when 201
+        response['Location'].match(%r{work/(\d+)})[1]
+      when 409
+        match = response.body.match(/put-code (\d+)\./)
+        raise 'ORCID.org API returned a 409, but could not find put-code' unless match
+
+        match[1]
+      else
+        raise "ORCID.org API returned #{response.status}"
+      end
+    end
+
     private
 
-    def token
+    def base_orcidid(orcidid)
+      orcidid[-19, 19]
+    end
+
+    def client_token
       client = OAuth2::Client.new(Settings.ORCID.CLIENT_ID, Settings.ORCID.CLIENT_SECRET, site: Settings.ORCID.BASE_AUTH_URL)
       token = client.client_credentials.get_token({ scope: '/read-public' })
-      "Bearer #{token.token}"
+      token.token
     end
 
     # @return [Faraday::Connection]
     def conn
-      @conn ||= begin
-        conn = Faraday.new(url: Settings.ORCID.BASE_URL) do |faraday|
-          faraday.request :retry, max: 3,
-                                  interval: 0.5,
-                                  interval_randomness: 0.5,
-                                  backoff_factor: 2
-          faraday.adapter :httpclient
-        end
-        conn.options.timeout = 500
-        conn.options.open_timeout = 10
-        conn.headers[:user_agent] = 'stanford-library-sul-pub'
-        conn.headers[:accept] = 'application/json'
-        conn.headers[:authorization] = token
-        conn
+      @conn ||= conn_with_token(client_token)
+    end
+
+    # @return [Faraday::Connection]
+    def conn_with_token(token)
+      conn = Faraday.new(url: Settings.ORCID.BASE_URL) do |faraday|
+        faraday.request :retry, max: 3,
+                                interval: 0.5,
+                                interval_randomness: 0.5,
+                                backoff_factor: 2
+        faraday.adapter :httpclient
       end
+      conn.options.timeout = 500
+      conn.options.open_timeout = 10
+      conn.headers[:user_agent] = 'stanford-library-sul-pub'
+      conn.headers[:accept] = 'application/json'
+      conn.headers[:authorization] = "Bearer #{token}"
+      conn
     end
   end
 end

--- a/spec/lib/orcid/client_spec.rb
+++ b/spec/lib/orcid/client_spec.rb
@@ -20,4 +20,115 @@ describe Orcid::Client do
       end
     end
   end
+
+  describe '#add_work' do
+    let(:work) do
+      {
+        title: {
+          title: {
+            value: 'Twitter Makes It Worse: Political Journalists, Gendered Echo Chambers, and the Amplification of Gender Bias'
+          },
+          subtitle: nil,
+          "translated-title": nil
+        },
+        "journal-title": {
+          value: 'The International Journal of Press/Politics'
+        },
+        "short-description": nil,
+        citation: {
+          "citation-type": 'bibtex',
+          "citation-value": "@article{Usher_2018,\n\tdoi = {10.1177/1940161218781254},\n\turl = {https://doi.org/10.1177%2F1940161218781254},\n\tyear = 2018,\n\tmonth = {jun},\n\tpublisher = {{SAGE} Publications},\n\tvolume = {23},\n\tnumber = {3},\n\tpages = {324--344},\n\tauthor = {Nikki Usher and Jesse Holcomb and Justin Littman},\n\ttitle = {Twitter Makes It Worse: Political Journalists, Gendered Echo Chambers, and the Amplification of Gender Bias},\n\tjournal = {The International Journal of Press/Politics}\n}"
+        },
+        type: 'journal-article',
+        "publication-date": {
+          year: {
+            value: '2018'
+          },
+          month: {
+            value: '07'
+          },
+          day: {
+            value: '24'
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": 'doi',
+              "external-id-value": '10.1177/1940161218781254',
+              "external-id-normalized": {
+                value: '10.1177/1940161218781254',
+                transient: true
+              },
+              "external-id-normalized-error": nil,
+              "external-id-url": {
+                value: 'https://doi.org/10.1177/1940161218781254'
+              },
+              "external-id-relationship": 'self'
+            }
+          ]
+        },
+        url: {
+          value: 'https://doi.org/10.1177/1940161218781254'
+        },
+        contributors: {
+          contributor: [
+            {
+              "contributor-orcid": nil,
+              "credit-name": {
+                value: 'Nikki Usher'
+              },
+              "contributor-email": nil,
+              "contributor-attributes": {
+                "contributor-sequence": nil,
+                "contributor-role": 'author'
+              }
+            },
+            {
+              "contributor-orcid": nil,
+              "credit-name": {
+                value: 'Jesse Holcomb'
+              },
+              "contributor-email": nil,
+              "contributor-attributes": {
+                "contributor-sequence": nil,
+                "contributor-role": 'author'
+              }
+            },
+            {
+              "contributor-orcid": nil,
+              "credit-name": {
+                value: 'Justin Littman'
+              },
+              "contributor-email": nil,
+              "contributor-attributes": {
+                "contributor-sequence": nil,
+                "contributor-role": 'author'
+              }
+            }
+          ]
+        },
+        "language-code": nil,
+        country: nil
+      }
+    end
+
+    let(:put_code) { subject.add_work('https://sandbox.orcid.org/0000-0003-3437-349X', work, 'FAKE29cb-194e-4bc3-8afg-99315b06be04') }
+
+    context 'when creating work the first time' do
+      it 'adds works' do
+        VCR.use_cassette('Orcid_Client/_add_work/adds work') do
+          expect(put_code).to eq('1250170')
+        end
+      end
+    end
+
+    context 'when work already exists' do
+      it 'handles conflict' do
+        VCR.use_cassette('Orcid_Client/_add_work/adds work again') do
+          expect(put_code).to eq('1250170')
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
closes #1258

## Why was this change made?
API support will be needed to add SUL-PUB publications to ORCID for researchers.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


