### PR TITLE
ORCID API OKComputer check

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -47,7 +47,8 @@ end
 clients = [
   Cap::Client,
   Pubmed,
-  Mais
+  Mais,
+  Orcid
 ]
 if Settings.WOS.enabled
   clients << WebOfScience

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -80,6 +80,7 @@ ORCID:
   BASE_AUTH_URL: https://sandbox.orcid.org
   CLIENT_ID: APP-FAKEJMB7RBQVFQ0D
   CLIENT_SECRET: FAKE6bb5-dba1-445d-ba10-c14745383ba0
+  orcidid_for_check: https://orcid.org/0000-0003-1527-0030
 
 DOI:
   BASE_URI: https://doi.org/

--- a/lib/orcid.rb
+++ b/lib/orcid.rb
@@ -6,4 +6,12 @@ module Orcid
   def self.client
     Orcid::Client.new
   end
+
+  # Fetch works for a known ID for which we expect to get back publications
+  def self.working?
+    response = client.fetch_works(Settings.ORCID.orcidid_for_check)
+    response[:group].size.positive?
+  rescue StandardError
+    false
+  end
 end

--- a/spec/lib/mais_spec.rb
+++ b/spec/lib/mais_spec.rb
@@ -22,7 +22,7 @@ describe Mais do
         allow(client).to receive(:fetch_orcid_users).and_raise(StandardError, 'Fail!')
       end
 
-      it 'returns true' do
+      it 'returns false' do
         expect(described_class.working?).to be(false)
       end
     end

--- a/spec/lib/orcid_spec.rb
+++ b/spec/lib/orcid_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+describe Orcid do
+  describe '#working' do
+    context 'when working' do
+      it 'returns true' do
+        VCR.use_cassette('Orcid_Client/_fetch_works/retrieves works summary') do
+          expect(described_class.working?).to be(true)
+        end
+      end
+    end
+
+    context 'when not working' do
+      it 'returns false' do
+        VCR.use_cassette('Orcid_Client/_fetch_works/raises') do
+          expect(described_class.working?).to be(false)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

fixes #1262

bonus copypasta fix for `spec/lib/mais_spec.rb` test description

we discussed after standup this morning, and people were OK with the VCR approach used in this PR, but i'm happy to switch to the pattern used for the `Mais` check if that's preferable (i.e. more explicitly mocking the `client.fetch_works` call/result -- i hadn't looked closely at `mais_spec.rb` until after that discussion). 

## How was this change tested?

unit tests


## Which documentation and/or configurations were updated?

added a setting for test orcid ID for the new check

