### PR TITLE
update comments that reference a now deleted class

### DIFF
--- a/lib/csl/bibtex_mapper.rb
+++ b/lib/csl/bibtex_mapper.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 module Csl
-  # Convert BibTexIngester content into a CSL format
+  # Convert BibtexIngester content into a CSL format
+  # NOTE: BibtexIngester was removed by https://github.com/sul-dlss/sul_pub/pull/1317 (commit fb4b3fc9a74a6f188673ac171dc0b72c1cc0fc93)
   class BibtexMapper
-    # Convert BibTexIngester authors into CSL authors
+    # Convert BibtexIngester authors into CSL authors
     # @param [Array<Hash>] authors array of hash data
     # @return [Array<Hash>] CSL authors array of hash data
     def self.authors_to_csl(authors)

--- a/lib/csl/role_mapper.rb
+++ b/lib/csl/role_mapper.rb
@@ -11,6 +11,7 @@ module Csl
         case pub_hash[:provenance].to_s.downcase
         when Settings.batch_source
           # This is from BibtexIngester.convert_bibtex_record_to_pub_hash
+          # NOTE: BibtexIngester was removed by https://github.com/sul-dlss/sul_pub/pull/1317 (commit fb4b3fc9a74a6f188673ac171dc0b72c1cc0fc93)
           Csl::BibtexMapper.authors_to_csl(authors)
         when Settings.cap_provenance
           # This is a CAP manual submission


### PR DESCRIPTION
## Why was this change made?

small follow on to #1317

maybe the better thing to do would be to reassess whether the code that's commented in this PR is still needed, but for now, this at least makes the comments less confusing.

## How was this change tested?

unit tests

## Which documentation and/or configurations were updated?

comment only update
