### PR TITLE
.gitignore and README touchups re: VCR cassette generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@ README_configs.txt
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
+## production.yml anywhere, in case shared_configs was copied to make new VCR cassettes
+production.yml
 
 ## Private seed data
 spec/factories/*.local.rb

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ To run the `data-integration` tests, make sure that your private credentials are
 bundle exec rake spec:data-integration
 ```
 
-### Private Configuration Files
+### Private Configuration Files (and VCR Cassette generation)
 
 There are private configuration data for this application, managed in a
 [private github repository](https://github.com/sul-dlss/shared_configs/branches/all?query=sul-pub).
@@ -88,27 +88,30 @@ It can be useful to access the external APIs from your laptop for testing or to
 create new VCR cassettes in testing.  You can use the `sul-pub-cap-dev-a` branch
 for this purpose since it has the private API keys.  To do this, grab the
 `config/settings/production.yml` file and save it as a `config/settings.local.yml`
-file for local development.  This file is gitignored so you don't commit by mistake
-and you can override other setting as needed.  If you are going to regenerate VCR cassettes
+file for local development.  These files are both gitignored so you don't commit by mistake,
+and you can override other settings as needed.  If you are going to (re-)generate VCR cassettes
 during tests, you will also need the private API keys in the test environment.  You can
 use the same config file to run in your local test environment as shown below.
-This will also be gitignored so you won't check it in.
+This is also gitignored so you won't check it in.
 
 ```sh
 mkdir config/settings
 cp config/settings.local.yml config/settings/test.local.yml
 ```
 
-### Updating the VCR Cassettes Using Private Configuration Files
+⚠️ Note: Since the VCR cassettes include the full request and response in plain text, it is important not to include any
+private information in these requests, such as API keys or non-public personal information.  In order to ensure
+this information is not checked in, there is configuration in `spec/spec_helper.rb` to look for private information and scrub it
+from cassettes automatically as they are generated.  Look under the `VCR.configure` heading in that file for the correct format
+if you need to add new filters for data that should not be checked into Github (e.g. private identifiers and API keys).
+
+#### Updating the VCR Cassettes Using Private Configuration Files
 
 First, follow the instructions above for obtaining the private configuration files.
 Be sure you have the `config/settings/test.local.yml`.
 Then remove the relevant VCR cassettes if needed, run the test suite and commit any changes to the VCR cassettes.
 
-Note: Since the VCR cassettes include the full request and response in plain text, it is important not to include any
-private information in these requests, such as API keys or non-public personal information.  In order to ensure
-this information is not checked in, there is configuration in `spec/spec_helper.rb` to look for private information and scrub it
-from cassettes automatically as they are generated.  Look under the `VCR.configure` heading in that file for the correct format if you need to add new filters for data that should not be checked into Github (e.g. private identifiers and API keys).
+⚠️ Note: Same warning about filtering private info from cassettes as when recording them anew, see above.
 
 ```sh
 # See commands above for using private configuration files.


### PR DESCRIPTION
## Why was this change made?

a bit more clarity in instructions and protection in .gitignore re: accidentally committing secrets in the course of testing

## How was this change tested?

* i created empty `production.yml` and `config/settings/production.yml` files, and they both stopped showing up in `git status` output once i made the `.gitignore` change.
* proof-reading 🙂 


## Which documentation and/or configurations were updated?

README, .gitignore
