### PR TITLE
Changes pub_hash validation to support publications submitted by CAP.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -111,7 +111,7 @@ RSpec/MultipleExpectations:
 # Offense count: 282
 # Configuration parameters: AllowSubject.
 RSpec/MultipleMemoizedHelpers:
-  Max: 18
+  Max: 19
 
 # Offense count: 288
 # Configuration parameters: IgnoreSharedExamples.

--- a/pub_hash_schema.yml
+++ b/pub_hash_schema.yml
@@ -6,7 +6,7 @@ properties:
     type: string
   abstract_restricted:
     type: string
-  additionalProperties: # Legacy. Not in current code.
+  additionalProperties: # Submitted by CAP
     type: object
   apa_citation: # Automatically added.
     type: string
@@ -185,7 +185,7 @@ $defs:
   Author:
     type: object
     properties:
-      additionalProperties: # Legacy. Not in current code.
+      additionalProperties: # Submitted by CAP
         type: object
       alternate: # Legacy. Not in current code.
         type: array
@@ -230,12 +230,16 @@ $defs:
     description: Stanford affiliated author.
     type: object
     properties:
+      additionalProperties: # Submitted by CAP
+        type: object
       cap_profile_id:
         description: Identifier for the author in the CAP system.
         type: integer
       sul_author_id:
         description: Identifier for the author in the SUL system.
-        type: integer
+        type:
+          - integer
+          - "null" # CAP submits authorships with null
       featured:
         description: Marks the publication for featured presentation.
         type: boolean
@@ -271,7 +275,7 @@ $defs:
   Conference:
     type: object
     properties:
-      additionalProperties: # Legacy. Not in current code.
+      additionalProperties: # Submitted by CAP
         type: object
       city:
         type:
@@ -317,6 +321,8 @@ $defs:
   Identifier:
     type: object
     properties:
+      additionalProperties: # Submitted by CAP
+        type: object
       id:
         type: string
       type:
@@ -329,7 +335,7 @@ $defs:
   Journal:
     type: object
     properties:
-      additionalProperties: # Legacy. Not in current code.
+      additionalProperties: # Submitted by CAP
         type: object
       articlenumber:
         type:

--- a/spec/controllers/publications_controller_spec.rb
+++ b/spec/controllers/publications_controller_spec.rb
@@ -26,7 +26,28 @@ describe PublicationsController, :vcr do
         sul_author_id: author.id,
         status: 'denied',
         visibility: 'public',
-        featured: true
+        featured: true,
+        additionalProperties: {}
+      }]
+    }
+  end
+  let(:valid_hash_for_post_with_nul_sul_author_and_uppercase_states) do
+    {
+      type: 'book',
+      title: 'some title',
+      year: '1938',
+      issn: '32242424',
+      pages: '34-56',
+      author: [{
+        name: 'jackson joe'
+      }],
+      authorship: [{
+        cap_profile_id: author.cap_profile_id,
+        sul_author_id: nil,
+        status: 'DENIED',
+        visibility: 'PUBLIC',
+        featured: true,
+        additionalProperties: {}
       }]
     }
   end
@@ -472,7 +493,13 @@ describe PublicationsController, :vcr do
         expect(result['identifier'][0]['id']).not_to eq('n')
       end
 
-      it 'creates a pub with with isbn' do
+      it 'creates a pub with a null sul_author_id' do
+        post :create, body: valid_hash_for_post_with_nul_sul_author_and_uppercase_states.to_json, params: { format: 'json' }
+        expect(response.status).to eq(201)
+        expect(response.body).to eq(last_pub.pub_hash.to_json)
+      end
+
+      it 'creates a pub with isbn' do
         post :create, body: with_isbn_hash.to_json, params: { format: 'json' }
         expect(response.status).to eq(201)
         # TODO: use the submission data to validate some of the identifier fields
@@ -489,7 +516,7 @@ describe PublicationsController, :vcr do
         expect(response.body).to eq(last_pub.pub_hash.to_json)
       end
 
-      it 'creates a pub with with pmid' do
+      it 'creates a pub with pmid' do
         post :create, body: json_with_pubmedid, params: { format: 'json' }
         expect(response.status).to eq(201)
         expect(result['identifier']).to include('id' => '999999999', 'type' => 'pmid')


### PR DESCRIPTION
closes #1331

## Why was this change made?
CAP submitting an application was resulting in an error due to validation.


## How was this change tested?
NA


## Which documentation and/or configurations were updated?
pub_hash_schema.yml


