### PR TITLE
Allows identifier url to be null.

### DIFF
--- a/pub_hash_schema.yml
+++ b/pub_hash_schema.yml
@@ -328,7 +328,9 @@ $defs:
       type:
         type: string
       url:
-        type: string
+        type:
+          - string
+          - "null" # Submitted by CAP
     required:
       - type
     additionalProperties: false


### PR DESCRIPTION
closes #1333

## Why was this change made?
To allow CAP to submit identifiers with null urls.


## How was this change tested?
NA


## Which documentation and/or configurations were updated?
pub_hash_schema.yml


