### PR TITLE
do not fail validation on pub_hash_schema, but alert HB instead

### DIFF
--- a/app/validators/publication_validator.rb
+++ b/app/validators/publication_validator.rb
@@ -2,6 +2,10 @@
 
 class PublicationValidator < ActiveModel::Validator
   def validate(record)
-    PubHashValidator.validate(record.pub_hash).each { |error| record.errors.add :pub_hash, error }
+    errors = PubHashValidator.validate(record.pub_hash)
+    Honeybadger.notify('[PUB_HASH VALIDATION ERROR]', context: { publication_id: record.id, message: errors }) if errors.present?
+
+    # to fail when validating, add the errors to the object
+    # errors.each { |error| record.errors.add :pub_hash, error }
   end
 end

--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -36,6 +36,25 @@ describe Publication do
     end
   end
 
+  describe 'pub_hash validation' do
+    subject { Publication.create!(pub_hash: pub_hash) }
+
+    it 'notifies HB but does not fail validation on invalid pub_hash' do
+      expect(Honeybadger).to receive(:notify).with(
+        '[PUB_HASH VALIDATION ERROR]',
+        { context: { message: ['/title with value  is invalid for schema: /properties/title'],
+                     publication_id: subject.id } }
+      )
+      subject.pub_hash[:title] = nil
+      expect(subject.save).to be true
+    end
+
+    it 'does not notify HB on valid pub_hash' do
+      expect(Honeybadger).not_to receive(:notify)
+      expect(subject.save).to be true
+    end
+  end
+
   describe 'test pub hash syncing for new object' do
     subject { Publication.create!(pub_hash: pub_hash) }
 


### PR DESCRIPTION
## Why was this change made?

Experiment to alert HB instead of failing validation on pub_hash schema validation errors (to prevent user errors)

## How was this change tested?

Updated tests


## Which documentation and/or configurations were updated?



