### PR TITLE
Use fetch_orcid_user client method in orcid rake. Handle 404.

### DIFF
--- a/lib/tasks/orcid.rake
+++ b/lib/tasks/orcid.rake
@@ -12,7 +12,7 @@ namespace :orcid do
   desc 'Add works/publications to ORCID.org for a single researchers/authors'
   task :add_author_works, [:sunetid] => :environment do |_t, args|
     # This approach for finding orcid_user can be replaced with https://github.com/sul-dlss/sul_pub/issues/1322
-    orcid_user = Mais.client.fetch_orcid_users.find { |check_orcid_user| check_orcid_user.sunetid == args[:sunetid] }
+    orcid_user = Mais.client.fetch_orcid_user(sunetid: args[:sunetid])
     raise "Could not get ORCID.org access token for #{args[:sunetid]}" unless orcid_user
 
     logger = Logger.new(Rails.root.join('log/orcid_add_work.log'))

--- a/spec/lib/mais/client_spec.rb
+++ b/spec/lib/mais/client_spec.rb
@@ -39,9 +39,9 @@ describe Mais::Client do
     end
 
     context 'when a user is not found' do
-      it 'raises' do
+      it 'returns nil' do
         VCR.use_cassette('Mais_Client/_fetch_orcid_user/raises') do
-          expect { bad_orcid_user }.to raise_error('UIT MAIS ORCID User API returned 404')
+          expect(bad_orcid_user).to be_nil
         end
       end
     end


### PR DESCRIPTION
## Why was this change made?
* Use the new fetch_orcid_user method added to MAIS client.
* Handle 404 without raising.

## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


