### PR TITLE
Stop adding DOI to journal for sciencewire.

### DIFF
--- a/app/models/sciencewire_source_record.rb
+++ b/app/models/sciencewire_source_record.rb
@@ -272,7 +272,6 @@ class SciencewireSourceRecord < ApplicationRecord
       journal_hash[:pages] = publication.xpath('Pagination').text if publication.xpath('Pagination').present?
       journal_identifiers = []
       journal_identifiers << issn_identifier if issn.present?
-      journal_identifiers << doi_identifier if doi.present?
       journal_hash[:identifier] = journal_identifiers
       record_as_hash[:journal] = journal_hash
     end

--- a/spec/models/sciencewire_source_record_spec.rb
+++ b/spec/models/sciencewire_source_record_spec.rb
@@ -142,7 +142,6 @@ describe SciencewireSourceRecord, :vcr do
                                              pages: '910-922')
         expect(subject[:journal][:articlenumber]).to be_nil
         expect(subject[:journal][:identifier][0]).to include(type: 'issn', id: '0044-7447')
-        expect(subject[:journal][:identifier][1]).to include(type: 'doi', id: '10.1007/s13280-013-0447-x')
       end
     end
 


### PR DESCRIPTION
closes #1337

## Why was this change made?
The DOI belongs to the publication, not the journal.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


