### PR TITLE
enable cron schedule for orcid pushing in dev and uat

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -22,9 +22,15 @@ every 1.day, at: stagger(4), roles: [:harvester_dev, :harvester_qa, :harvester_p
   rake 'cap:poll[1]'
 end
 
-# poll mais for new ORCID information nightly at 5am-ish in qa and dev
+# poll mais for new ORCID information nightly at 5am-ish in prod, qa and dev
 every 1.day, at: stagger(5), roles: [:harvester_dev, :harvester_qa, :harvester_prod] do
   rake 'mais:update_authors'
+end
+
+# send publications to ORCID profiles for all authorized users at 6am-ish every 3 days in qa and dev
+# when validation is complete, we will add the :harvester_prod role and remove this comment
+every 3.days, at: stagger(6), roles: [:harvester_dev, :harvester_qa] do
+  rake 'orcid:add_all_works'
 end
 
 # ensure delayed_job is started on a reboot


### PR DESCRIPTION
## Why was this change made?

Fixes #1348 -- note we are deliberately leaving this schedule off in production until we are complete with testing

## How was this change tested?



## Which documentation and/or configurations were updated?



