### PR TITLE
we only need push to orcid in one environment

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -27,9 +27,9 @@ every 1.day, at: stagger(5), roles: [:harvester_dev, :harvester_qa, :harvester_p
   rake 'mais:update_authors'
 end
 
-# send publications to ORCID profiles for all authorized users at 6am-ish every 3 days in qa and dev
-# when validation is complete, we will add the :harvester_prod role and remove this comment
-every 3.days, at: stagger(6), roles: [:harvester_dev, :harvester_qa] do
+# send publications to ORCID profiles for all authorized users at 6am-ish every 3 days in qa
+# when validation is complete, we will add the :harvester_prod role and remove this comment (and update comment above)
+every 3.days, at: stagger(6), roles: [:harvester_qa] do
   rake 'orcid:add_all_works'
 end
 


### PR DESCRIPTION
## Why was this change made?

Both cap-dev and uat are connected to the Sandbox ORCID and the UAT MaIS APIs (this is the one that returns Stanford users who have connected their sunet with ORCID).  Even though our cap-dev and qa servers each have their own databases, the author information is very similar and will be the same for users who have connected their SUNET with their ORCID (since there is only one uat API for that and both our dev and uat environment connect to it).  If we run the cron job to push ORCID works from both cap-dev and uat, we will be doing exactly the same thing twice.  Let's just setup the cron job in uat to push to ORCID once.

## How was this change tested?



## Which documentation and/or configurations were updated?



