### PR TITLE
turn on orcid push in production

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -27,9 +27,8 @@ every 1.day, at: stagger(5), roles: [:harvester_dev, :harvester_qa, :harvester_p
   rake 'mais:update_authors'
 end
 
-# send publications to ORCID profiles for all authorized users at 6am-ish every 3 days in qa
-# when validation is complete, we will add the :harvester_prod role and remove this comment (and update comment above)
-every 3.days, at: stagger(6), roles: [:harvester_qa] do
+# send publications to ORCID profiles for all authorized users at 6am-ish every 3 days in qa and prod
+every 3.days, at: stagger(6), roles: [:harvester_qa, :harvester_prod] do
   rake 'orcid:add_all_works'
 end
 


### PR DESCRIPTION
## Why was this change made?

Fixes #1296 - turn on orcid push rake task in cron

## How was this change tested?



## Which documentation and/or configurations were updated?



