### PR TITLE
Strips whitespace from year.

### DIFF
--- a/lib/orcid/pub_mapper.rb
+++ b/lib/orcid/pub_mapper.rb
@@ -80,10 +80,11 @@ module Orcid
     end
 
     def map_pub_date_from_year
-      return nil unless pub_hash[:year]&.match(/\d\d\d\d/)
+      year = pub_hash[:year]&.strip
+      return nil unless year&.match(/^\d\d\d\d$/)
 
       {
-        year: { value: pub_hash[:year] },
+        year: { value: year },
         month: nil,
         day: nil
       }

--- a/spec/lib/orcid/pub_mapper_spec.rb
+++ b/spec/lib/orcid/pub_mapper_spec.rb
@@ -151,6 +151,23 @@ describe Orcid::PubMapper do
     end
   end
 
+  context 'when year has whitespace' do
+    let(:pub_hash) do
+      base_pub_hash.dup.tap do |pub_hash|
+        pub_hash.delete(:date)
+        pub_hash[:year] = ' 1950'
+      end
+    end
+
+    it 'maps without whitespace' do
+      expect(work['publication-date']).to eq({
+        year: { value: '1950' },
+        month: nil,
+        day: nil
+      }.with_indifferent_access)
+    end
+  end
+
   context 'when a book' do
     let(:pub_hash) do
       {


### PR DESCRIPTION
closes #1367

## Why was this change made?
So that work can be successfully submitted to ORCID.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


