### PR TITLE
Add a docker-compose file for starting the database in development mode

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -17,11 +17,17 @@ default: &default
   pool: 5
   username: root
   password:
-  host: 127.0.0.1
+  host: "<%= ENV.fetch('DATABASE_HOSTNAME', '127.0.0.1') %>"
+  port: "<%= ENV.fetch('DATABASE_PORT', 3306) %>"
+  # socket: /var/run/mysqld/mysqlx.sock
 
 development:
   <<: *default
+  username: sulbib
+  password: sulbib
   database: sulbib_development
+  host: 127.0.0.1
+  port: 3306
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.6'
+
+services:
+  mysqldb:
+   image: mysql
+   command: --default-authentication-plugin=mysql_native_password
+   ports:
+     - 3306:3306
+   environment:
+     MYSQL_ROOT_PASSWORD: root
+     MYSQL_DATABASE: sulbib_development
+     MYSQL_USER: sulbib
+     MYSQL_PASSWORD: sulbib
+   volumes:
+     - mysql:/var/lib/mysql
+     - mysql_config:/etc/mysql
+
+volumes:
+  mysql:
+  mysql_config:


### PR DESCRIPTION
## Why was this change made?

It makes development setup easier.

## How was this change tested?



## Which documentation and/or configurations were updated?



