### PR TITLE
Persist rspec state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 .binstubs/
 vendor/
 
+spec/examples.txt
+
 # Ignore gems
 .gems/
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,6 +49,11 @@ RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   # config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
+  # Allows RSpec to persist some state between runs in order to support
+  # the `--only-failures` and `--next-failure` CLI options. We recommend
+  # you configure your source control system to ignore this file.
+  config.example_status_persistence_file_path = 'spec/examples.txt'
+  
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.


### PR DESCRIPTION


## Why was this change made?
So that we can run with --only-failures


## How was this change tested?



## Which documentation and/or configurations were updated?



