### PR TITLE
truncate long abstracts when mapping to orcid

### DIFF
--- a/lib/orcid/pub_mapper.rb
+++ b/lib/orcid/pub_mapper.rb
@@ -26,7 +26,7 @@ module Orcid
         visibility: 'public',
         title: map_title,
         'external-ids': PubIdentifierMapper.map(pub_hash),
-        'short-description': pub_hash[:abstract],
+        'short-description': pub_hash[:abstract]&.truncate(5000), # ORCID has a max length of 5000 for this field
         'publication-date': map_pub_date,
         citation: map_citation,
         contributors: map_contributors,

--- a/spec/lib/orcid/pub_mapper_spec.rb
+++ b/spec/lib/orcid/pub_mapper_spec.rb
@@ -168,6 +168,25 @@ describe Orcid::PubMapper do
     end
   end
 
+  context 'with abstract greater than 5000 characters' do
+    let(:big_abstract) { SecureRandom.random_number(36**6000).to_s(36) } # generates 6000 character random string
+    let(:pub_hash) { base_pub_hash.merge(abstract: big_abstract) }
+
+    it 'truncates abstract to 5000 characters' do
+      expect(big_abstract.length).to eq 6000
+      expect(work['short-description'].length).to eq 5000
+      expect(work['short-description']).to eq(big_abstract.truncate(5000))
+    end
+  end
+
+  context 'with nil abstract' do
+    let(:pub_hash) { base_pub_hash.merge(abstract: nil) }
+
+    it 'does not add a short-description' do
+      expect(work['short-description']).to eq(nil)
+    end
+  end
+
   context 'when a book' do
     let(:pub_hash) do
       {


### PR DESCRIPTION
## Why was this change made?

Fixes #1383 - long abstracts need to be truncated when pushing to ORCID to fit their Works data model

Note: this is the publication we will want to try and push again when deployed, publication_id = 797885, cap_profile_id = 247934, sunet_id = ajdawes

```
p=Publication.find(797885)
p.pub_hash[:abstract].size
=> 5139
[6] pry(main)> p.contributions
=> [#<Contribution:0x00000000072a4890
  id: 1577149,
  author_id: 142648,
  cap_profile_id: 247934,
  publication_id: 797885,
  status: "approved",
  featured: false,
  visibility: "public",
  created_at: Fri, 06 Nov 2020 12:26:52 UTC +00:00,
  updated_at: Sat, 07 Nov 2020 12:13:36 UTC +00:00,
  orcid_put_code: nil>]
p.contributions.first.author
=> #<Author:0x0000000007093e70
 id: 142648,
 cap_profile_id: 247934,
 sunetid: 'ajdawes',
....
```

We can re-run the works like this:

```
RAILS_ENV=production bundle exec rake orcid:add_author_works['ajdawes']
```

## How was this change tested?

Added new unit tests

## Which documentation and/or configurations were updated?



