### PR TITLE
modify frequency of orcid pushes and make less frequent in qa

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -27,8 +27,13 @@ every 1.day, at: stagger(5), roles: [:harvester_dev, :harvester_qa, :harvester_p
   rake 'mais:update_authors'
 end
 
-# send publications to ORCID profiles for all authorized users at 6am-ish every 3 days in qa and prod
-every 3.days, at: stagger(6), roles: [:harvester_qa, :harvester_prod] do
+# send publications to ORCID profiles for all authorized users at 8am-ish every 7 days in qa
+every 7.days, at: stagger(8), roles: [:harvester_qa] do
+  rake 'orcid:add_all_works'
+end
+
+# send publications to ORCID profiles for all authorized users at 6am-ish every 2 days in prod
+every 2.days, at: stagger(6), roles: [:harvester_prod] do
   rake 'orcid:add_all_works'
 end
 


### PR DESCRIPTION
## Why was this change made?

Stakeholder request to try increasing the frequency of push to ORCID.  Examined the log files and noted that the job currently takes about 20 minutes to run, so switching from every 3 days to every 2 days seems low risk.  Also, allow the QA job to just run weekly -- it doesn't need to be as frequent now that testing is mostly done.


## How was this change tested?



## Which documentation and/or configurations were updated?



