### PR TITLE
log warnings for errors; do not alert HB on invalid token

### DIFF
--- a/lib/orcid/add_works.rb
+++ b/lib/orcid/add_works.rb
@@ -42,8 +42,8 @@ module Orcid
       contribution.save!
       logger&.info("#{self.class} - author #{author.id} - added publication #{contribution.publication.id} with put-code #{contribution.orcid_put_code}")
       true
-    rescue Orcid::PubMapper::PubMapperError => e
-      logger&.info("#{self.class} - author #{author.id} - did not add publication #{contribution.publication.id}: #{e.message}")
+    rescue Orcid::PubMapper::PubMapperError, Orcid::Client::InvalidTokenError => e
+      logger&.warn("#{self.class} - author #{author.id} - did not add publication #{contribution.publication.id}: #{e.message}")
       false
     rescue StandardError => e
       logger&.error("#{self.class} - author #{author.id} - error publication #{contribution.publication.id}: #{e.message}")

--- a/lib/orcid/client.rb
+++ b/lib/orcid/client.rb
@@ -5,6 +5,8 @@ require 'oauth2'
 module Orcid
   # Client for ORCID.org API.
   class Client
+    class InvalidTokenError < StandardError; end
+
     # Fetch the works for a researcher.
     # Model for the response: https://pub.orcid.org/v3.0/#!/Development_Public_API_v3.0/viewWorksv3
     # @param [string] ORCID ID for the researcher
@@ -68,6 +70,8 @@ module Orcid
       case response.status
       when 201
         response['Location'].match(%r{work/(\d+)})[1]
+      when 401
+        raise InvalidTokenError, "Invalid token for #{orcidid} - ORCID.org API returned #{response.status} (#{response.body}) for: #{work.to_json}"
       when 409
         match = response.body.match(/put-code (\d+)\./)
         raise 'ORCID.org API returned a 409, but could not find put-code' unless match

--- a/lib/orcid/client.rb
+++ b/lib/orcid/client.rb
@@ -71,7 +71,7 @@ module Orcid
       when 201
         response['Location'].match(%r{work/(\d+)})[1]
       when 401
-        raise InvalidTokenError, "Invalid token for #{orcidid} - ORCID.org API returned #{response.status} (#{response.body}) for: #{work.to_json}"
+        raise InvalidTokenError, "Invalid token for #{orcidid} - ORCID.org API returned #{response.status} (#{response.body})"
       when 409
         match = response.body.match(/put-code (\d+)\./)
         raise 'ORCID.org API returned a 409, but could not find put-code' unless match

--- a/spec/lib/orcid/add_works_spec.rb
+++ b/spec/lib/orcid/add_works_spec.rb
@@ -3,7 +3,7 @@
 describe Orcid::AddWorks do
   let(:add_works) { described_class.new(logger: logger) }
 
-  let(:logger) { instance_double(Logger, info: nil, error: nil) }
+  let(:logger) { instance_double(Logger, info: nil, error: nil, warn: nil) }
 
   let(:orcid_user) do
     Mais::Client::OrcidUser.new(author.sunetid, author.orcidid, ['/read-limited', '/activities/update', '/person/update'],

--- a/spec/lib/orcid/add_works_spec.rb
+++ b/spec/lib/orcid/add_works_spec.rb
@@ -10,10 +10,18 @@ describe Orcid::AddWorks do
                                 '91gd29cb-124e-5bf8-1ard-90315b03ae12')
   end
 
+  # This is an author that has no currently valid publications that can be pushed to ORCID
+  let(:orcid_user_no_orcid_approved_contributions) do
+    Mais::Client::OrcidUser.new(author_no_orcid_approved_contributions.sunetid, author_no_orcid_approved_contributions.orcidid,
+                                ['/read-limited', '/activities/update', '/person/update'], '91gd29cb-124e-5bf8-1ard-90315b03ae12')
+  end
+
   describe '#add_for_orcid_user' do
     let(:contribution_count) { add_works.add_for_orcid_user(orcid_user) }
+    let(:contribution_count_no_orcid_approved_contributions) { add_works.add_for_orcid_user(orcid_user_no_orcid_approved_contributions) }
 
     let(:author) { create :author, cap_visibility: cap_visibility }
+    let(:author_no_orcid_approved_contributions) { create :author, cap_visibility: cap_visibility }
 
     let(:cap_visibility) { 'public' }
 
@@ -64,12 +72,26 @@ describe Orcid::AddWorks do
       end
     end
 
+    context 'when ORCID token is invalid' do
+      it 'logs a warning, does not push, and does not HB' do
+        create :contribution, author: author, publication: publication, status: 'approved'
+        expect(NotificationManager).not_to receive(:error)
+        error_message = "Orcid::AddWorks - author #{author.id}"\
+          " - did not add publication #{publication.id}: Invalid token for #{author.orcidid}"\
+          ' - ORCID.org API returned 401 '\
+          "({\n  \"error\" : \"invalid_token\",\n  \"error_description\" : \"Invalid access token: 91gd29cb-124e-5bf8-1ard-90315b03ae12\"\n})"
+        expect(logger).to receive(:warn).with(error_message)
+        expect(contribution_count).to be_zero
+      end
+    end
+
     context 'when pub_hash cannot be mapped to work' do
       # Default factory pub_hash is missing an identifier so allowing factory to create publication.
       let!(:contribution) { create :contribution, author: author } # rubocop:disable RSpec/LetSetup
 
       it 'ignores' do
         expect(NotificationManager).not_to receive(:error)
+        expect(logger).to receive(:warn)
         expect(contribution_count).to be_zero
       end
     end
@@ -92,28 +114,31 @@ describe Orcid::AddWorks do
 
     context 'when Contribution is not approved' do
       it 'skips' do
-        create :contribution, author: author, publication: publication, status: 'new'
-        expect(contribution_count).to be_zero
+        create :contribution, author: author_no_orcid_approved_contributions, publication: publication, status: 'new'
+        expect(logger).not_to receive(:warn)
+        expect(contribution_count_no_orcid_approved_contributions).to be_zero
       end
     end
 
     context 'when Contribution is not public' do
       before do
-        create :contribution, author: author, publication: publication, visibility: 'private'
+        create :contribution, author: author_no_orcid_approved_contributions, publication: publication, visibility: 'private'
       end
 
       it 'skips' do
-        expect(contribution_count).to be_zero
+        expect(logger).not_to receive(:warn)
+        expect(contribution_count_no_orcid_approved_contributions).to be_zero
       end
     end
 
     context 'when Contribution already has put-code' do
       before do
-        create :contribution, author: author, publication: publication, orcid_put_code: '1250170'
+        create :contribution, author: author_no_orcid_approved_contributions, publication: publication, orcid_put_code: '1250170'
       end
 
       it 'skips' do
-        expect(contribution_count).to be_zero
+        expect(logger).not_to receive(:warn)
+        expect(contribution_count_no_orcid_approved_contributions).to be_zero
       end
     end
   end

--- a/spec/lib/orcid/client_spec.rb
+++ b/spec/lib/orcid/client_spec.rb
@@ -166,6 +166,15 @@ describe Orcid::Client do
         end
       end
     end
+
+    context 'when user token is invalid' do
+      xit 'logs but does not alert HB' do
+        # TODO: Make this work
+        # VCR.use_cassette('Orcid_Client/_add_work/adds work again') do
+        #   expect(put_code).to eq('1250170')
+        # end
+      end
+    end
   end
 
   describe '#fetch_work' do

--- a/spec/lib/orcid/client_spec.rb
+++ b/spec/lib/orcid/client_spec.rb
@@ -166,15 +166,6 @@ describe Orcid::Client do
         end
       end
     end
-
-    context 'when user token is invalid' do
-      xit 'logs but does not alert HB' do
-        # TODO: Make this work
-        # VCR.use_cassette('Orcid_Client/_add_work/adds work again') do
-        #   expect(put_code).to eq('1250170')
-        # end
-      end
-    end
   end
 
   describe '#fetch_work' do


### PR DESCRIPTION
## Why was this change made?

Fixes #1401 - do not alert HB if the user has revoked their ORCID token (we do not get notified about this, and it is an expected error that we cannot do anything about currently)

## How was this change tested?

Needs a new test


## Which documentation and/or configurations were updated?



