### PR TITLE
do not map non-numeric page numbers from web of science

### DIFF
--- a/lib/web_of_science/map_citation.rb
+++ b/lib/web_of_science/map_citation.rb
@@ -55,6 +55,11 @@ module WebOfScience
 
       fst = page['begin'].to_s.strip
       lst = page['end'].to_s.strip
+
+      # ignore anything that doesn't look like a number
+      fst = '' unless fst.to_i.to_s == fst
+      lst = '' unless lst.to_i.to_s == lst
+
       fst == lst ? fst : [fst, lst].select(&:present?).join('-')
     end
   end

--- a/spec/lib/web_of_science/map_citation_spec.rb
+++ b/spec/lib/web_of_science/map_citation_spec.rb
@@ -30,7 +30,6 @@ describe WebOfScience::MapCitation do
       expect(pub_hash).to match a_hash_including(
         year: String,
         date: String,
-        pages: String,
         title: String,
         journal: a_hash_including(:name, :identifier)
       )
@@ -40,9 +39,10 @@ describe WebOfScience::MapCitation do
 
   context 'WOS records' do
     it_behaves_like 'common_citation_data'
-    it 'trims the whitespace from the title' do
+    it 'trims the whitespace from the title and maps the numeric page number' do
       # whitespace trimmed
       expect(pub_hash[:title]).to eq 'LIBRARY MANAGEMENT - BEHAVIOR-BASED PERSONNEL SYSTEMS (BBPS) - FRAMEWORK FOR ANALYSIS - KEMPER,RE'
+      expect(pub_hash[:pages]).to eq '413'
     end
   end
 
@@ -50,9 +50,10 @@ describe WebOfScience::MapCitation do
     let(:mapper) { described_class.new(medline_record) }
 
     it_behaves_like 'common_citation_data'
-    it 'trims the whitespace from the title' do
+    it 'trims the whitespace from the title and ignores the non-numeric page number' do
       # whitespace trimmed
       expect(pub_hash[:title]).to eq 'Identifying druggable targets by protein microenvironments matching: application to transcription factors.'
+      expect(pub_hash[:pages]).to be nil # this record has a non numeric page number of "e93", which will be ignored
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

Sometimes WOS records include non-numeric page numbers in the source data (e.g. "E23").  This (pending verification if we really want to do it) will not map these non-numeric pages when creating citations.


## How was this change tested?

Updated test

## Which documentation and/or configurations were updated?



