### PR TITLE
there is no new publication method, remove route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   root to: 'default#index'
 
   # Publication API (for retrieving publications, searching and creating/updating manually entered publications)
-  resources :publications, defaults: { format: :json } do
+  resources :publications, except: [:new], defaults: { format: :json } do
     collection do
       get 'sourcelookup', to: 'publications#sourcelookup'
     end


### PR DESCRIPTION
## Why was this change made?

There is no "new" publication method, so it doesn't need a route.

## How was this change tested?



## Which documentation and/or configurations were updated?



