### PR TITLE
truncate long author names when mapping to orcid

### DIFF
--- a/lib/orcid/pub_author_mapper.rb
+++ b/lib/orcid/pub_author_mapper.rb
@@ -44,7 +44,7 @@ module Orcid
       {
         'contributor-orcid': nil,
         'credit-name': {
-          value: map_credit_name
+          value: map_credit_name.truncate(150) # ORCID has a max length of 150 for this field
         },
         'contributor-email': nil,
         'contributor-attributes': {

--- a/spec/lib/orcid/pub_mapper_spec.rb
+++ b/spec/lib/orcid/pub_mapper_spec.rb
@@ -87,6 +87,21 @@ describe Orcid::PubMapper do
     )
   end
 
+  context 'with author name greater than 150 characters' do
+    let(:long_author) { SecureRandom.random_number(36**160).to_s(36) } # generates 160 character random string
+    let(:pub_hash) do
+      base_pub_hash.dup.tap { |pub_hash| pub_hash[:author] = [{ name: long_author }] }
+    end
+
+    it 'truncates the name to 150 characters' do
+      expect(long_author.length).to eq(160)
+      expect(work['contributors']['contributor'].size).to eq(1)
+      mapped_name = work['contributors']['contributor'].first['credit-name']['value']
+      expect(mapped_name.length).to eq(150)
+      expect(mapped_name).to eq(long_author.truncate(150))
+    end
+  end
+
   it 'maps journal title' do
     expect(work['journal-title']['value']).to eq('Mind')
   end


### PR DESCRIPTION
## Why was this change made?

ORCID allows a maximum of 150 characters in the author field name.  Let's truncate when mapping just in case we end up with a longer name in our name (which should be very rare).

Here is the HB alert that triggered it (though in this case, it this turned out to be a wonky data we generated):  https://app.honeybadger.io/projects/50046/faults/81826301 

## How was this change tested?

Added a new test

## Which documentation and/or configurations were updated?



