### PR TITLE
sciencewire provenance should map wositemid to wosuid for orcid

### DIFF
--- a/lib/orcid/identifier_type_mapper.rb
+++ b/lib/orcid/identifier_type_mapper.rb
@@ -3,11 +3,13 @@
 module Orcid
   # Maps identifier types between ORCID and SUL-PUB.
   class IdentifierTypeMapper
+    # These map what ORCID calls an identifier to what we call the same identifier
     ORCID_ID_TYPE_TO_SUL_PUB_ID_TYPE = {
       'pmid' => 'PMID',
       'wosuid' => 'WosUID'
     }.freeze
 
+    # These map what we call an identifier to what ORCID calls the same identifier
     SUL_PUB_ID_TYPE_TO_ORCID_ID_TYPE = {
       'eissn' => 'issn',
       'PMID' => 'pmid',
@@ -15,6 +17,8 @@ module Orcid
     }.freeze
 
     # From https://pub.orcid.org/v3.0/identifiers
+    # These are the known ID types that we can push to ORCID
+    # Our publications need to have one of these known identifiers in order to push to ORCID
     ORCID_ID_TYPES = %w[
       agr
       ark

--- a/lib/orcid/pub_identifier_mapper.rb
+++ b/lib/orcid/pub_identifier_mapper.rb
@@ -46,11 +46,21 @@ module Orcid
 
         # Only mappable types.
         id_type = IdentifierTypeMapper.to_orcid_id_type(identifier[:type])
+        id_value = identifier[:id]
+
+        # Sciencewire has WoSItemIDs, but not WosUIDs.  We need a WosUID to push to ORCID, and for sciencewire records they are
+        # the same, so we can set to this to WosUID and add the "WOS:" prefix.  See https://github.com/sul-dlss/sul_pub/issues/1418
+        if pub_hash[:provenance] == 'sciencewire' && identifier[:type] == 'WoSItemID'
+          id_type = 'wosuid'
+          id_value = "WOS:#{identifier[:id]}"
+        end
+
+        # Skip if this is not a mappable identifier type
         next if id_type.nil?
 
         {
           'external-id-type' => id_type,
-          'external-id-value' => identifier[:id],
+          'external-id-value' => id_value,
           'external-id-url' => map_url(identifier),
           'external-id-relationship' => relationship
         }

--- a/spec/lib/orcid/pub_identifier_mapper_spec.rb
+++ b/spec/lib/orcid/pub_identifier_mapper_spec.rb
@@ -326,6 +326,118 @@ describe Orcid::PubIdentifierMapper do
       end
     end
 
+    context 'sciencewire provenance with a WosItemID' do
+      let(:pub_hash) do
+        {
+          provenance: 'sciencewire',
+          identifier: [
+            {
+              type: 'WoSItemID',
+              id: 'A1976BT25700002'
+            }
+          ]
+        }
+      end
+
+      it 'converts to a WoSUID' do
+        expect(ids['external-id']).to eq([
+                                           {
+                                             'external-id-type' => 'wosuid',
+                                             'external-id-value' => 'WOS:A1976BT25700002',
+                                             'external-id-url' => nil,
+                                             'external-id-relationship' => 'self'
+                                           }
+                                         ])
+      end
+    end
+
+    context 'sciencewire provenance with a both a WosItemID and a WosUID' do
+      let(:pub_hash) do
+        {
+          provenance: 'sciencewire',
+          identifier: [
+            {
+              type: 'WoSItemID',
+              id: 'A1976BT25700002'
+            },
+            {
+              type: 'WoSUID',
+              id: 'WOS:A1976BT25700002'
+            }
+          ]
+        }
+      end
+
+      it 'does not duplicate the wosuid' do
+        expect(ids['external-id']).to eq([
+                                           {
+                                             'external-id-type' => 'wosuid',
+                                             'external-id-value' => 'WOS:A1976BT25700002',
+                                             'external-id-url' => nil,
+                                             'external-id-relationship' => 'self'
+                                           }
+                                         ])
+      end
+    end
+
+    context 'wos provenance with a MEDLINE WosItemID' do
+      let(:pub_hash) do
+        {
+          provenance: 'wos',
+          identifier: [
+            {
+              type: 'WoSItemID',
+              id: '123456'
+            },
+            {
+              type: 'WosUID',
+              id: 'MEDLINE:123456'
+            }
+          ]
+        }
+      end
+
+      it 'ignores the WoSItemID and uses the existing WoSUID' do
+        expect(ids['external-id']).to eq([
+                                           {
+                                             'external-id-type' => 'wosuid',
+                                             'external-id-value' => 'MEDLINE:123456',
+                                             'external-id-url' => nil,
+                                             'external-id-relationship' => 'self'
+                                           }
+                                         ])
+      end
+    end
+
+    context 'wos provenance with a WOS WosItemID' do
+      let(:pub_hash) do
+        {
+          provenance: 'wos',
+          identifier: [
+            {
+              type: 'WoSItemID',
+              id: '123456'
+            },
+            {
+              type: 'WosUID',
+              id: 'WOS:123456'
+            }
+          ]
+        }
+      end
+
+      it 'does not duplicate the wosuid' do
+        expect(ids['external-id']).to eq([
+                                           {
+                                             'external-id-type' => 'wosuid',
+                                             'external-id-value' => 'WOS:123456',
+                                             'external-id-url' => nil,
+                                             'external-id-relationship' => 'self'
+                                           }
+                                         ])
+      end
+    end
+
     context 'when dupe' do
       let(:pub_hash) do
         {


### PR DESCRIPTION
## Why was this change made?

Fixes #1418 - older sciencewire publications do not have WosUIDs in the pub_hash, which is needed for pushing to ORCID.  But for older sciencewire publications, the WosUID is the same as the WosItemId (which we do have), we just need to add a prefix.

So when mapping identifiers for ORCID, let's allow this to happen.  No changes to existing data or data model, it all happens during the mapping only when sending to ORCID.

I also added a few comments to the orcid identifier mapping class to better explain what is happening.

## How was this change tested?

Added new tests.



## Which documentation and/or configurations were updated?



