### PR TITLE
update to ruby 3.0.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,12 @@
 version: 2.1
+parameters:
+  ruby-version:
+    type: string
+    default: "3.0.3"
 jobs:
   test:
     docker:
-    - image: circleci/ruby:2.7.1-node
+    - image: 'cimg/ruby:<< pipeline.parameters.ruby-version >>-node'
       environment:
         BUNDLE_JOBS: 3
         BUNDLE_RETRY: 3

--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,8 @@ gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '~> 4.1'
 
-# pinning myql2 since 0.5.3 is currently not compatible with our version of CentOS and Ruby (as of Apr 2020)
-gem 'mysql2', '~> 0.5', '< 0.5.3'
+# mysql 0.5.3 is required for ruby 3 and is supported on latest OS in use: Oracle Linux (as of Jan 2022)
+gem 'mysql2', '>= 0.5.3'
 
 gem 'nokogiri', '>= 1.7.1'
 
@@ -64,7 +64,7 @@ end
 
 group :development do
   gem 'byebug'
-  gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'listen', '~> 3.7'
   gem 'pry-doc'
   gem 'ruby-prof'
   gem 'thin' # app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,10 +266,9 @@ GEM
       kaminari-core (= 1.2.1)
     kaminari-core (1.2.1)
     latex-decode (0.3.2)
-    listen (3.1.5)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-      ruby_dep (~> 1.2)
+    listen (3.7.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     loofah (2.13.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -285,7 +284,7 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
-    mysql2 (0.5.2)
+    mysql2 (0.5.3)
     namae (1.1.1)
     net-scp (3.0.0)
       net-ssh (>= 2.6.5, < 7.0.0)
@@ -409,7 +408,6 @@ GEM
     ruby-prof (1.4.3)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
-    ruby_dep (1.5.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -459,7 +457,7 @@ GEM
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
-    thor (1.1.0)
+    thor (1.2.1)
     tilt (2.0.10)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -491,7 +489,7 @@ GEM
       rake (>= 0.8.7)
     yard (0.9.27)
       webrick (~> 1.7.0)
-    zeitwerk (2.5.1)
+    zeitwerk (2.5.3)
 
 PLATFORMS
   ruby
@@ -532,8 +530,8 @@ DEPENDENCIES
   jquery-rails
   json_schemer
   kaminari
-  listen (>= 3.0.5, < 3.2)
-  mysql2 (~> 0.5, < 0.5.3)
+  listen (~> 3.7)
+  mysql2 (>= 0.5.3)
   nokogiri (>= 1.7.1)
   oauth2
   okcomputer
@@ -567,4 +565,4 @@ DEPENDENCIES
   yaml_db
 
 BUNDLED WITH
-   2.2.27
+   2.2.32


### PR DESCRIPTION
## Why was this change made?

Update to ruby 3.0.3

~~Note: I had to update the mysql2 gem locally to a version that the gemfile says is not currently supported on the VM, else I got errors like this:~~

~~`expected ActiveRecord::RecordNotUnique, got #<ActiveRecord::StatementInvalid: TypeError: no implicit conversion of Hash into String>`~~

~~We need to see if mysql2 0.5.3 will work on the VMs.~~ seems to install fine on both ruby 2 and ruby 3 on the vms

## How was this change tested?

Locally.  Testing on CI now


## Which documentation and/or configurations were updated?



