### PR TITLE
Parse dates from Pubmed records into pub_hash

### DIFF
--- a/app/models/pubmed_source_record.rb
+++ b/app/models/pubmed_source_record.rb
@@ -99,6 +99,58 @@ class PubmedSourceRecord < ApplicationRecord
     mesh_headings_for_record
   end
 
+  def extract_year_from_pubmed_record(publication)
+    year = nil
+
+    # look for a year in all of the xpath locations in order
+    #  stop after the first produces something that looks like a year
+    pubmed_date_xpaths('Year').each do |path|
+      match = publication.xpath(path).text.match(/[12][0-9]{3}/)
+      next unless match
+
+      year = match.to_s
+      break
+    end
+
+    year
+  end
+
+  def extract_month_from_pubmed_record(publication)
+    month = nil
+
+    # look for a month in all of the xpath locations in order
+    #  stop after the first produces something that looks like a month (12 or Aug)
+    pubmed_date_xpaths('Month').each do |path|
+      month_value = publication.xpath(path).text
+      match = month_value.match(/\A[012]?[0-9]{1}\z/) # e.g. 01, 11, 06, 6, 12
+      name_match = month_value.match(/\A[a-zA-Z]{3}\z/) # e.g. Aug, aug, Oct
+      match = Date::ABBR_MONTHNAMES.index(name_match.to_s) if name_match # convert month name to number
+      next unless match
+
+      month = match.to_s
+      break
+    end
+
+    month
+  end
+
+  def extract_day_from_pubmed_record(publication)
+    day = nil
+
+    # look for a day in all of the xpath locations in order
+    #  stop after the first produces something that looks like a month (12 or Aug)
+    pubmed_date_xpaths('Day').each do |path|
+      day_value = publication.xpath(path).text
+      match = day_value.match(/\A[0123]?[0-9]{1}\z/) # e.g. 01, 11, 06, 6, 12, 23, 30
+      next unless match
+
+      day = match.to_s
+      break
+    end
+
+    day
+  end
+
   # Convert MEDLINE®PubMed® XML to pub_hash
   # @param [Nokogiri::XML::Node] publication
   # @return [Hash<Symbol => Object>] pub_hash
@@ -139,22 +191,16 @@ class PubmedSourceRecord < ApplicationRecord
     record_as_hash[:author] = author_list.map { |a| author_to_hash(a) }.compact
 
     record_as_hash[:mesh_headings] = mesh_headings if mesh_headings.present?
-    year_xpaths = [
-      'MedlineCitation/Article/Journal/JournalIssue/PubDate/Year',
-      'MedlineCitation/Article/ArticleDate/Year',
-      'PubmedData/History/PubMedPubDate[@PubStatus="accepted"]/Year',
-      'PubmedData/History/PubMedPubDate[@PubStatus="pubmed"]/Year',
-      'PubmedData/History/PubMedPubDate[@PubStatus="medline"]/Year',
-      'PubmedData/History/PubMedPubDate[@PubStatus="entrez"]/Year'
-    ]
-    # look for a year in all of the xpath locations above in order
-    #  stop after the first produces something that looks like a year
-    year_xpaths.each do |path|
-      match = publication.xpath(path).text.match(/[12][0-9]{3}/)
-      next unless match
 
-      record_as_hash[:year] = match.to_s
-      break
+    year = extract_year_from_pubmed_record(publication)
+    record_as_hash[:year] = year if year
+
+    month = extract_month_from_pubmed_record(publication)
+    day = extract_day_from_pubmed_record(publication)
+    if year && month && day
+      record_as_hash[:date] =  "#{year}-#{month.rjust(2, '0')}-#{day.rjust(2, '0')}"
+    elsif year && month
+      record_as_hash[:date] =  "#{year}-#{month.rjust(2, '0')}"
     end
 
     record_as_hash[:type] = Settings.sul_doc_types.article
@@ -291,5 +337,16 @@ class PubmedSourceRecord < ApplicationRecord
     # TODO: extract Affiliation
     # <AffiliationInfo> was added to <AuthorList> with the 2015 DTD.
     # The <AffiliationInfo> envelope element includes <Affliliation> and <Identifier>.
+  end
+
+  def pubmed_date_xpaths(date_part)
+    [
+      "MedlineCitation/Article/Journal/JournalIssue/PubDate/#{date_part}",
+      "MedlineCitation/Article/ArticleDate/#{date_part}",
+      "PubmedData/History/PubMedPubDate[@PubStatus='accepted']/#{date_part}",
+      "PubmedData/History/PubMedPubDate[@PubStatus='pubmed']/#{date_part}",
+      "PubmedData/History/PubMedPubDate[@PubStatus='medline']/#{date_part}",
+      "PubmedData/History/PubMedPubDate[@PubStatus='entrez']/#{date_part}"
+    ]
   end
 end

--- a/app/models/pubmed_source_record.rb
+++ b/app/models/pubmed_source_record.rb
@@ -101,57 +101,34 @@ class PubmedSourceRecord < ApplicationRecord
 
   # see https://dtd.nlm.nih.gov/ncbi/pubmed/doc/out/180101/el-Year.html
   def extract_year_from_pubmed_record(publication)
-    year = nil
-
-    # look for a year in all of the xpath locations in order
-    #  stop after the first produces something that looks like a year
-    pubmed_date_xpaths('Year').each do |path|
-      match = publication.xpath(path).text.match(/[12][0-9]{3}/)
-      next unless match
-
-      year = match.to_s
-      break
-    end
-
-    year
+    # look for a year in all of the xpath locations in order, pick the first that produces something that looks like a four digit year
+    pubmed_date_xpaths('Year')
+      .map { |path| publication.xpath(path).text.match(/[12][0-9]{3}/).to_s }
+      .compact_blank.first
   end
 
   # see https://dtd.nlm.nih.gov/ncbi/pubmed/doc/out/180101/el-Month.html
   def extract_month_from_pubmed_record(publication)
-    month = nil
-
     # look for a month in all of the xpath locations in order
-    #  stop after the first produces something that looks like a month (12 or Aug)
-    pubmed_date_xpaths('Month').each do |path|
+    #  pick the first that produces something that looks like a month (12 or Aug)
+    pubmed_date_xpaths('Month').map do |path|
       month_value = publication.xpath(path).text
       match = month_value.match(/\A[012]?[0-9]{1}\z/) # e.g. 01, 11, 06, 6, 12
       name_match = month_value.match(/\A[a-zA-Z]{3}\z/) # e.g. Aug, aug, Oct
       match = Date::ABBR_MONTHNAMES.index(name_match.to_s) if name_match # convert month name to number
-      next unless match
-
-      month = match.to_s
-      break
-    end
-
-    month
+      match.to_s
+    end.compact_blank.first
   end
 
   # see https://dtd.nlm.nih.gov/ncbi/pubmed/doc/out/180101/el-Day.html
   def extract_day_from_pubmed_record(publication)
-    day = nil
-
     # look for a day in all of the xpath locations in order
-    #  stop after the first produces something that looks like a month (12 or Aug)
-    pubmed_date_xpaths('Day').each do |path|
+    #  pick the first that produces something that looks like a day
+    pubmed_date_xpaths('Day').map do |path|
       day_value = publication.xpath(path).text
       match = day_value.match(/\A[0123]?[0-9]{1}\z/) # e.g. 01, 11, 06, 6, 12, 23, 30
-      next unless match
-
-      day = match.to_s
-      break
-    end
-
-    day
+      match.to_s
+    end.compact_blank.first
   end
 
   # Convert MEDLINE®PubMed® XML to pub_hash
@@ -342,7 +319,10 @@ class PubmedSourceRecord < ApplicationRecord
     # The <AffiliationInfo> envelope element includes <Affliliation> and <Identifier>.
   end
 
-  # see https://dtd.nlm.nih.gov/ncbi/pubmed/doc/out/180101/el-PubDate.html
+  # see https://dtd.nlm.nih.gov/ncbi/pubmed/doc/out/180101/el-PubDate.html for PubDate definition
+  # and https://dtd.nlm.nih.gov/ncbi/pubmed/doc/out/180101/att-PubStatus.html for PubStatus type definitions
+  # and https://dtd.nlm.nih.gov/ncbi/pubmed/doc/out/180101/el-JournalIssue.html for the JournalIssue definition
+  # and https://dtd.nlm.nih.gov/ncbi/pubmed/doc/out/180101/el-ArticleDate.html for the ArticleDate definition
   def pubmed_date_xpaths(date_part)
     [
       "MedlineCitation/Article/Journal/JournalIssue/PubDate/#{date_part}",

--- a/app/models/pubmed_source_record.rb
+++ b/app/models/pubmed_source_record.rb
@@ -99,6 +99,7 @@ class PubmedSourceRecord < ApplicationRecord
     mesh_headings_for_record
   end
 
+  # see https://dtd.nlm.nih.gov/ncbi/pubmed/doc/out/180101/el-Year.html
   def extract_year_from_pubmed_record(publication)
     year = nil
 
@@ -115,6 +116,7 @@ class PubmedSourceRecord < ApplicationRecord
     year
   end
 
+  # see https://dtd.nlm.nih.gov/ncbi/pubmed/doc/out/180101/el-Month.html
   def extract_month_from_pubmed_record(publication)
     month = nil
 
@@ -134,6 +136,7 @@ class PubmedSourceRecord < ApplicationRecord
     month
   end
 
+  # see https://dtd.nlm.nih.gov/ncbi/pubmed/doc/out/180101/el-Day.html
   def extract_day_from_pubmed_record(publication)
     day = nil
 
@@ -339,6 +342,7 @@ class PubmedSourceRecord < ApplicationRecord
     # The <AffiliationInfo> envelope element includes <Affliliation> and <Identifier>.
   end
 
+  # see https://dtd.nlm.nih.gov/ncbi/pubmed/doc/out/180101/el-PubDate.html
   def pubmed_date_xpaths(date_part)
     [
       "MedlineCitation/Article/Journal/JournalIssue/PubDate/#{date_part}",

--- a/spec/fixtures/pubmed/pubmed_record_10000166.xml
+++ b/spec/fixtures/pubmed/pubmed_record_10000166.xml
@@ -14,8 +14,8 @@
           <Issue>1</Issue>
           <PubDate>
             <Year>1992</Year>
-            <Month>Jan</Month>
-            <Day>01</Day>
+            <Month>Feb</Month>
+            <Day>5</Day>
           </PubDate>
         </JournalIssue>
         <Title>Physical review. B, Condensed matter</Title>

--- a/spec/models/pubmed_source_record_spec.rb
+++ b/spec/models/pubmed_source_record_spec.rb
@@ -155,7 +155,7 @@ describe PubmedSourceRecord, :vcr do
       # manual test data
       source_data = '<PubmedArticle><MedlineCitation Status="Publisher" Owner="NLM"><PMID Version="1">1</PMID><OriginalData/></PubmedArticle>'
       record = described_class.create(pmid: pmid_created_1999, source_data: source_data)
-      expect(record.source_as_hash[:year]).to eq nil # no year
+      expect(record.source_as_hash[:year]).to be_nil # no year
     end
 
     it 'ignores an invalid year' do
@@ -176,7 +176,7 @@ describe PubmedSourceRecord, :vcr do
           </PubmedArticle>
         XML
       record = described_class.create(pmid: pmid_created_1999, source_data: source_data)
-      expect(record.source_as_hash[:year]).to eq nil # bogus is not a valid year
+      expect(record.source_as_hash[:year]).to be_nil # bogus is not a valid year
     end
 
     it 'parses the date correctly' do
@@ -193,7 +193,7 @@ describe PubmedSourceRecord, :vcr do
       # manual test data
       source_data = '<PubmedArticle><MedlineCitation Status="Publisher" Owner="NLM"><PMID Version="1">1</PMID><OriginalData/></PubmedArticle>'
       record = described_class.create(pmid: pmid_created_1999, source_data: source_data)
-      expect(record.source_as_hash[:date]).to eq nil # no date
+      expect(record.source_as_hash[:date]).to be_nil # no date
     end
 
     it 'ignores the day when not found' do

--- a/spec/models/pubmed_source_record_spec.rb
+++ b/spec/models/pubmed_source_record_spec.rb
@@ -149,6 +149,15 @@ describe PubmedSourceRecord, :vcr do
       record = create :pubmed_source_record_23388678 # year in another alternate location
       expect(record.source_as_hash[:year]).to eq '2013'
     end
+
+    it 'parses the date correctly' do
+      record = create :pubmed_source_record_10000166 # date
+      expect(record.source_as_hash[:date]).to eq '1992-02-05'
+      record = create :pubmed_source_record_29279863 # another date
+      expect(record.source_as_hash[:date]).to eq '2017-12-22'
+      record = create :pubmed_source_record_23388678 # another date
+      expect(record.source_as_hash[:date]).to eq '2013-02-08'
+    end
   end
 
   describe '.pubmed_update' do


### PR DESCRIPTION
## Why was this change made?

Fixes #1441 (upcoming request from Profiles):  if available, we should map dates from PubmedSource Records into the same YYYY-MM-DD format as we do for WoS and ORCID records

Notes:
- refactored how the year (currently done in our code) is extracted so we can use the same type of code for the month/year
- could add some more Pubmed fixtures to test some more permutations of date locations/formats to be parsed
- once done, we will need to go back and rebuild the pubhash for Pubmed sourced records if we want to the date added

There is a rake task for rebuilding Pubmed pub hashes from a previous remediation, but it starts with cap_profile_ids: see https://github.com/sul-dlss/sul_pub/blob/main/lib/tasks/pubmed.rake#L7  In this case, we may want to do *all* Pubmed sourced publications (or all retrieved after a certain date), so we'd have a much bigger set to start from.  Basically all you have to do is call `publication#rebuild_pub_hash` on any publication that has a Pubmed provenance to remap.  See https://github.com/sul-dlss/sul_pub/issues/1441#issuecomment-1054842850 for how to do this (tested in cap-dev)

Note that rebuilding pubhashes will touch the "last_updated" field in the publication record, which will then cause the publication to be returned to Profiles as updated in their nightly update API call.  So after we do the remediation (if we do it), they will end up with a huge batch of updated publications (when they are used to a much smaller number).  Edit: there will be ~17910 (see https://github.com/sul-dlss/sul_pub/issues/1441#issuecomment-1054842850)

See https://github.com/sul-dlss/sul_pub/wiki/Useful-console-commands-(harvest,-WoS,-Pubmed,-others)#provenance-publication-stats for some ideas on how to query for the Pubmed provenance publications.

## How was this change tested?

- Added some new tests
- Deployed to cap-dev, which has ~16k publications that are Pubmed provenance.  Added the date to all of these and then verified that the date's year matched the year using https://github.com/sul-dlss/sul_pub/issues/1441#issuecomment-1054842850


## Which documentation and/or configurations were updated?



