### PR TITLE
remove unnec requires from a spec

### DIFF
--- a/spec/lib/web_of_science/wsdl.rb
+++ b/spec/lib/web_of_science/wsdl.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'faraday'
-require 'webmock'
-
 module WebOfScience
   # WebOfScience WSDL files
   class WSDL


### PR DESCRIPTION
## Why was this change made?

cruft is confusing

## How was this change tested?

test suite

## Which documentation and/or configurations were updated?



