### PR TITLE
temporarily disable MaIS update job during maintenance

### DIFF
--- a/app/models/pubmed_source_record.rb
+++ b/app/models/pubmed_source_record.rb
@@ -175,13 +175,15 @@ class PubmedSourceRecord < ApplicationRecord
     year = extract_year_from_pubmed_record(publication)
     record_as_hash[:year] = year if year
 
-    month = extract_month_from_pubmed_record(publication)
-    day = extract_day_from_pubmed_record(publication)
-    if year && month && day
-      record_as_hash[:date] =  "#{year}-#{month.rjust(2, '0')}-#{day.rjust(2, '0')}"
-    elsif year && month
-      record_as_hash[:date] =  "#{year}-#{month.rjust(2, '0')}"
-    end
+    # NOTE: Temporarily disable date extraction from Pubmed until we can troubleshoot with Profiles
+    # When renabled, also un 'xit' the tests in pumbed_source_record_spec
+    # month = extract_month_from_pubmed_record(publication)
+    # day = extract_day_from_pubmed_record(publication)
+    # if year && month && day
+    #   record_as_hash[:date] =  "#{year}-#{month.rjust(2, '0')}-#{day.rjust(2, '0')}"
+    # elsif year && month
+    #   record_as_hash[:date] =  "#{year}-#{month.rjust(2, '0')}"
+    # end
 
     record_as_hash[:type] = Settings.sul_doc_types.article
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -23,9 +23,9 @@ every 1.day, at: stagger(4), roles: [:harvester_dev, :harvester_qa, :harvester_p
 end
 
 # poll mais for new ORCID information nightly at 5am-ish in prod, qa and dev
-every 1.day, at: stagger(5), roles: [:harvester_dev, :harvester_qa, :harvester_prod] do
-  rake 'mais:update_authors'
-end
+# every 1.day, at: stagger(5), roles: [:harvester_dev, :harvester_qa, :harvester_prod] do
+#   rake 'mais:update_authors'
+# end
 
 # send publications to ORCID profiles for all authorized users at 8am-ish every 7 days in qa
 every 7.days, at: stagger(8), roles: [:harvester_qa] do

--- a/spec/models/pubmed_source_record_spec.rb
+++ b/spec/models/pubmed_source_record_spec.rb
@@ -179,7 +179,7 @@ describe PubmedSourceRecord, :vcr do
       expect(record.source_as_hash[:year]).to be_nil # bogus is not a valid year
     end
 
-    it 'parses the date correctly' do
+    xit 'parses the date correctly' do
       # fixture records
       record = create :pubmed_source_record_10000166 # date
       expect(record.source_as_hash[:date]).to eq '1992-02-05'
@@ -189,14 +189,14 @@ describe PubmedSourceRecord, :vcr do
       expect(record.source_as_hash[:date]).to eq '2013-02-08'
     end
 
-    it 'sets the date to nil when not found' do
+    xit 'sets the date to nil when not found' do
       # manual test data
       source_data = '<PubmedArticle><MedlineCitation Status="Publisher" Owner="NLM"><PMID Version="1">1</PMID><OriginalData/></PubmedArticle>'
       record = described_class.create(pmid: pmid_created_1999, source_data: source_data)
       expect(record.source_as_hash[:date]).to be_nil # no date
     end
 
-    it 'ignores the day when not found' do
+    xit 'ignores the day when not found' do
       source_data =
         <<-XML
           <PubmedArticle>
@@ -217,7 +217,7 @@ describe PubmedSourceRecord, :vcr do
       expect(record.source_as_hash[:date]).to eq '2017-05' # no day in one of the acceptable date paths, it zero pads the month
     end
 
-    it 'handles a month as an abbreviation' do
+    xit 'handles a month as an abbreviation' do
       source_data =
         <<-XML
           <PubmedArticle>


### PR DESCRIPTION
## Why was this change made?

MaIS is performing maintenance the weekend of March 18 - March 21.  We should disable the MaIS job during this window to avoid errors by deploying this branch on March 18 and then letting main get redeployed on the 21st.  We can then delete this branch.

## How was this change tested?



## Which documentation and/or configurations were updated?



