### PR TITLE
[HOLD] Add provenance column to publication table

### DIFF
--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -48,24 +48,35 @@ class Author < ApplicationRecord
     Settings.HARVESTER.INSTITUTION.name
   end
 
-  # rubocop:disable Metrics/AbcSize
   # indicates if the LastName, FirstInitial form for this user is unique within our author database
   #  (including any alternate identities that include Stanford as an institution)
   #  also checks to see if there are alternate identities with institutions other than Stanford, which is problematic, and should be considered ambiguous
   def unique_first_initial?
     return false unless first_name && last_name # this method only works if you have a complete first and last name
 
-    first_initial_not_unique = self.class.where('preferred_first_name like ? and preferred_last_name = ?', "#{first_name[0]}%", last_name).size > 1
-    author_identities_not_unique = author_identities.map do |author_identity|
-      (author_identity.institution.present? && author_identity.institution.exclude?('Stanford')) ||
-        self.class.where(
-          'preferred_first_name like ? and preferred_last_name = ? and id != ?',
-          "#{author_identity.first_name[0]}%", author_identity.last_name, author_identity.author_id
-        ).size > 1
-    end
-    !(first_initial_not_unique || author_identities_not_unique.include?(true))
+    !(first_initial_not_unique? || author_identities_not_unique?)
   end
-  # rubocop:enable Metrics/AbcSize
+
+  def first_initial_not_unique?
+    self.class.where_first_name_like_and_last_name_equal(first_name[0], last_name).size > 1
+  end
+
+  def author_identities_not_unique?
+    author_identities.map do |author_identity|
+      (author_identity.institution.present? && author_identity.institution.exclude?('Stanford')) ||
+        self.class.where_first_name_like_and_last_name_equal(author_identity.first_name[0],
+                                                             author_identity.last_name,
+                                                             exclude_author_id: author_identity.author_id).size > 1
+    end.include?(true)
+  end
+
+  def self.where_first_name_like_and_last_name_equal(first_name_prefix, last_name, exclude_author_id: nil)
+    relation = where('preferred_first_name like ?', "#{first_name_prefix}%")
+               .where(preferred_last_name: last_name)
+    relation = relation.where.not(id: exclude_author_id) if exclude_author_id
+
+    relation
+  end
 
   # @param [Hash] auth_hash data as-is from CAP API
   def update_from_cap_authorship_profile_hash(auth_hash)

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -31,6 +31,7 @@ class Publication < ApplicationRecord
     self.publication_type = pub_hash[:type] if pub_hash[:type].present?
     self.year = pub_hash[:year] if pub_hash[:year].present?
     self.wos_uid ||= web_of_science_source_record.uid if web_of_science_source_record.present?
+    self.provenance = pub_hash[:provenance] # NOTE: we validate the presence and value of provenance with the PubHashValidator
   end
 
   has_one :batch_uploaded_source_record, dependent: :destroy
@@ -270,7 +271,8 @@ class Publication < ApplicationRecord
 
   private
 
-  # @return [String] might be empty, won't be nil
+  # @return [String] might be empty, won't be nil, normalize since we have some older data in varying cases
+  # @note obscures ActiveRecord field/attribute getter for provenance
   def provenance
     pub_hash[:provenance].to_s.downcase
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -85,7 +85,6 @@ DOI:
 HARVESTER:
   LOG: log/all_sources_harvester.log
   USE_MIDDLE_NAME: true
-  USE_FIRST_INITIAL: false
   USE_AUTHOR_IDENTITIES: false
   INSTITUTION:
     name: Stanford University

--- a/db/migrate/20220311182838_add_provenance_field.rb
+++ b/db/migrate/20220311182838_add_provenance_field.rb
@@ -1,0 +1,6 @@
+class AddProvenanceField < ActiveRecord::Migration[6.1]
+  def change
+    add_column :publications, :provenance, :string
+    add_index :publications, :provenance
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_11_185021) do
+ActiveRecord::Schema.define(version: 2022_03_11_182838) do
 
   create_table "author_identities", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "author_id", null: false
@@ -140,9 +140,11 @@ ActiveRecord::Schema.define(version: 2022_01_11_185021) do
     t.string "issn"
     t.string "publication_type"
     t.string "wos_uid"
+    t.string "provenance"
     t.index ["issn"], name: "index_publications_on_issn"
     t.index ["pages"], name: "index_publications_on_pages"
     t.index ["pmid"], name: "index_publications_on_pmid"
+    t.index ["provenance"], name: "index_publications_on_provenance"
     t.index ["sciencewire_id"], name: "index_publications_on_sciencewire_id"
     t.index ["title"], name: "index_publications_on_title", length: 255
     t.index ["updated_at"], name: "index_publications_on_updated_at"

--- a/lib/agent/author_name.rb
+++ b/lib/agent/author_name.rb
@@ -50,9 +50,14 @@ module Agent
     # an 'or' conjuction is likely to generate results that mostly match this variant,
     # but additional variants might add something when using an 'ExactMatch' search.
     # @return [String] name(s) to be queried in an OR (disjunction) query
-    def text_search_terms
+    def text_search_query
+      text_search_terms.map { |x| "\"#{x}\"" }.join(' or ')
+    end
+
+    def text_search_terms(options = {})
+      use_first_initial = options[:use_first_initial] || true
       @text_search_terms ||=
-        [first_name_query, middle_name_query].flatten.compact_blank.uniq
+        [first_name_query(use_first_initial), middle_name_query(use_first_initial)].flatten.compact_blank.uniq
     end
 
     def ==(other)
@@ -67,11 +72,11 @@ module Agent
     # 'Lastname,Firstname' or
     # 'Lastname,FirstInitial'
     # @return [Array<String>|String] names
-    def first_name_query
+    def first_name_query(use_first_initial)
       return '' if last.empty? && first.empty?
 
-      query =  ["#{last_name},#{first_name}"]
-      query += ["#{last_name},#{first_initial}"] if Settings.HARVESTER.USE_FIRST_INITIAL
+      query = ["#{last_name},#{first_name}"]
+      query += ["#{last_name},#{first_initial}"] if use_first_initial
       query
     end
 
@@ -80,14 +85,11 @@ module Agent
     # 'Lastname,Firstname,MiddleInitial' or
     # 'Lastname,FirstInitial,MiddleInitial'
     # @return [Array<String>|String] names
-    def middle_name_query
+    def middle_name_query(use_first_initial)
       return '' unless middle =~ /^[[:alpha:]]/
 
-      query = ["#{last_name},#{first_name},#{middle_name}", "#{last_name},#{first_name},#{middle_initial}"]
-      if Settings.HARVESTER.USE_FIRST_INITIAL
-        query += ["#{last_name},#{first_initial}#{middle_initial}",
-                  "#{last_name},#{first_initial},#{middle_initial}"]
-      end
+      query =  ["#{last_name},#{first_name},#{middle_name}", "#{last_name},#{first_name},#{middle_initial}"]
+      query += ["#{last_name},#{first_initial}#{middle_initial}", "#{last_name},#{first_initial},#{middle_initial}"] if use_first_initial
       query
     end
 

--- a/lib/agent/author_name.rb
+++ b/lib/agent/author_name.rb
@@ -50,12 +50,7 @@ module Agent
     # an 'or' conjuction is likely to generate results that mostly match this variant,
     # but additional variants might add something when using an 'ExactMatch' search.
     # @return [String] name(s) to be queried in an OR (disjunction) query
-    def text_search_query
-      text_search_terms.map { |x| "\"#{x}\"" }.join(' or ')
-    end
-
-    def text_search_terms(options = {})
-      use_first_initial = options[:use_first_initial] || true
+    def text_search_terms(use_first_initial: true)
       @text_search_terms ||=
         [first_name_query(use_first_initial), middle_name_query(use_first_initial)].flatten.compact_blank.uniq
     end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+namespace :data do
+  desc 'Backfile provenance into AR column for all records'
+  # A new field was added to the publication table to allow for querying on publication provenance (already stored in pub_hash).
+  # This task goes through all publications and adds the value to this field from the pub_hash
+  # RAILS_ENV=production bundle exec rake cleanup:merge_profiles[123,456] # will merge all publications from cap_profile_id 456 into 123, without duplication
+  # rubocop:disable Rails/SkipsModelValidations
+  task add_provenance: :environment do |_t, _args|
+    num_pubs = Publication.where(provenance: nil).count
+    puts "Started at #{Time.zone.now}"
+    puts "Found #{num_pubs} with missing provenance."
+    Publication.where(provenance: nil).find_each.with_index do |pub, i|
+      puts "#{i + 1} of #{num_pubs}"
+      pub.update_column('provenance', pub.pub_hash[:provenance]) # skip callbacks and timetamp updates, just set the value
+    end
+    puts "Finished at #{Time.zone.now}"
+  end
+  # rubocop:enable Rails/SkipsModelValidations
+end

--- a/lib/web_of_science/query_name.rb
+++ b/lib/web_of_science/query_name.rb
@@ -41,7 +41,7 @@ module WebOfScience
             ident.first_name,
             Settings.HARVESTER.USE_MIDDLE_NAME ? ident.middle_name : ''
           )
-        end&.text_search_terms
+        end&.text_search_terms(use_first_initial: author.unique_first_initial?)
       end.flatten.compact.uniq
     end
 

--- a/spec/factories/author.rb
+++ b/spec/factories/author.rb
@@ -65,6 +65,26 @@ FactoryBot.define do
     end
   end
 
+  factory :author_duped_last_name, parent: :author do
+    sunetid { FactoryBot.generate(:random_id) }
+    cap_profile_id { FactoryBot.generate(:random_id) }
+    university_id { FactoryBot.generate(:random_id) }
+    california_physician_license { FactoryBot.generate(:random_string) }
+    active_in_cap { true }
+    email { 'alice.edler@stanford.edu' }
+    official_first_name { 'Albert' }
+    official_last_name { 'Edler' }
+    official_middle_name { '' }
+    preferred_first_name { 'Albert' }
+    preferred_last_name { 'Edler' }
+    preferred_middle_name { '' }
+    emails_for_harvest { 'albert.edler@stanford.edu' }
+  end
+
+  factory :inactive_author, parent: :author do
+    active_in_cap { false }
+  end
+
   factory :author_with_alternate_identities, parent: :author do
     transient do
       alt_count { 1 } # default number of alternate identities to create
@@ -74,6 +94,19 @@ FactoryBot.define do
         create(:author_identity, author: author)
       end
     end
+  end
+
+  factory :odd_name, parent: :author do
+    active_in_cap { true }
+    cap_import_enabled { true }
+    official_first_name { 'Somebody' }
+    official_last_name { 'WithReallyUnusualName' }
+    official_middle_name { '' }
+    preferred_first_name { 'Somebody' }
+    preferred_last_name { 'WithReallyUnusualName' }
+    preferred_middle_name { '' }
+    email { 'Somebody.WithReallyUnusualName@stanford.edu' }
+    emails_for_harvest { 'Somebody.WithReallyUnusualName@stanford.edu' }
   end
 
   # Public data from

--- a/spec/lib/agent/author_name_spec.rb
+++ b/spec/lib/agent/author_name_spec.rb
@@ -120,10 +120,21 @@ describe Agent::AuthorName do
   end
 
   describe '#text_search_terms' do
-    it 'includes first_name_query and middle_name_query elements' do
+    it 'includes first_name_query and middle_name_query elements when first initial is unique' do
       fnames = all_names.send(:first_name_query, true)
       mnames = all_names.send(:middle_name_query, true)
-      expect(all_names.text_search_terms).to include(*fnames, *mnames)
+      expect(fnames.size).to eq 2 # two name variants, full first name plus first initial
+      expect(mnames.size).to eq 4 # four name variants, which include middle name and middle initial variants
+      expect(all_names.text_search_terms).to include(*fnames, *mnames) # default is to use first initial, this verifies
+      expect(all_names.text_search_terms(use_first_initial: true)).to include(*fnames, *mnames)
+    end
+
+    it 'includes first_name_query and middle_name_query elements when first initial is not unique' do
+      fnames = all_names.send(:first_name_query, false)
+      mnames = all_names.send(:middle_name_query, false)
+      expect(fnames.size).to eq 1 # only one name variant with only full first name (i.e. no first initial)
+      expect(mnames.size).to eq 2 # two name variants, includes full middle name and middle initial
+      expect(all_names.text_search_terms(use_first_initial: false)).to include(*fnames, *mnames)
     end
   end
 

--- a/spec/lib/agent/author_name_spec.rb
+++ b/spec/lib/agent/author_name_spec.rb
@@ -181,16 +181,20 @@ describe Agent::AuthorName do
         expect(fn_query).not_to include(be_empty)
         expect(fn_query.size).to eq(fn_query.uniq.size)
       end
+
       it 'includes name with first_name' do
         expect(fn_query).to include "#{all_names.last_name},#{all_names.first_name}"
       end
+
       it 'does not include name with first_initial' do
         expect(fn_query).not_to include "#{all_names.last_name},#{all_names.first_initial}"
       end
+
       it 'does not include name with middle_name' do
         expect(fn_query).not_to include "#{all_names.last_name},#{all_names.first_name},#{all_names.middle_name}"
         expect(fn_query).to all(exclude(",#{all_names.middle_name}"))
       end
+
       it 'does not include name with middle_initial' do
         expect(fn_query).not_to include "#{all_names.last_name},#{all_names.first_name},#{all_names.middle_initial}"
         expect(fn_query).to all(exclude(",#{all_names.middle_initial}"))

--- a/spec/lib/agent/author_name_spec.rb
+++ b/spec/lib/agent/author_name_spec.rb
@@ -121,23 +121,19 @@ describe Agent::AuthorName do
 
   describe '#text_search_terms' do
     it 'includes first_name_query and middle_name_query elements' do
-      fnames = all_names.send(:first_name_query)
-      mnames = all_names.send(:middle_name_query)
+      fnames = all_names.send(:first_name_query, true)
+      mnames = all_names.send(:middle_name_query, true)
       expect(all_names.text_search_terms).to include(*fnames, *mnames)
     end
   end
 
   describe '#first_name_query' do
     it 'when no names are present returns an empty String' do
-      expect(no_names.send(:first_name_query)).to eq ''
+      expect(no_names.send(:first_name_query, true)).to eq ''
     end
 
-    context 'when all names are present' do
-      let(:fn_query) { all_names.send(:first_name_query) }
-
-      before do
-        allow(Settings.HARVESTER).to receive(:USE_FIRST_INITIAL).and_return(false)
-      end
+    context 'when all names are present with middle initial' do
+      let(:fn_query) { all_names.send(:first_name_query, true) }
 
       it 'is Array<String> with non-empty unique values' do
         expect(fn_query).to be_an Array
@@ -150,8 +146,8 @@ describe Agent::AuthorName do
         expect(fn_query).to include "#{all_names.last_name},#{all_names.first_name}"
       end
 
-      it 'excludes name with first_initial when settings do not allow for it' do
-        expect(fn_query).not_to include "#{all_names.last_name},#{all_names.first_initial}"
+      it 'includes name with first_initial when settings allow for it' do
+        expect(fn_query).to include "#{all_names.last_name},#{all_names.first_initial}"
       end
 
       it 'does not include name with middle_name' do
@@ -165,30 +161,39 @@ describe Agent::AuthorName do
       end
     end
 
-    context 'when all names are present and settings allow for first initial' do
-      before do
-        allow(Settings.HARVESTER).to receive(:USE_FIRST_INITIAL).and_return(true)
+    context 'when all names are present without middle initial' do
+      let(:fn_query) { all_names.send(:first_name_query, false) }
+
+      it 'is Array<String> with non-empty unique values' do
+        expect(fn_query).to be_an Array
+        expect(fn_query).to all(be_a(String))
+        expect(fn_query).not_to include(be_empty)
+        expect(fn_query.size).to eq(fn_query.uniq.size)
       end
-
-      let(:fn_query) { all_names.send(:first_name_query) }
-
-      it 'includes name with first_initial when settings allow for it' do
-        expect(fn_query).to include "#{all_names.last_name},#{all_names.first_initial}"
+      it 'includes name with first_name' do
+        expect(fn_query).to include "#{all_names.last_name},#{all_names.first_name}"
+      end
+      it 'does not include name with first_initial' do
+        expect(fn_query).not_to include "#{all_names.last_name},#{all_names.first_initial}"
+      end
+      it 'does not include name with middle_name' do
+        expect(fn_query).not_to include "#{all_names.last_name},#{all_names.first_name},#{all_names.middle_name}"
+        expect(fn_query).to all(exclude(",#{all_names.middle_name}"))
+      end
+      it 'does not include name with middle_initial' do
+        expect(fn_query).not_to include "#{all_names.last_name},#{all_names.first_name},#{all_names.middle_initial}"
+        expect(fn_query).to all(exclude(",#{all_names.middle_initial}"))
       end
     end
   end
 
   describe '#middle_name_query' do
     it 'when no names are present returns an empty String' do
-      expect(no_names.send(:middle_name_query)).to eq ''
+      expect(no_names.send(:middle_name_query, false)).to eq ''
     end
 
     context 'when all names are present' do
-      let(:mn_query) { all_names.send(:middle_name_query) }
-
-      before do
-        allow(Settings.HARVESTER).to receive(:USE_FIRST_INITIAL).and_return(false)
-      end
+      let(:mn_query) { all_names.send(:middle_name_query, false) }
 
       it 'is Array<String> with non-empty unique values' do
         expect(mn_query).to be_an Array
@@ -219,11 +224,7 @@ describe Agent::AuthorName do
     end
 
     context 'when all names are present and settings allow for first initial' do
-      let(:mn_query) { all_names.send(:middle_name_query) }
-
-      before do
-        allow(Settings.HARVESTER).to receive(:USE_FIRST_INITIAL).and_return(true)
-      end
+      let(:mn_query) { all_names.send(:middle_name_query, true) }
 
       it 'includes name with middle_initial appended to first initial when settings allow for it' do
         expect(mn_query).to include "#{all_names.last_name},#{all_names.first_initial}#{all_names.middle_initial}"

--- a/spec/lib/web_of_science/query_author_spec.rb
+++ b/spec/lib/web_of_science/query_author_spec.rb
@@ -8,6 +8,9 @@ describe WebOfScience::QueryAuthor, :vcr do
   let(:author_blank_name) { create :author, :blank_first_name, :valid_orcid }
   let(:author_blank_name_and_orcid) { create :author, :blank_first_name, :blank_orcid }
 
+  let(:alternate_identity) { create :author_identity } # this creates the associated author as well
+  let(:alternate_author_identity) { alternate_identity.author }
+
   # avoid caching Savon client across examples (affects VCR)
   before { allow(WebOfScience).to receive(:client).and_return(WebOfScience::Client.new(Settings.WOS.AUTH_CODE)) }
 

--- a/spec/lib/web_of_science/query_name_spec.rb
+++ b/spec/lib/web_of_science/query_name_spec.rb
@@ -13,6 +13,9 @@ describe WebOfScience::QueryName, :vcr do
   let(:blank_author) { create :author, :blank_first_name }
   let(:names) { query_name.send(:names) }
 
+  let(:alternate_identity) { create :author_identity } # this creates the associated author as well
+  let(:alternate_author_identity) { alternate_identity.author }
+
   # avoid caching Savon client across examples (affects VCR)
   before { allow(WebOfScience).to receive(:client).and_return(WebOfScience::Client.new(Settings.WOS.AUTH_CODE)) }
 
@@ -75,9 +78,9 @@ describe WebOfScience::QueryName, :vcr do
   end
 
   describe '#names' do
-    #=> "\"Altman,Russ\" or \"Altman,R\" or \"Altman,Russ,Biagio\" or \"Altman,Russ,B\" or \"Altman,R,B\""
+    #=> "\"Altman,Russ\" or \"Altman,R\" or \"Altman,Russ,Biagio\" or \"Altman,Russ,B\" or \"Altman,RB\" or "\"Altman,R,B\""
     it 'includes all of the name variations, including the preferred last name' do
-      expect(names.size).to eq 5
+      expect(names.size).to eq 6
       expect(names).to include('Altman,Russ')
     end
   end
@@ -131,21 +134,75 @@ describe WebOfScience::QueryName, :vcr do
     end
   end
 
-  context 'for a single alternate identity with invalid data' do
-    describe '#names' do
-      let(:author_one_identity) { create :author }
-      let(:bad_alternate_identity) { create :author_identity }
+  context 'for a single alternate identity' do
+    let(:alt_last_name) { alternate_identity.last_name }
+    let(:alt_first_name) { alternate_identity.first_name }
+    let(:alt_middle_name) { alternate_identity.middle_name }
 
-      before do
-        bad_alternate_identity.update(first_name: '.')
-        author_one_identity.author_identities << bad_alternate_identity
+    describe '#names' do
+      context 'with invalid data and ambiguous first name' do
+        it 'ignores the bad alternate identity data and first initial variants' do
+          alternate_identity.update(first_name: '.', institution: 'Example')
+          expect(alternate_author_identity.unique_first_initial?).to be false # because of a non-Stanford alternate identity
+          expect(alternate_author_identity.author_identities.first.first_name).to eq '.' # bad first name
+          # we do not get the name variant with the period for a first name (i.e. the alternate identity)
+          #  nor do we get first initial variants because of the ambiguous first initial
+          #  (we would have more if we allowed the bad name variant and the ambiguous first initial)
+          expect(described_class.new(alternate_author_identity).send(:names)).to match_array %w[Edler,Alice
+                                                                                                Edler,Alice,Jim
+                                                                                                Edler,Alice,J]
+        end
       end
 
-      it 'ignores the bad alternate identity data' do
-        expect(author_one_identity.author_identities.first.first_name).to eq '.' # bad first name
-        # we get three name variants out (we would have more if we allowed the bad name variant)
-        expect(described_class.new(author_one_identity).send(:names)).to eq %w[Edler,Alice Edler,Alice,Jim
-                                                                               Edler,Alice,J]
+      context 'with invalid data and non-ambiguous first name' do
+        it 'ignores the bad alternate identity data but includes first initial variants' do
+          alternate_identity.update(first_name: '.', institution: 'Stanford')
+          expect(alternate_author_identity.unique_first_initial?).to be true # because alternate identity is Stanford and unique
+          expect(alternate_author_identity.author_identities.first.first_name).to eq '.' # bad first name
+          # we do not get the name variant with the period for a first name (i.e. no alternate identity)
+          expect(described_class.new(alternate_author_identity).send(:names)).to match_array %w[Edler,Alice
+                                                                                                Edler,A
+                                                                                                Edler,Alice,Jim
+                                                                                                Edler,Alice,J
+                                                                                                Edler,AJ
+                                                                                                Edler,A,J]
+        end
+      end
+
+      context 'with valid data and ambiguous first name' do
+        it 'ignores the first initial variants' do
+          alternate_identity.update(first_name: 'Sam', institution: 'Example')
+          expect(alternate_author_identity.unique_first_initial?).to be false # because of a non-Stanford alternate identity
+          #  we do not get first initial variants because of the ambiguous first initial
+          #  but we do get the other variants with the alternate identity
+          #  (we would have more if we allowed the bad name variant and the ambiguous first initial)
+          expect(described_class.new(alternate_author_identity).send(:names)).to match_array ['Edler,Alice',
+                                                                                              'Edler,Alice,Jim',
+                                                                                              'Edler,Alice,J',
+                                                                                              "#{alt_last_name},#{alt_first_name}",
+                                                                                              "#{alt_last_name},#{alt_first_name},#{alt_middle_name}",
+                                                                                              "#{alt_last_name},#{alt_first_name},#{alt_middle_name[0]}"]
+        end
+      end
+
+      context 'with valid data and non-ambiguous first name' do
+        it 'includes all name variants' do
+          alternate_identity.update(first_name: 'Alice2', institution: 'Stanford')
+          expect(alternate_author_identity.unique_first_initial?).to be true # because alternate identity is Stanford and unique
+          # we get all variants with first initials and also the alternate identity
+          expect(described_class.new(alternate_author_identity).send(:names)).to match_array ['Edler,Alice',
+                                                                                              'Edler,A',
+                                                                                              'Edler,Alice,Jim',
+                                                                                              'Edler,Alice,J',
+                                                                                              'Edler,AJ',
+                                                                                              'Edler,A,J',
+                                                                                              "#{alt_last_name},#{alt_first_name}",
+                                                                                              "#{alt_last_name},#{alt_first_name[0]}",
+                                                                                              "#{alt_last_name},#{alt_first_name},#{alt_middle_name}",
+                                                                                              "#{alt_last_name},#{alt_first_name},#{alt_middle_name[0]}",
+                                                                                              "#{alt_last_name},#{alt_first_name[0]}#{alt_middle_name[0]}",
+                                                                                              "#{alt_last_name},#{alt_first_name[0]},#{alt_middle_name[0]}"]
+        end
       end
     end
   end

--- a/spec/models/author_spec.rb
+++ b/spec/models/author_spec.rb
@@ -70,25 +70,28 @@ describe Author do
     it 'confirms unique first initial within stanford with no alternate identities' do
       odd_name = create :odd_name
       expect(odd_name.author_identities.size).to eq(0) # has no alternate identities
-      expect(odd_name.unique_first_initial?).to eq(true) # and no other odd names likes this at stanford, so ok to search with first initial
+      expect(odd_name.unique_first_initial?).to be(true) # and no other odd names likes this at stanford, so ok to search with first initial
     end
+
     it 'confirms unique first initial within stanford with stanford only alternate identities' do
       subject.update_from_cap_authorship_profile_hash(auth_hash)
       expect(subject.author_identities.size).to eq(2) # has alternate identities
-      expect(subject.unique_first_initial?).to eq(true) # ok, because all identities are stanford or no institution, and no other first name ambiguity
+      expect(subject.unique_first_initial?).to be(true) # ok, because all identities are stanford or no institution, and no other first name ambiguity
     end
+
     it 'confirms ambiguous first initial within stanford with no alternate identities' do
       create :author_duped_last_name
       expect(subject.author_identities.size).to eq(0) # no alternate identities
-      expect(subject.unique_first_initial?).to eq(false) # not unique, because we now have another stanford author with same last name and first initial
+      expect(subject.unique_first_initial?).to be(false) # not unique, because we now have another stanford author with same last name and first initial
     end
+
     it 'confirms ambiguous first initial even when non ambiguous within Stanford due to a non-Stanford alternate identity existing' do
       author_with_alternate_identities = create :author_with_alternate_identities
       expect(author_with_alternate_identities.author_identities.size).to eq(1) # alternate identities for primary author
       expect(author_with_alternate_identities.author_identities.first.institution).not_to be blank? # alternate institution is not empty
       expect(author_with_alternate_identities.author_identities.first.institution.include?('Stanford')).to be false # alternate institution is not Stanford
       # not unique, because even though there are no other stanford authors with similar names, they have a non-Stanford alternate identity
-      expect(author_with_alternate_identities.unique_first_initial?).to eq(false)
+      expect(author_with_alternate_identities.unique_first_initial?).to be(false)
     end
   end
 


### PR DESCRIPTION
SOMETHING GOT MESSED UP ... EXTRA COMMITS.  I will fix and force push.

## Why was this change made?

Fixes #652 - this will make it easier to run some analysis queries about where publications originally came from without resorting to identifiers or inspecting the pub_hash.  Note that this change will need a migration to the database, adding a column and an index to a big table, so may want to do off hours in case it takes a while.  

Hold for now so we can plan this for a good time.

we will then want to run the rake task to back-fill data

## How was this change tested?

Localhost

## Which documentation and/or configurations were updated?



