### PR TITLE
replace mysql2 gem with sqllite3 in dev/test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,9 +9,6 @@ gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '~> 4.1'
 
-# mysql 0.5.3 is required for ruby 3 and is supported on latest OS in use: Oracle Linux (as of Jan 2022)
-gem 'mysql2', '>= 0.5.3'
-
 gem 'nokogiri', '>= 1.7.1'
 
 gem 'activerecord-import'
@@ -60,6 +57,7 @@ group :development, :test do
   gem 'rubocop-rake'
   gem 'rspec'
   gem 'rspec-rails'
+  gem 'sqlite3'
 end
 
 group :development do
@@ -79,6 +77,11 @@ group :test do
   gem 'simplecov', '~> 0.13', require: false
   gem 'vcr'
   gem 'webmock'
+end
+
+group :production do
+  # mysql 0.5.3 is required for ruby 3 and is supported on latest OS in use: Oracle Linux (as of Jan 2022)
+  gem 'mysql2', '>= 0.5.3'
 end
 
 group :deployment do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -250,7 +250,7 @@ GEM
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    loofah (2.14.0)
+    loofah (2.15.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -377,7 +377,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.16.0)
       parser (>= 3.1.1.0)
-    rubocop-rails (2.13.2)
+    rubocop-rails (2.14.0)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)
@@ -426,6 +426,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sqlite3 (1.4.2)
     sshkit (1.21.2)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
@@ -469,7 +470,7 @@ GEM
 
 PLATFORMS
   ruby
-  x86_64-darwin-18
+  x86_64-darwin-19
   x86_64-linux
 
 DEPENDENCIES
@@ -529,6 +530,7 @@ DEPENDENCIES
   savon (~> 2.12)
   simple_form
   simplecov (~> 0.13)
+  sqlite3
   thin
   uglifier (~> 4.1)
   unicode
@@ -538,4 +540,4 @@ DEPENDENCIES
   yaml_db
 
 BUNDLED WITH
-   2.2.32
+   2.3.8

--- a/config/database.yml
+++ b/config/database.yml
@@ -12,22 +12,17 @@
 #   http://dev.mysql.com/doc/refman/5.0/en/old-client.html
 #
 default: &default
-  adapter: mysql2
-  encoding: utf8
+  adapter: sqlite3
   pool: 5
-  username: root
-  password:
-  host: "<%= ENV.fetch('DATABASE_HOSTNAME', '127.0.0.1') %>"
-  port: "<%= ENV.fetch('DATABASE_PORT', 3306) %>"
-  # socket: /var/run/mysqld/mysqlx.sock
+  timeout: 5000
 
 development:
   <<: *default
-  database: sulbib_development
+  database: db/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: sulbib_test
+  database: db/test.sqlite3

--- a/lib/web_of_science/process_pubmed.rb
+++ b/lib/web_of_science/process_pubmed.rb
@@ -71,7 +71,7 @@ module WebOfScience
       pmid ||= parse_pmid(pub.pmid)
       return unless Pubmed.working?
 
-      pub_id = pub.publication_identifiers.find_by(identifier_type: 'PMID', identifier_value: pmid)
+      pub_id = pub.publication_identifiers.find_by('identifier_type = ? OR identifier_type = ? AND identifier_value = ?', 'pmid', 'PMID', pmid)
       if pub_id.present?
         pub_id.pub_hash_update(delete: true)
         pub_id.destroy


### PR DESCRIPTION
## Why was this change made?

We do not need mysql installed locally just to run in development/test mode.  Also, installing the mysql2 gem can be a challenge to install on a laptop due to dependencies.  This moves the mysql2 gem so it is only used in production, and allows sqlite3 to be used for dev/test.  

Since mysql defaults to case insensitive text searches, and sqllite3 does not, I made one small change to the code to ensure the tests continue to run successfully with sqlite3.

All environments deploy in production mode, so will continue to use mysql.

## How was this change tested?

Test suite, and tried deploying to cap-dev to ensure it still deploys cleanly.


## Which documentation and/or configurations were updated?



