### PR TITLE
adjust db migrations to work with sqlite3

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -16,9 +16,19 @@ default: &default
   pool: 5
   timeout: 5000
 
+  # If you want to use mysql, e.g. with docker, use this instead of the adapter above
+  #  and change database names below for development and test:
+  # adapter: mysql2
+  # encoding: utf8
+  # username: root
+  # password:
+  # host: "<%= ENV.fetch('DATABASE_HOSTNAME', '127.0.0.1') %>"
+  # port: "<%= ENV.fetch('DATABASE_PORT', 3306) %>"
+
 development:
   <<: *default
   database: db/development.sqlite3
+  # database: sulbib_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -26,3 +36,4 @@ development:
 test:
   <<: *default
   database: db/test.sqlite3
+  # database: sulbib_test

--- a/db/migrate/20160412224434_create_author_identities.rb
+++ b/db/migrate/20160412224434_create_author_identities.rb
@@ -1,10 +1,9 @@
 class CreateAuthorIdentities < ActiveRecord::Migration[4.2]
   def change
     # On MySQL, foreign keys require the InnoDB storage engine, and we need to ensure UTF8 charsets for strings
-    opts = {}
-    opts[:options] = 'ENGINE=InnoDB DEFAULT CHARSET=utf8' if ActiveRecord::Base.connection.adapter_name.downcase.starts_with? 'mysql'
+    options = ActiveRecord::Base.connection.adapter_name.downcase.starts_with?('mysql') ? 'ENGINE=InnoDB DEFAULT CHARSET=utf8' : ''
 
-    create_table :author_identities, opts do |t|
+    create_table :author_identities, options: options do |t|
       t.belongs_to :author,       index: true, foreign_key: true, null: false
       t.integer :identity_type,   limit: 1, default: 0, null: false # enum: :alternate = 0, :official, :preferred, or :primary
       t.string :first_name,       limit: 255, null: false

--- a/db/migrate/20210520185112_create_orcid_source_records.rb
+++ b/db/migrate/20210520185112_create_orcid_source_records.rb
@@ -1,7 +1,8 @@
 class CreateOrcidSourceRecords < ActiveRecord::Migration[6.0]
+  # `:text` column with 16MB is the same as MySQL's MEDIUMTEXT but works on sqlite3
   def change
     create_table :orcid_source_records do |t|
-      t.mediumtext :source_data
+      t.text :source_data, limit: 16_777_215
       t.bigint :last_modified_date
       t.string :orcidid
       t.string :put_code


### PR DESCRIPTION
## Why was this change made?

If you run migrations on a brand new blank database, you will hit a couple failures.  One seems to be change in syntax, the other uses a datatype that is only applicable to MySQL.  These changes are needed to get them to run correctly and work with sqlite3.  They also work with mysql (I tested locally).  

Also, I added in some comments into the database.yml file in case you want to use mysql locally.

## How was this change tested?

Running migrations from a blank database on sqlite3 and mysql (on laptop)

## Which documentation and/or configurations were updated?



