### PR TITLE
[HOLD] pick month and day from same part of xml

### DIFF
--- a/app/models/pubmed_source_record.rb
+++ b/app/models/pubmed_source_record.rb
@@ -102,33 +102,34 @@ class PubmedSourceRecord < ApplicationRecord
   # see https://dtd.nlm.nih.gov/ncbi/pubmed/doc/out/180101/el-Year.html
   def extract_year_from_pubmed_record(publication)
     # look for a year in all of the xpath locations in order, pick the first that produces something that looks like a four digit year
-    pubmed_date_xpaths('Year')
-      .map { |path| publication.xpath(path).text.match(/[12][0-9]{3}/).to_s }
+    pubmed_date_xpaths
+      .map { |path| publication.xpath("#{path}/Year").text.match(/[12][0-9]{3}/).to_s }
       .compact_blank.first
   end
 
   # see https://dtd.nlm.nih.gov/ncbi/pubmed/doc/out/180101/el-Month.html
-  def extract_month_from_pubmed_record(publication)
+  # see https://dtd.nlm.nih.gov/ncbi/pubmed/doc/out/180101/el-Day.html
+  def extract_month_day_from_pubmed_record(publication)
     # look for a month in all of the xpath locations in order
     #  pick the first that produces something that looks like a month (12 or Aug)
-    pubmed_date_xpaths('Month').map do |path|
-      month_value = publication.xpath(path).text
-      match = month_value.match(/\A[012]?[0-9]{1}\z/) # e.g. 01, 11, 06, 6, 12
+    # then look for a day in the same place as the month ... since they must go together
+    #  we will return just a month or a month and a day, going in the order set in the xpaths
+    result = pubmed_date_xpaths.map do |path|
+      month_value = publication.xpath("#{path}/Month").text
+      month_match = month_value.match(/\A[012]?[0-9]{1}\z/) # e.g. 01, 11, 06, 6, 12
       name_match = month_value.match(/\A[a-zA-Z]{3}\z/) # e.g. Aug, aug, Oct
-      match = Date::ABBR_MONTHNAMES.index(name_match.to_s) if name_match # convert month name to number
-      match.to_s
-    end.compact_blank.first
-  end
+      month_match = Date::ABBR_MONTHNAMES.index(name_match.to_s) if name_match # convert month name to number if it's a name
 
-  # see https://dtd.nlm.nih.gov/ncbi/pubmed/doc/out/180101/el-Day.html
-  def extract_day_from_pubmed_record(publication)
-    # look for a day in all of the xpath locations in order
-    #  pick the first that produces something that looks like a day
-    pubmed_date_xpaths('Day').map do |path|
-      day_value = publication.xpath(path).text
-      match = day_value.match(/\A[0123]?[0-9]{1}\z/) # e.g. 01, 11, 06, 6, 12, 23, 30
-      match.to_s
-    end.compact_blank.first
+      day_value = publication.xpath("#{path}/Day").text
+      day_match = day_value.match(/\A[0123]?[0-9]{1}\z/) # e.g. 01, 11, 06, 6, 12, 23, 30
+
+      if month_match && day_match # add both 0 padded month and day if both exist in same spot
+        "#{month_match.to_s.rjust(2, '0')}-#{day_match.to_s.rjust(2, '0')}"
+      elsif month_match # only add the month if day not found
+        month_match.to_s.rjust(2, '0').to_s
+      end
+    end
+    result.compact_blank.first # return the first entry that has either a month or a month and a day
   end
 
   # Convert MEDLINE®PubMed® XML to pub_hash
@@ -175,15 +176,8 @@ class PubmedSourceRecord < ApplicationRecord
     year = extract_year_from_pubmed_record(publication)
     record_as_hash[:year] = year if year
 
-    # NOTE: Temporarily disable date extraction from Pubmed until we can troubleshoot with Profiles
-    # When renabled, also un 'xit' the tests in pumbed_source_record_spec
-    # month = extract_month_from_pubmed_record(publication)
-    # day = extract_day_from_pubmed_record(publication)
-    # if year && month && day
-    #   record_as_hash[:date] =  "#{year}-#{month.rjust(2, '0')}-#{day.rjust(2, '0')}"
-    # elsif year && month
-    #   record_as_hash[:date] =  "#{year}-#{month.rjust(2, '0')}"
-    # end
+    month_day = extract_month_day_from_pubmed_record(publication)
+    record_as_hash[:date] = "#{year}-#{month_day}" if year && month_day
 
     record_as_hash[:type] = Settings.sul_doc_types.article
 
@@ -325,14 +319,14 @@ class PubmedSourceRecord < ApplicationRecord
   # and https://dtd.nlm.nih.gov/ncbi/pubmed/doc/out/180101/att-PubStatus.html for PubStatus type definitions
   # and https://dtd.nlm.nih.gov/ncbi/pubmed/doc/out/180101/el-JournalIssue.html for the JournalIssue definition
   # and https://dtd.nlm.nih.gov/ncbi/pubmed/doc/out/180101/el-ArticleDate.html for the ArticleDate definition
-  def pubmed_date_xpaths(date_part)
+  def pubmed_date_xpaths
     [
-      "MedlineCitation/Article/Journal/JournalIssue/PubDate/#{date_part}",
-      "MedlineCitation/Article/ArticleDate/#{date_part}",
-      "PubmedData/History/PubMedPubDate[@PubStatus='accepted']/#{date_part}",
-      "PubmedData/History/PubMedPubDate[@PubStatus='pubmed']/#{date_part}",
-      "PubmedData/History/PubMedPubDate[@PubStatus='medline']/#{date_part}",
-      "PubmedData/History/PubMedPubDate[@PubStatus='entrez']/#{date_part}"
+      'MedlineCitation/Article/Journal/JournalIssue/PubDate',
+      'MedlineCitation/Article/ArticleDate',
+      "PubmedData/History/PubMedPubDate[@PubStatus='accepted']",
+      "PubmedData/History/PubMedPubDate[@PubStatus='pubmed']",
+      "PubmedData/History/PubMedPubDate[@PubStatus='medline']",
+      "PubmedData/History/PubMedPubDate[@PubStatus='entrez']"
     ]
   end
 end

--- a/fixtures/vcr_cassettes/PubmedSourceRecord/_pubmed_update/does_not_update_the_source_data_field_if_no_pubmed_record_is_found.yml
+++ b/fixtures/vcr_cassettes/PubmedSourceRecord/_pubmed_update/does_not_update_the_source_data_field_if_no_pubmed_record_is_found.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=Settings.PUBMED.API_KEY&db=pubmed&retmode=xml
+    body:
+      encoding: UTF-8
+      string: "&id=10000166"
+    headers:
+      User-Agent:
+      - stanford-library-sul-pub
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 19 Mar 2022 01:03:18 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Cookie:
+      - ncbi_sid=0259A21CB7D50F92_F884SID
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 19 Mar 2022 01:03:19 GMT
+      Server:
+      - Finatra
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Referrer-Policy:
+      - origin-when-cross-origin
+      X-Test-Test:
+      - test42
+      Ncbi-Sid:
+      - '0259A21CB7D50F92_F884SID'
+      Ncbi-Phid:
+      - D0BD0D4D367A16C5000040E706BA0889.1.1.m_3
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Cache-Control:
+      - private
+      Content-Encoding:
+      - gzip
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Set-Cookie:
+      - ncbi_sid=0259A21CB7D50F92_F884SID; domain=.nih.gov; path=/; expires=Sun, 19
+        Mar 2023 01:03:20 GMT
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" ?>
+        <!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2019//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_190101.dtd">
+        <PubmedArticleSet><PubmedArticle><MedlineCitation Status="PubMed-not-MEDLINE" Owner="NLM"><PMID Version="1">10000166</PMID><DateRevised><Year>2019</Year><Month>11</Month><Day>20</Day></DateRevised><Article PubModel="Print"><Journal><ISSN IssnType="Print">0163-1829</ISSN><JournalIssue CitedMedium="Print"><Volume>45</Volume><Issue>1</Issue><PubDate><Year>1992</Year><Month>Jan</Month><Day>01</Day></PubDate></JournalIssue><Title>Physical review. B, Condensed matter</Title><ISOAbbreviation>Phys Rev B Condens Matter</ISOAbbreviation></Journal><ArticleTitle>Fluid permeability in porous media: Comparison of electrical estimates with hydrodynamical calculations.</ArticleTitle><Pagination><MedlinePgn>186-195</MedlinePgn></Pagination><AuthorList CompleteYN="Y"><Author ValidYN="Y"><LastName>Kostek</LastName><Initials>S</Initials></Author><Author ValidYN="Y"><LastName>Schwartz</LastName><Initials>LM</Initials></Author><Author ValidYN="Y"><LastName>Johnson</LastName><Initials>DL</Initials></Author></AuthorList><Language>eng</Language><PublicationTypeList><PublicationType UI="D016428">Journal Article</PublicationType></PublicationTypeList></Article><MedlineJournalInfo><Country>United States</Country><MedlineTA>Phys Rev B Condens Matter</MedlineTA><NlmUniqueID>9878217</NlmUniqueID><ISSNLinking>0163-1829</ISSNLinking></MedlineJournalInfo></MedlineCitation><PubmedData><History><PubMedPubDate PubStatus="pubmed"><Year>1992</Year><Month>1</Month><Day>1</Day><Hour>0</Hour><Minute>0</Minute></PubMedPubDate><PubMedPubDate PubStatus="medline"><Year>1999</Year><Month>2</Month><Day>19</Day><Hour>0</Hour><Minute>0</Minute></PubMedPubDate><PubMedPubDate PubStatus="entrez"><Year>1992</Year><Month>1</Month><Day>1</Day><Hour>0</Hour><Minute>0</Minute></PubMedPubDate></History><PublicationStatus>ppublish</PublicationStatus><ArticleIdList><ArticleId IdType="pubmed">10000166</ArticleId><ArticleId IdType="doi">10.1103/physrevb.45.186</ArticleId></ArticleIdList></PubmedData></PubmedArticle></PubmedArticleSet>
+  recorded_at: Sat, 19 Mar 2022 01:03:20 GMT
+recorded_with: VCR 6.1.0

--- a/fixtures/vcr_cassettes/PubmedSourceRecord/_pubmed_update/updates_the_source_data_field.yml
+++ b/fixtures/vcr_cassettes/PubmedSourceRecord/_pubmed_update/updates_the_source_data_field.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=Settings.PUBMED.API_KEY&db=pubmed&retmode=xml
+    body:
+      encoding: UTF-8
+      string: "&id=10000166"
+    headers:
+      User-Agent:
+      - stanford-library-sul-pub
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 19 Mar 2022 01:03:20 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Cookie:
+      - ncbi_sid=0259A21CB7D50F92_F884SID
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 19 Mar 2022 01:03:20 GMT
+      Server:
+      - Finatra
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Referrer-Policy:
+      - origin-when-cross-origin
+      X-Test-Test:
+      - test42
+      Ncbi-Sid:
+      - '0259A21CB7D50F92_F884SID'
+      Ncbi-Phid:
+      - D0BD0D4D367A16C5000038E7071511B2.1.1.m_3
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Cache-Control:
+      - private
+      Content-Encoding:
+      - gzip
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '8'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Set-Cookie:
+      - ncbi_sid=0259A21CB7D50F92_F884SID; domain=.nih.gov; path=/; expires=Sun, 19
+        Mar 2023 01:03:20 GMT
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" ?>
+        <!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2019//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_190101.dtd">
+        <PubmedArticleSet><PubmedArticle><MedlineCitation Status="PubMed-not-MEDLINE" Owner="NLM"><PMID Version="1">10000166</PMID><DateRevised><Year>2019</Year><Month>11</Month><Day>20</Day></DateRevised><Article PubModel="Print"><Journal><ISSN IssnType="Print">0163-1829</ISSN><JournalIssue CitedMedium="Print"><Volume>45</Volume><Issue>1</Issue><PubDate><Year>1992</Year><Month>Jan</Month><Day>01</Day></PubDate></JournalIssue><Title>Physical review. B, Condensed matter</Title><ISOAbbreviation>Phys Rev B Condens Matter</ISOAbbreviation></Journal><ArticleTitle>Fluid permeability in porous media: Comparison of electrical estimates with hydrodynamical calculations.</ArticleTitle><Pagination><MedlinePgn>186-195</MedlinePgn></Pagination><AuthorList CompleteYN="Y"><Author ValidYN="Y"><LastName>Kostek</LastName><Initials>S</Initials></Author><Author ValidYN="Y"><LastName>Schwartz</LastName><Initials>LM</Initials></Author><Author ValidYN="Y"><LastName>Johnson</LastName><Initials>DL</Initials></Author></AuthorList><Language>eng</Language><PublicationTypeList><PublicationType UI="D016428">Journal Article</PublicationType></PublicationTypeList></Article><MedlineJournalInfo><Country>United States</Country><MedlineTA>Phys Rev B Condens Matter</MedlineTA><NlmUniqueID>9878217</NlmUniqueID><ISSNLinking>0163-1829</ISSNLinking></MedlineJournalInfo></MedlineCitation><PubmedData><History><PubMedPubDate PubStatus="pubmed"><Year>1992</Year><Month>1</Month><Day>1</Day><Hour>0</Hour><Minute>0</Minute></PubMedPubDate><PubMedPubDate PubStatus="medline"><Year>1999</Year><Month>2</Month><Day>19</Day><Hour>0</Hour><Minute>0</Minute></PubMedPubDate><PubMedPubDate PubStatus="entrez"><Year>1992</Year><Month>1</Month><Day>1</Day><Hour>0</Hour><Minute>0</Minute></PubMedPubDate></History><PublicationStatus>ppublish</PublicationStatus><ArticleIdList><ArticleId IdType="pubmed">10000166</ArticleId><ArticleId IdType="doi">10.1103/physrevb.45.186</ArticleId></ArticleIdList></PubmedData></PubmedArticle></PubmedArticleSet>
+  recorded_at: Sat, 19 Mar 2022 01:03:20 GMT
+recorded_with: VCR 6.1.0

--- a/spec/models/pubmed_source_record_spec.rb
+++ b/spec/models/pubmed_source_record_spec.rb
@@ -179,7 +179,7 @@ describe PubmedSourceRecord, :vcr do
       expect(record.source_as_hash[:year]).to be_nil # bogus is not a valid year
     end
 
-    xit 'parses the date correctly' do
+    it 'parses the date correctly' do
       # fixture records
       record = create :pubmed_source_record_10000166 # date
       expect(record.source_as_hash[:date]).to eq '1992-02-05'
@@ -189,14 +189,75 @@ describe PubmedSourceRecord, :vcr do
       expect(record.source_as_hash[:date]).to eq '2013-02-08'
     end
 
-    xit 'sets the date to nil when not found' do
+    # rubocop:disable RSpec/ExampleLength
+    it 'parses the date correctly when day is not provided in preferred location but is later' do
+      # manual test data
+      source_data = <<-XML
+          <PubmedArticle>
+            <MedlineCitation Status="Publisher" Owner="NLM">
+                <PMID Version="1">11096574</PMID>
+                <DateCreated>
+                    <Year>2000</Year>
+                    <Month>11</Month>
+                    <Day>29</Day>
+                </DateCreated>
+                <Article PubModel="Print">
+                    <Journal>
+                        <ISSN IssnType="Print">1092-8472</ISSN>
+                        <JournalIssue CitedMedium="Print">
+                            <Volume>2</Volume>
+                            <Issue>1</Issue>
+                            <PubDate>
+                                <Year>1999</Year>
+                                <Month>Feb</Month>
+                            </PubDate>
+                        </JournalIssue>
+                        <Title>Current treatment options in gastroenterology</Title>
+                        <ISOAbbreviation>Curr Treat Options Gastroenterol</ISOAbbreviation>
+                    </Journal>
+                    <ArticleTitle>Variceal Bleeding.</ArticleTitle>
+                    <Pagination>
+                        <MedlinePgn>61-67</MedlinePgn>
+                    </Pagination>
+                </Article>
+            </MedlineCitation>
+            <PubmedData>
+                <History>
+                    <PubMedPubDate PubStatus="pubmed">
+                        <Year>2000</Year>
+                        <Month>11</Month>
+                        <Day>30</Day>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="medline">
+                        <Year>2000</Year>
+                        <Month>11</Month>
+                        <Day>30</Day>
+                    </PubMedPubDate>
+                    <PubMedPubDate PubStatus="entrez">
+                        <Year>2000</Year>
+                        <Month>11</Month>
+                        <Day>30</Day>
+                        <Hour>0</Hour>
+                        <Minute>0</Minute>
+                    </PubMedPubDate>
+                </History>
+                <PublicationStatus>ppublish</PublicationStatus>
+            </PubmedData>
+        </PubmedArticle>
+      XML
+      record = described_class.create(pmid: pmid_created_1999, source_data: source_data)
+      expect(record.source_as_hash[:date]).to eq '1999-02' # no day
+    end
+    # rubocop:enable RSpec/ExampleLength
+
+    it 'sets the date to nil when not found' do
       # manual test data
       source_data = '<PubmedArticle><MedlineCitation Status="Publisher" Owner="NLM"><PMID Version="1">1</PMID><OriginalData/></PubmedArticle>'
       record = described_class.create(pmid: pmid_created_1999, source_data: source_data)
       expect(record.source_as_hash[:date]).to be_nil # no date
     end
 
-    xit 'ignores the day when not found' do
+    it 'ignores the day when not found' do
       source_data =
         <<-XML
           <PubmedArticle>
@@ -217,7 +278,7 @@ describe PubmedSourceRecord, :vcr do
       expect(record.source_as_hash[:date]).to eq '2017-05' # no day in one of the acceptable date paths, it zero pads the month
     end
 
-    xit 'handles a month as an abbreviation' do
+    it 'handles a month as an abbreviation' do
       source_data =
         <<-XML
           <PubmedArticle>


### PR DESCRIPTION
## Why was this change made?

Fix for #1469 - when parsing dates from Pubmed, we need to be sure to pick the month and day from the same part of the XML structure, still going in the preferred order.  We still return the first match, even if it's only the month (and even if a month-day combo is found later in one of less preferred locations).  This is because the places to look in the XML (the xpaths) are set in order of "best date to use".  

The problem was discovered when the Profiles team updated all of their publications on -dev (where I had back-filled with the current date mapping code) and started hitting exceptions on publications with bad dates (e.g. PMID:11096574, SulPubId:8787 for example, where we had sent a date of 2019-02-30).

This makes the needed changes and re-enables the date parsing for Pubmed records that was disabled in #1468 

Hold:
~~1. to verify this is the correct approach with the Profiles team~~ Verified
~~2. to see if when there is only a month and no day if we should leave the day off (as in this PR) or just set the day to some value (like 01 or 15)~~  Ok to send just month and year
3. until testing of parsing of dates again on -dev

Testing suggested:
- deploy this branch to -dev
- re-run all of the date parsing for previously harvested Pubmed applications (see https://github.com/sul-dlss/sul_pub/issues/1441#issuecomment-1054842850 for how to do this)
- have Profiles ran the publication update on their end, and see if any new errors occur

if successful, we can merge, deploy everywhere and then back-port dates on other environments as well

Note: these changes were already ported into #1463 , the refactoring of pubmed pub hash generation

## How was this change tested?

Existing tests, and added a new test that confirms we will not grab a day from a different part of the XML if we find a valid month only in an earlier part.

## Which documentation and/or configurations were updated?



