### PR TITLE
do not map blank names when sending publications to ORCID

### DIFF
--- a/lib/orcid/pub_author_mapper.rb
+++ b/lib/orcid/pub_author_mapper.rb
@@ -41,6 +41,8 @@ module Orcid
     def map
       return nil if IGNORED_SUL_PUB_ROLES.include?(author_hash[:role])
 
+      return nil if map_credit_name.blank?
+
       {
         'contributor-orcid': nil,
         'credit-name': {

--- a/spec/lib/orcid/pub_author_mapper_spec.rb
+++ b/spec/lib/orcid/pub_author_mapper_spec.rb
@@ -311,5 +311,14 @@ describe Orcid::PubAuthorMapper do
         expect(contributor).to be_nil
       end
     end
+
+    context 'when blank name provided' do
+      let(:name) { '' }
+      let(:role) { 'book_editor' }
+
+      it 'skips' do
+        expect(contributor).to be_nil
+      end
+    end
   end
 end

--- a/spec/lib/orcid/pub_mapper_spec.rb
+++ b/spec/lib/orcid/pub_mapper_spec.rb
@@ -102,6 +102,19 @@ describe Orcid::PubMapper do
     end
   end
 
+  context 'with blank author name' do
+    let(:pub_hash) do
+      base_pub_hash.dup.tap { |pub_hash| pub_hash[:author] << { name: '' } }
+    end
+
+    it 'skips the blank author' do
+      expect(pub_hash[:author].size).to eq(2) # two authors in pub_hash (second is blank)
+      expect(work['contributors']['contributor'].size).to eq(1) # but just one author gets mapped
+      mapped_name = work['contributors']['contributor'].first['credit-name']['value']
+      expect(mapped_name).to eq('Alan Turing')
+    end
+  end
+
   it 'maps journal title' do
     expect(work['journal-title']['value']).to eq('Mind')
   end


### PR DESCRIPTION
## Why was this change made?

Fixes #1478 

The response from the ORCID API is a bit opaque as to which field is the problem, but I suspect it is the blank name we are sending to ORCID.  See #1478 comments for the investigation.

Note that is error is from a manually entered publication where the user sent us a blank author and we just blindly send it to ORCID.  I suspect the error coming from ORCID is a rejection of this blank author value.  This PR just drops any blank authors when mapping to the ORCID JSON.

Once merged, we can try and push this publication again to confirm it makes it this time.

## How was this change tested?

Added new tests.

## Which documentation and/or configurations were updated?



