### PR TITLE
prevent bad data from being created in contributions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,8 +44,8 @@ jobs:
         name: Wait for DB
         command: dockerize -wait tcp://localhost:3306 -timeout 1m
     - run:
-        name: Prepare DB for tests
-        command: bin/rails db:reset
+        name: Database setup
+        command: bin/rails db:test:prepare
     - run:
         name: Setup Code Climate test-reporter
         command: |

--- a/db/migrate/20220405041748_contributions_not_null.rb
+++ b/db/migrate/20220405041748_contributions_not_null.rb
@@ -1,0 +1,6 @@
+class ContributionsNotNull < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null(:contributions, :author_id, false)
+    change_column_null(:contributions, :publication_id, false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_11_185021) do
+ActiveRecord::Schema.define(version: 2022_04_05_041748) do
 
   create_table "author_identities", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "author_id", null: false
@@ -80,9 +80,9 @@ ActiveRecord::Schema.define(version: 2022_01_11_185021) do
   end
 
   create_table "contributions", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
-    t.integer "author_id"
+    t.integer "author_id", null: false
     t.integer "cap_profile_id"
-    t.integer "publication_id"
+    t.integer "publication_id", null: false
     t.string "status"
     t.boolean "featured"
     t.string "visibility"


### PR DESCRIPTION
## Why was this change made?

To deal with data issues highlighted in #1477 

Just add a database constraint to prevent nulls from being created (it will throw an exception if we try to do this).

~~HOLD Until the existing nulls are dealt with in the production database.~~ Data deleted in #1477

~~Not sure we really need to do this, since we really should never have a nil publication_id in a contribution (though we somehow did in this case) and it is bad data.   Perhaps it's better to know by getting an exception so we can cleanup the bad data?~~

## How was this change tested?

Existing tests


## Which documentation and/or configurations were updated?



