### PR TITLE
deal with nils in our identifier pub_hash when mapping to ORCID

### DIFF
--- a/lib/orcid/pub_identifier_mapper.rb
+++ b/lib/orcid/pub_identifier_mapper.rb
@@ -42,7 +42,7 @@ module Orcid
     def map_identifiers(pub_hash_identifiers, relationship)
       Array(pub_hash_identifiers).map do |identifier|
         # Need a type and id
-        next if identifier[:type].blank? || identifier[:id].blank?
+        next if identifier.blank? || identifier[:type].blank? || identifier[:id].blank?
 
         # Only mappable types.
         id_type = IdentifierTypeMapper.to_orcid_id_type(identifier[:type])

--- a/spec/lib/orcid/pub_identifier_mapper_spec.rb
+++ b/spec/lib/orcid/pub_identifier_mapper_spec.rb
@@ -11,7 +11,8 @@ describe Orcid::PubIdentifierMapper do
             type: 'doi',
             id: '10.1093/mind/LIX.236.433',
             url: 'https://doi.org/10.1093%2Fmind%2FLIX.236.433'
-          }
+          },
+          nil
         ]
       }
     end


### PR DESCRIPTION
## Why was this change made?

We apparently have nils in our identifier part of the pub_hash, this prevents an exception from occurring when mapping to ORCID.  See https://app.honeybadger.io/projects/50046/faults/84755970

## How was this change tested?

Updated test to include a nil

## Which documentation and/or configurations were updated?



