### PR TITLE
truncate large titles when posting to ORCID API

### DIFF
--- a/lib/orcid/pub_mapper.rb
+++ b/lib/orcid/pub_mapper.rb
@@ -3,6 +3,7 @@
 require 'citeproc'
 require 'csl/styles'
 
+# ORCID API Documentation: https://info.orcid.org/documentation/
 module Orcid
   # Maps from pub_hash to Orcid Work.
   class PubMapper
@@ -58,7 +59,7 @@ module Orcid
 
       {
         title: {
-          value: title
+          value: title.truncate(500) # ORCID has a max length for this field
         }
       }
     end

--- a/spec/lib/orcid/pub_mapper_spec.rb
+++ b/spec/lib/orcid/pub_mapper_spec.rb
@@ -137,6 +137,17 @@ describe Orcid::PubMapper do
     end
   end
 
+  context 'when title greater than 500 characters' do
+    let(:big_title) { SecureRandom.random_number(36**600).to_s(36) } # generates 600 character random string
+    let(:pub_hash) { base_pub_hash.merge(title: big_title) }
+
+    it 'truncates title to 500 characters' do
+      expect(big_title.length).to eq 600
+      expect(work[:title][:title][:value].length).to eq 500
+      expect(work[:title][:title][:value]).to eq(big_title.truncate(500))
+    end
+  end
+
   context 'when year but no date' do
     let(:pub_hash) do
       base_pub_hash.dup.tap do |pub_hash|


### PR DESCRIPTION
## Why was this change made?

Fixes #1496 - ORCID API has a limit on the size of a title field

I could not locate the actual field limit in the ORCID docs and don't see it in the error message, but this error was triggered with a 22,522 character title length.  I am truncating after 500 characters, which seems more than sufficient for a title. 

## How was this change tested?

Added a new test


## Which documentation and/or configurations were updated?



