### PR TITLE
do not need to throw two exceptions for same problem

### DIFF
--- a/lib/web_of_science/process_records.rb
+++ b/lib/web_of_science/process_records.rb
@@ -139,6 +139,7 @@ module WebOfScience
       links_client.links(link_uids)
     rescue StandardError => e
       NotificationManager.error(e, "Author: #{author.id}, retrieve_links failed", self)
+      {} # return an empty set after reporting the error
     end
   end
 end

--- a/spec/lib/web_of_science/process_records_spec.rb
+++ b/spec/lib/web_of_science/process_records_spec.rb
@@ -147,6 +147,10 @@ describe WebOfScience::ProcessRecords, :vcr do
       before { allow(links_client).to receive(:links).and_raise(RuntimeError) }
 
       it_behaves_like 'fail_forward'
+
+      it 'returns an empty hash from retrieve_links' do
+        expect(processor.send(:retrieve_links, records)).to eq({})
+      end
     end
   end
 


### PR DESCRIPTION
## Why was this change made?

Fixes #1502 (and #1501) -- basically if an exception occurs due to a failed external API call, our current code will log the exception via HB, but then return a data structure to the caller which will then trigger a second HB exception (which is not obvious that is is connected to the first).  This just returns an appropriate data structure to the caller so it won't trigger a secondary exception.

## How was this change tested?

Added a new test.


## Which documentation and/or configurations were updated?



