### PR TITLE
make this spec less flaky

### DIFF
--- a/spec/lib/orcid/pub_mapper_spec.rb
+++ b/spec/lib/orcid/pub_mapper_spec.rb
@@ -94,7 +94,7 @@ describe Orcid::PubMapper do
     end
 
     it 'truncates the name to 150 characters' do
-      expect(long_author.length).to eq(160)
+      expect(long_author.length).to be > 151
       expect(work['contributors']['contributor'].size).to eq(1)
       mapped_name = work['contributors']['contributor'].first['credit-name']['value']
       expect(mapped_name.length).to eq(150)


### PR DESCRIPTION
## Why was this change made?

We generate a random string for this spec, and sometimes it is not exactly 160, but it is really only important that is bigger than 150 so we can verify it truncates to 150.

## How was this change tested?

Existing tests



## Which documentation and/or configurations were updated?



