### PR TITLE
Prevent null exception in smci report

### DIFF
--- a/lib/smci_report.rb
+++ b/lib/smci_report.rb
@@ -220,7 +220,7 @@ class SmciReport
     article_number = pub_hash[:journal] ? pub_hash[:journal][:articlenumber] : ''
     mesh = if pub_hash[:mesh_headings]
              pub_hash[:mesh_headings].map do |h|
-               h[:descriptor][0][:name]
+               h.dig(:descriptor, 0, :name)
              end.compact.compact_blank.join('; ')
            else
              ''


### PR DESCRIPTION
## Why was this change made?

Our mapped data in the pub hash may not be perfect, and our current report code will throw a null exception in some cases.  Using dig to find values in the hash prevents this.

## How was this change tested?

Ran report with this proposed change.

## Which documentation and/or configurations were updated?



