### PR TITLE
pin oauth2 gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'jquery-rails'
 gem 'json_schemer'
 gem 'kaminari'
 gem 'okcomputer' # for monitoring
-gem 'oauth2'
+gem 'oauth2', '~> 1.0' # pinning to v1, since v2 breaks authentication with MaIS ORCID API, June 29, 2022
 gem 'paper_trail'
 gem 'parallel'
 gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,6 +264,7 @@ GEM
     mini_portile2 (2.8.0)
     minitest (5.16.1)
     msgpack (1.5.2)
+    multi_json (1.15.0)
     multi_xml (0.6.0)
     mysql2 (0.5.4)
     namae (1.1.1)
@@ -279,13 +280,12 @@ GEM
     nokogiri (1.13.6-x86_64-linux)
       racc (~> 1.4)
     nori (2.6.0)
-    oauth2 (2.0.3)
+    oauth2 (1.4.9)
       faraday (>= 0.17.3, < 3.0)
       jwt (>= 1.0, < 3.0)
+      multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-      rash_alt (>= 0.4, < 1)
-      version_gem (~> 1.0)
     okcomputer (1.18.4)
     paper_trail (12.3.0)
       activerecord (>= 5.2)
@@ -338,8 +338,6 @@ GEM
       thor (~> 1.0)
     rainbow (3.1.1)
     rake (13.0.6)
-    rash_alt (0.4.12)
-      hashie (>= 3.4)
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -449,7 +447,6 @@ GEM
     uri_template (0.7.0)
     urn (2.0.2)
     vcr (6.1.0)
-    version_gem (1.1.0)
     wasabi (3.7.0)
       addressable
       httpi (~> 2.0)
@@ -514,7 +511,7 @@ DEPENDENCIES
   listen (~> 3.7)
   mysql2 (>= 0.5.3)
   nokogiri (>= 1.7.1)
-  oauth2
+  oauth2 (~> 1.0)
   okcomputer
   paper_trail
   parallel


### PR DESCRIPTION
## Why was this change made?

v2 of the oauth2 gem seems to be causing issues getting a token for the MaIS API....the previous version of the gem works on localhost for me

see https://app.honeybadger.io/projects/50046/faults/86280516
relevant part of the code that uses this gem: https://github.com/sul-dlss/sul_pub/blob/main/lib/mais/client.rb#L94-L99

will create a separate ticket to figure out why and how we can upgrade to the v2: #1521

## How was this change tested?

Localhost, verified in UAT/QA


## Which documentation and/or configurations were updated?



