### PR TITLE
fix oauth2 gem settings so we can upgrade to v2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'jquery-rails'
 gem 'json_schemer'
 gem 'kaminari'
 gem 'okcomputer' # for monitoring
-gem 'oauth2', '~> 1.0' # pinning to v1, since v2 breaks authentication with MaIS ORCID API, June 29, 2022
+gem 'oauth2'
 gem 'paper_trail'
 gem 'parallel'
 gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,7 +264,6 @@ GEM
     mini_portile2 (2.8.0)
     minitest (5.16.1)
     msgpack (1.5.2)
-    multi_json (1.15.0)
     multi_xml (0.6.0)
     mysql2 (0.5.4)
     namae (1.1.1)
@@ -280,12 +279,13 @@ GEM
     nokogiri (1.13.6-x86_64-linux)
       racc (~> 1.4)
     nori (2.6.0)
-    oauth2 (1.4.9)
+    oauth2 (2.0.3)
       faraday (>= 0.17.3, < 3.0)
       jwt (>= 1.0, < 3.0)
-      multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
+      rash_alt (>= 0.4, < 1)
+      version_gem (~> 1.0)
     okcomputer (1.18.4)
     paper_trail (12.3.0)
       activerecord (>= 5.2)
@@ -338,6 +338,8 @@ GEM
       thor (~> 1.0)
     rainbow (3.1.1)
     rake (13.0.6)
+    rash_alt (0.4.12)
+      hashie (>= 3.4)
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -447,6 +449,7 @@ GEM
     uri_template (0.7.0)
     urn (2.0.2)
     vcr (6.1.0)
+    version_gem (1.1.0)
     wasabi (3.7.0)
       addressable
       httpi (~> 2.0)
@@ -511,7 +514,7 @@ DEPENDENCIES
   listen (~> 3.7)
   mysql2 (>= 0.5.3)
   nokogiri (>= 1.7.1)
-  oauth2 (~> 1.0)
+  oauth2
   okcomputer
   paper_trail
   parallel

--- a/lib/mais/client.rb
+++ b/lib/mais/client.rb
@@ -93,7 +93,8 @@ module Mais
 
     def token
       client = OAuth2::Client.new(Settings.MAIS.CLIENT_ID, Settings.MAIS.CLIENT_SECRET, site: Settings.MAIS.BASE_URL,
-                                                                                        token_url: '/api/oauth/token', authorize_url: '/api/oauth/authorize')
+                                                                                        token_url: '/api/oauth/token', authorize_url: '/api/oauth/authorize',
+                                                                                        auth_scheme: :request_body)
       token = client.client_credentials.get_token
       "Bearer #{token.token}"
     end


### PR DESCRIPTION
## Why was this change made?

Fixes #1521 - updating oauth2 gem to v2 has some breaking changes as noted in https://github.com/oauth-xx/oauth2/blob/master/CHANGELOG.md#changed

We need to set the `:auth_scheme` which changed it's default.  This lets us unpin and go to v2 of the gem

## How was this change tested?

Localhost, should also verified in qa/uat


## Which documentation and/or configurations were updated?



