### PR TITLE
allow rebuilding of pub_hash for wos records

### DIFF
--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -304,14 +304,21 @@ describe Publication do
   end
 
   describe 'update_from_pubmed' do
+    let(:pmid) { 1 }
+
     it 'does not update from pubmed source if there is no pmid' do
       expect(publication.pmid).to be_nil
       expect(publication.update_from_pubmed).to be false
     end
 
-    it 'updates from pubmed source if there is a pmid' do
-      pmid = 1
+    it 'does not update from pubmed source if not a pubmed source record' do
+      publication.pub_hash[:provenance] = 'cap'
+      expect(publication.update_from_pubmed).to be false
+    end
+
+    it 'updates from pubmed source for a pubmed source record with a pmid' do
       publication.pmid = pmid
+      publication.pub_hash[:provenance] = 'pubmed'
       source_data = '<PubmedArticle><MedlineCitation Status="Publisher" Owner="NLM"><OriginalData/><Article><ArticleTitle>How I learned Rails</ArticleTitle></Article></PubmedArticle>'
       new_source_data = '<PubmedArticle><MedlineCitation Status="Publisher" Owner="NLM"><Article><ArticleTitle>How I learned Rails</ArticleTitle></Article><PMID Version="1">123</PMID><SomeNewData/></PubmedArticle>'
       pubmed_record = PubmedSourceRecord.create(pmid: pmid, source_data: source_data)
@@ -469,8 +476,9 @@ describe Publication do
   describe '#rebuild_pub_hash' do
     it 'correctly rebuilds pub_hash from SciencewireSourceRecord'
     it 'correctly rebuilds pub_hash from PubmedSourceRecord'
-    it 'raises for WoS record' do
-      pub = described_class.new(pub_hash: { provenance: 'wos' })
+    it 'correctly rebuilds pub_hash from WebofScienceRecord'
+    it 'raises for non-harvested records record' do
+      pub = described_class.new(pub_hash: { provenance: 'cap' })
       expect { pub.rebuild_pub_hash }.to raise_error(RuntimeError)
     end
   end


### PR DESCRIPTION
## Why was this change made?

Rebuilding the pub_hash from source data is sometimes helpful if we need to do some data correction after harvesting has been done.  This is not something that is done in the production code automatically, but we have rake tasks that allow this to happen.  Use cases are (1) we discover a bug in our code that maps source data to the pub_hash, and we need to remediate previously harvested data, (2) a single record is updated at the source and we'd like to update our mapped data.

Up until now, Web of Science records cannot be rebuilt in the code as easily as other source records, even though it is absolutely possible.  

1. This adds the ability to do this by calling the same method that we can call for Pubmed or Sciencewire source records.
2. It uses a better check of the record provenance instead of using identifiers to decide if the record can be rebuilt or not.
3. It raises an exception if you try to rebuild a manually entered publication

The methods changed are not called in running production code, they are called in rake tasks and sometimes manually on the rails console for data remediation.


## How was this change tested?

Updated a couple tests.

## Which documentation and/or configurations were updated?



