### PR TITLE
add organization data and rake tasks for loading it

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'StreetAddress', '~> 1.0', '>= 1.0.6'
 gem 'whenever', require: false
 gem 'yaml_db'
 gem 'hashie' # this used to be part of grape, but we still need it since we believe pub_hashes may still be seralized in the database this way 9/10/2018
+gem 'awesome_nested_set'
 
 gem 'honeybadger', '~> 4.2'
 gem 'retina_tag'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,8 @@ GEM
       gyoku (>= 0.4.0)
       nokogiri
     ast (2.4.2)
+    awesome_nested_set (3.5.0)
+      activerecord (>= 4.0.0, < 7.1)
     bibtex-ruby (6.0.0)
       latex-decode (~> 0.0)
     bootsnap (1.16.0)
@@ -469,6 +471,7 @@ PLATFORMS
 DEPENDENCIES
   StreetAddress (~> 1.0, >= 1.0.6)
   activerecord-import
+  awesome_nested_set
   bibtex-ruby
   bootsnap (>= 1.1.0)
   byebug

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -14,6 +14,9 @@ class Author < ApplicationRecord
   has_many :contributions, dependent: :destroy
   has_many :publications, through: :contributions
 
+  has_many :author_organizations, dependent: :destroy
+  has_many :organizations, through: :author_organizations
+
   # nil values allowed because we have historical records without visibility info, for which cap API
   # will no longer have updated author info (e.g. for authors who are no longer at Stanford)
   validates :cap_visibility, inclusion: { in: VISIBILITY_VALUES }, allow_nil: true

--- a/app/models/author_organization.rb
+++ b/app/models/author_organization.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class AuthorOrganization < ApplicationRecord
+  belongs_to :author
+  belongs_to :organization
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Organization < ApplicationRecord
+  acts_as_nested_set parent_column: :group_id
+
+  validates :code, uniqueness: true, presence: true
+  validates :name, presence: true
+  validates :org_type, presence: true
+
+  # hierarchy
+  belongs_to :group, class_name: 'Organization', optional: true
+  has_many :organizations, foreign_key: 'group_id', dependent: :destroy, inverse_of: :organization
+
+  has_many :author_organizations, dependent: :destroy
+  has_many :authors, through: :author_organizations
+end

--- a/db/migrate/20220801232858_add_org_codes.rb
+++ b/db/migrate/20220801232858_add_org_codes.rb
@@ -1,0 +1,23 @@
+class AddOrgCodes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :organizations do |t|
+      t.string :name
+      t.string :code, null: false, index: { unique: true }
+      t.string :org_type
+      t.string :alias
+      t.integer :group_id, null: true, index: true
+      t.integer :lft, null: false, index: true
+      t.integer :rgt, null: false, index: true
+      t.integer :depth, null: false, default: 0
+      t.integer :children_count, null: false, default: 0
+      t.timestamps
+    end
+
+    create_table :author_organizations do |t|
+      t.integer :author_id
+      t.integer :organization_id
+      t.string :affiliation
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_18_164661) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_01_232858) do
   create_table "author_identities", force: :cascade do |t|
     t.integer "author_id", null: false
     t.string "first_name", limit: 255, null: false
@@ -23,6 +23,14 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_18_164661) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["author_id"], name: "index_author_identities_on_author_id"
+  end
+
+  create_table "author_organizations", force: :cascade do |t|
+    t.integer "author_id"
+    t.integer "organization_id"
+    t.string "affiliation"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "authors", force: :cascade do |t|
@@ -106,6 +114,24 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_18_164661) do
     t.integer "publication_id"
     t.index ["orcidid", "put_code"], name: "index_orcid_source_records_on_orcidid_and_put_code", unique: true
     t.index ["publication_id"], name: "index_orcid_source_records_on_publication_id", unique: true
+  end
+
+  create_table "organizations", force: :cascade do |t|
+    t.string "name"
+    t.string "code", null: false
+    t.string "org_type"
+    t.string "alias"
+    t.integer "group_id"
+    t.integer "lft", null: false
+    t.integer "rgt", null: false
+    t.integer "depth", default: 0, null: false
+    t.integer "children_count", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["code"], name: "index_organizations_on_code", unique: true
+    t.index ["group_id"], name: "index_organizations_on_group_id"
+    t.index ["lft"], name: "index_organizations_on_lft"
+    t.index ["rgt"], name: "index_organizations_on_rgt"
   end
 
   create_table "publication_identifiers", force: :cascade do |t|

--- a/lib/tasks/orgs.rake
+++ b/lib/tasks/orgs.rake
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+# Data is obtained using rialto-etl codebase:
+# git clone https://github.com/sul-dlss-labs/rialto-etl.git
+# cd rialto-etl
+# rvm use 2.7 # rialto-etl still on ruby 2
+# git checkout petucket-researcher-extract # this branch reduces the amount of data pulled for researchers to bare minimum
+# bundle install
+# exe/extract call StanfordOrganizations > organizations.json
+# exe/extract call StanfordResearchers > researchers.ndj
+#
+# Go back to sul-pub codebase and grab data
+# cd ../sul_pub
+# mv ../rialto-etl/organizations.json .
+# mv ../rialto-etl/researchers.ndj .
+#
+# Load data using rake tasks in sul-pub:
+# bundle exec rake orgs:load_from_json['organizations.json']
+# bundle exec rake orgs:load_researcher_affiliation['researchers.ndj']
+
+# Uses awesome_nested_set: https://github.com/collectiveidea/awesome_nested_set
+# Cheat sheet for nested_set API
+# https://github.com/brennovich/cheat-ruby-sheets/blob/master/awesome_nested_set.md
+#
+# Find an author and their organizations
+# author = Author.find_by(sunetid: 'kcasciot')
+# author.organizations # see which organizations the author is part of
+# author.author_organizations # see the role/affiliation (e.g. faculty/staff) for each organization
+#
+# Find an organization (e.g. a School)
+# org = Organization.find_by(name: 'School of Earth, Energy and Environmental Sciences')
+# org.ancestors # the school's parents (e.g. Stanford University)
+# org.siblings # the school's siblings (e.g. other schools in the university)
+# org.children # the school's immediate children (e.g. departments in the school)
+# org.descendants # the school's children and all of it's children (e.g. departments plus anything below those departments)
+
+# Find all of the researchers in a given higher level organization (e.g. a school, which has many departments)
+# AuthorOrganization.where(organization_id: org.self_and_descendants.map(&:id)).map(&:author)
+
+# Find all of the researchers associated with a single organization (e.g. a department)
+# note: this will miss any authors not directly associated with the organization,
+# e.g. faculty will be associated with a department, but not with the partent school directly in the data
+# Organization.find_by(name: 'Earth System Science').authors
+
+require 'json'
+
+def load_organization(org, parent: nil)
+  # each organization can have multiple org codes, create an entry for each
+  org['orgCodes'].each do |org_code|
+    # update or create as needed by searching for existing org_codes
+    o = Organization.find_or_initialize_by(code: org_code)
+    puts "Loading #{org_code} : #{org['name']}"
+    o.update(name: org['name'], alias: org['alias'], org_type: org['type'])
+    if parent
+      parent_org = Organization.find_by(code: parent['orgCodes'].first)
+      o.move_to_child_of(parent_org)
+    end
+    o.save
+  end
+
+  # recursive exit condition for no children in this organization
+  return if org['children'].blank?
+
+  # loop over organizational unit's children recursively
+  org['children'].each { |child| load_organization(child, parent: org) }
+end
+
+namespace :orgs do
+  desc 'Load organization data from JSON'
+  # Load/update all organization data pulled from Profiles API into the database
+  # bundle exec rake orgs:load_from_json['organizations.json']
+  task :load_from_json, %i[input_file] => :environment do |_t, args|
+    input_file = args[:input_file]
+    raise 'input file missing or not specified' unless input_file && File.exist?(input_file)
+
+    org_json = JSON.parse(File.read(input_file))
+    load_organization(org_json) # defined above, we call this method recursively
+  end
+
+  desc 'Load researcher organization affiliation data from JSON'
+  # Load/update all researcher organization affiliation data pulled from Profiles API into the database
+  # bundle exec rake orgs:load_researcher_affiliation['researchers.ndj']
+  task :load_researcher_affiliation, %i[input_file] => :environment do |_t, args|
+    input_file = args[:input_file]
+    raise 'input file missing or not specified' unless input_file && File.exist?(input_file)
+
+    total_lines = 0
+    total_authors_found = 0
+    total_authors_orgs_added = 0
+
+    File.readlines(input_file).each do |line|
+      total_lines += 1
+      researcher_json = JSON.parse(line)
+      sunetid = researcher_json['uid']
+      next if sunetid.blank?
+
+      author = Author.find_by(sunetid: sunetid)
+      next if author.blank?
+
+      puts "loading #{sunetid}"
+      total_authors_found += 1
+
+      researcher_json['orgs']&.each do |org| # some researchers have no orgs, don't crash on nil
+        total_authors_orgs_added += 1
+        affiliation = org['affiliation']
+        org_code = org['organization']['orgCode']
+        puts ".... #{affiliation} : #{org_code}"
+        organization = Organization.find_by(code: org_code)
+        if organization && author.organizations.exclude?(organization)
+          AuthorOrganization.create(author: author, organization: organization, affiliation: affiliation)
+        end
+      end
+    end
+    puts
+    puts "Total lines in file: #{total_lines}. Total authors found: #{total_authors_found}. Total organization affiliations found: #{total_authors_orgs_added}"
+  end
+end


### PR DESCRIPTION
## Why was this change made?

Experiment in loading organizations and affiliation data pulled from Profiles API (via rialto-etl codebase) into sul-pub database and some examples queries of how it can be used to find researchers in departments.

## How was this change tested?

Rails console on localhost