### PR TITLE
additional comments around pubmed date searching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ doc/
 .byebug_history
 coverage
 README_configs.txt
+/*.json
+/*.ndj
 
 ## Ignore ruby version pins
 .ruby-*

--- a/lib/pubmed/map_pub_hash.rb
+++ b/lib/pubmed/map_pub_hash.rb
@@ -247,10 +247,11 @@ module Pubmed
       # The <AffiliationInfo> envelope element includes <Affliliation> and <Identifier>.
     end
 
-    # see https://dtd.nlm.nih.gov/ncbi/pubmed/doc/out/180101/el-PubDate.html for PubDate definition
-    # and https://dtd.nlm.nih.gov/ncbi/pubmed/doc/out/180101/att-PubStatus.html for PubStatus type definitions
-    # and https://dtd.nlm.nih.gov/ncbi/pubmed/doc/out/180101/el-JournalIssue.html for the JournalIssue definition
-    # and https://dtd.nlm.nih.gov/ncbi/pubmed/doc/out/180101/el-ArticleDate.html for the ArticleDate definition
+    # Order in which to search for article publication dates in a Pubmed record
+    # 1. https://dtd.nlm.nih.gov/ncbi/pubmed/doc/out/180101/el-PubDate.html for PubDate definition
+    # 2. https://dtd.nlm.nih.gov/ncbi/pubmed/doc/out/180101/el-ArticleDate.html for the ArticleDate definition
+    # 3. https://dtd.nlm.nih.gov/ncbi/pubmed/doc/out/180101/el-PubMedPubDate.html for PubmedData defintion
+    # along with https://dtd.nlm.nih.gov/ncbi/pubmed/doc/out/180101/att-PubStatus.html for the PubStatus type definitions
     def pubmed_date_xpaths
       [
         'MedlineCitation/Article/Journal/JournalIssue/PubDate',


### PR DESCRIPTION
## Why was this change made?

Based on some questions around article publication dates in Pubmed records, I double-checked the search for dates and the order in which we search for them. I believe the current ordering is still valid and correct despite the one example shown below, but I updated the code documentation so that the ordering of links in the code comment reflect the order in which we search for dates and just added a bit more text.

## How was this change tested?

Existing tests
