### PR TITLE
look for invalid names for pubmed queries

### DIFF
--- a/spec/factories/author.rb
+++ b/spec/factories/author.rb
@@ -63,6 +63,26 @@ FactoryBot.define do
       official_first_name { '.' }
       preferred_first_name { '.' }
     end
+
+    trait :or_first_name do
+      official_first_name { 'Or' }
+      preferred_first_name { 'Or' }
+    end
+
+    trait :not_last_name do
+      official_first_name { 'Not' }
+      preferred_first_name { 'Not' }
+    end
+
+    trait :nil_first_name do
+      official_first_name { nil }
+      preferred_first_name { nil }
+    end
+
+    trait :nil_last_name do
+      official_last_name { nil }
+      preferred_last_name { nil }
+    end
   end
 
   factory :author_with_alternate_identities, parent: :author do
@@ -73,6 +93,11 @@ FactoryBot.define do
       evaluator.alt_count.times do
         create(:author_identity, author: author)
       end
+    end
+
+    trait :or_first_name do
+      official_first_name { 'Or' }
+      preferred_first_name { 'Or' }
     end
   end
 


### PR DESCRIPTION
## Why was this change made?

Code changes for #1546 

- if an author has a name that includes "Or", "And", or "Not" (case insensitive, either first or last), that name will be ignored when constructing the query ... this means a user could in theory have a second "alternate identity" name that is valid, and we would still use it
- if there are no valid names available, the entire query will be marked as invalid and thus not run, producing no results
- while I was making this change, I extended our existing check for invalid names (currently only first name must have at least one character) to ensure the last name also has to have at least one valid character (eg. a last name of blank or null will also be marked as an invalid name)
- reorganize spec to put all of the tests related to the `valid?` method in a describe block

## How was this change tested?

Added new tests


## Which documentation and/or configurations were updated?



