### PR TITLE
add HB checkins for cron jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,3 +152,13 @@ Additional information about this project is contained in the [wiki](https://git
 ### Publication metadata isssues
 
 See https://github.com/sul-dlss/sul_pub/wiki/Publication-metadata-issues.
+
+## Cron check-ins
+
+Some cron jobs (configured via the whenever gem) are integrated with Honeybadger check-ins. These cron jobs will check-in with HB (via a curl request to an HB endpoint) whenever run. If a cron job does not check-in as expected, HB will alert.
+
+Cron check-ins are configured in the following locations:
+1. `config/schedule.rb`: This specifies which cron jobs check-in and what setting keys to use for the checkin key. See this file for more details.
+2. `config/settings.yml`: Stubs out a check-in key for each cron job. Since we may not want to have a check-in for all environments, this stub key will be used and produce a null check-in.
+3. `config/settings/production.yml` in shared_configs: This contains the actual check-in keys.
+4. HB notification page: Check-ins are configured per project in HB. To configure a check-in, the cron schedule will be needed, which can be found with `bundle exec whenever`. After a check-in is created, the check-in key will be available. (If the URL is `https://api.honeybadger.io/v1/check_in/rkIdpB` then the check-in key will be `rkIdpB`).

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,5 +1,9 @@
 # Learn more: http://github.com/javan/whenever
-job_type :envcommand, 'cd :path && RAILS_ENV=:environment :bundle_command :task :output'
+
+# These define jobs that checkin with Honeybadger.
+# If changing the schedule of one of these jobs, also update at https://app.honeybadger.io/projects/77112/check_ins
+job_type :rake_hb,
+         'cd :path && :environment_variable=:environment bundle exec rake --silent ":task" :output && curl --silent https://api.honeybadger.io/v1/check_in/:check_in'
 
 def stagger(hour)
   ('%02d' % hour) + (':%02d' % rand(60)) # some minute between 00 and 59
@@ -9,30 +13,36 @@ set :output, 'log/cron.log'
 
 # bi-weekly harvest at 5pm in qa, on the 8th and 23rd of the month
 every "0 17 7,23 * *", roles: [:harvester_qa] do
-  rake 'harvest:all_authors_update'
+  set :check_in, Settings.honeybadger_checkins.harvest_all_authors
+  rake_hb 'harvest:all_authors_update'
 end
 
 # every three day harvest at 5pm in prod, don't overlap with qa
 every "0 17 1,5,9,13,17,21,25,29 * *", roles: [:harvester_prod] do
-  rake 'harvest:all_authors_update'
+  set :check_in, Settings.honeybadger_checkins.harvest_all_authors
+  rake_hb 'harvest:all_authors_update'
 end
 
 # poll cap for new authorship information nightly at 4am-ish in prod, qa and dev
 every 1.day, at: stagger(4), roles: [:harvester_dev, :harvester_qa, :harvester_prod] do
-  rake 'cap:poll[1]'
+  set :check_in, Settings.honeybadger_checkins.cap_poll
+  rake_hb 'cap:poll[1]'
 end
 
 # poll mais for new ORCID information nightly at 5am-ish in prod, qa and dev
 every 1.day, at: stagger(5), roles: [:harvester_dev, :harvester_qa, :harvester_prod] do
-  rake 'mais:update_authors'
+  set :check_in, Settings.honeybadger_checkins.mais_update_authors
+  rake_hb 'mais:update_authors'
 end
 
 # send publications to ORCID profiles for all authorized users at 8am-ish every 7 days in qa
 every 7.days, at: stagger(8), roles: [:harvester_qa] do
-  rake 'orcid:add_all_works'
+  set :check_in, Settings.honeybadger_checkins.orcid_all_all_works
+  rake_hb 'orcid:add_all_works'
 end
 
 # send publications to ORCID profiles for all authorized users at 6am-ish every 2 days in prod
 every 2.days, at: stagger(6), roles: [:harvester_prod] do
-  rake 'orcid:add_all_works'
+  set :check_in, Settings.honeybadger_checkins.orcid_all_all_works
+  rake_hb 'orcid:add_all_works'
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -122,3 +122,11 @@ cap_provenance: cap
 pubmed_source: pubmed
 sciencewire_source: sciencewire
 wos_source: wos
+
+# checkin keys for honeybadger (actual keys are in shared_configs per environment as needed)
+# see https://app.honeybadger.io/projects/50046/check_ins
+honeybadger_checkins:
+  harvest_all_authors: null
+  cap_poll: null
+  mais_update_authors: null
+  orcid_all_all_works: null


### PR DESCRIPTION
## Why was this change made?

Fixes #1564 

Note: I don't think we need check ins for any environment other than production and QA (there are also cron jobs that run in dev, but don't warrant a checkin)

Also need shared_configs PRs:
- https://github.com/sul-dlss/shared_configs/pull/1898 (prod)
- https://github.com/sul-dlss/shared_configs/pull/1899 (qa)

