### PR TITLE
skip users with blank sunet in rake task report

### DIFF
--- a/lib/tasks/sul.rake
+++ b/lib/tasks/sul.rake
@@ -429,7 +429,7 @@ namespace :sul do
     output_file = args[:output_file]
 
     # active stanford users who have gone through the Stanford ORCID integration
-    users = Author.where.not(orcidid: nil).where(active_in_cap: true)
+    users = Author.where.not(orcidid: nil).where.not(sunetid: ['', nil]).where(active_in_cap: true)
     total_stanford = users.size
     orcidids_stanford = users.map(&:orcidid)
     puts "Number of active Stanford users who have gone through integration: #{total_stanford}"


### PR DESCRIPTION
## Why was this change made?

Exporting user rake task for reporting purposes, and some users have an ORCID but no sunet.  Not sure why or how this happened, but I still need to export the data and to gather stats from the ORCID integration, we need a SUNET, so we will skip users with a blank sunet.

## How was this change tested?

Ran in production