### PR TITLE
change the cap_profile_id for health check, add to config

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,6 +19,8 @@ CAP:
   AUTHORSHIP_API_PORT: 443
   AUTHORSHIP_API_URI: https://cap-uat.stanford.edu
   HARVEST_ON_CHANGE: true
+  cap_profile_id_for_check: 45761 # (kcasciotti) used by CAP health check,
+                                  # if person leaves Stanford, will get 404 for check, then change this
 
 MAIS:
   LOG: log/mais.log
@@ -76,7 +78,7 @@ ORCID:
   CLIENT_ID: APP-FAKEJMB7RBQVFQ0D
   CLIENT_SECRET: FAKE6bb5-dba1-445d-ba10-c14745383ba0
   LOG: log/orcid.log
-  orcidid_for_check: https://sandbox.orcid.org/0000-0002-7262-6251 # jtim
+  orcidid_for_check: https://sandbox.orcid.org/0000-0002-7262-6251 # (jtim) used by ORCID health check
 
 DOI:
   BASE_URI: https://doi.org/

--- a/fixtures/vcr_cassettes/Cap_Client/_working_/returns_true_when_it_can_fetch_author_data.yml
+++ b/fixtures/vcr_cassettes/Cap_Client/_working_/returns_true_when_it_can_fetch_author_data.yml
@@ -41,7 +41,7 @@ http_interactions:
   recorded_at: Thu, 22 Feb 2018 21:49:50 GMT
 - request:
     method: get
-    uri: https://cap-uat.stanford.edu/cap-api/api/cap/v1/authors/4176
+    uri: https://cap-uat.stanford.edu/cap-api/api/cap/v1/authors/45761
     body:
       encoding: UTF-8
       string: ''
@@ -95,7 +95,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"active":true,"authorModifiedOn":"2017-12-07T11:43:45.000-08:00","importEnabled":false,"importSettings":[{"email":"CAP-UID@stanford.edu","firstName":"Test","institution":"Stanford
         University","lastName":"User","middleName":"A"}],"lastModified":"2017-12-07T12:15:13.578-08:00","populations":["stanford","stanfordOnly"],"profile":{"displayName":"Test
-        User","email":"CAP-UID@stanford.edu","meta":{"links":[{"href":"https://cap-uat.stanford.edu/cap-api/api/profiles/v1/4176","rel":"https://cap.stanford.edu/rel/self"},{"href":"https://cap-uat.stanford.edu/test-user","rel":"https://cap.stanford.edu/rel/public"},{"href":"https://cap-uat.stanford.edu/profiles/auth/frdActionServlet?choiceId=facProfile&profileId=4176","rel":"https://cap.stanford.edu/rel/intranet"},{"href":"https://cap-uat.stanford.edu/profiles/frdActionServlet?choiceId=printerprofile&profileversion=full&profileId=4176","rel":"https://cap.stanford.edu/rel/pdf"},{"href":"https://cap-uat.stanford.edu/cap-api/api/cap/v1/schemas/ProfileDto","rel":"https://cap.stanford.edu/rel/schema"}]},"names":{"legal":{"firstName":"Test","lastName":"User","middleName":"C"},"preferred":{"firstName":"Test","lastName":"User","middleName":"A"}},"profileId":4176,"uid":"CAP-UID","universityId":"CAP-UniversityID"},"profileId":4176,"visibility":"public"}'
+        User","email":"CAP-UID@stanford.edu","meta":{"links":[{"href":"https://cap-uat.stanford.edu/cap-api/api/profiles/v1/45761","rel":"https://cap.stanford.edu/rel/self"},{"href":"https://cap-uat.stanford.edu/test-user","rel":"https://cap.stanford.edu/rel/public"},{"href":"https://cap-uat.stanford.edu/profiles/auth/frdActionServlet?choiceId=facProfile&profileId=45761","rel":"https://cap.stanford.edu/rel/intranet"},{"href":"https://cap-uat.stanford.edu/profiles/frdActionServlet?choiceId=printerprofile&profileversion=full&profileId=45761","rel":"https://cap.stanford.edu/rel/pdf"},{"href":"https://cap-uat.stanford.edu/cap-api/api/cap/v1/schemas/ProfileDto","rel":"https://cap.stanford.edu/rel/schema"}]},"names":{"legal":{"firstName":"Test","lastName":"User","middleName":"C"},"preferred":{"firstName":"Test","lastName":"User","middleName":"A"}},"profileId":45761,"uid":"CAP-UID","universityId":"CAP-UniversityID"},"profileId":45761,"visibility":"public"}'
     http_version:
   recorded_at: Thu, 22 Feb 2018 21:49:50 GMT
 recorded_with: VCR 4.0.0

--- a/lib/cap/client.rb
+++ b/lib/cap/client.rb
@@ -7,8 +7,8 @@ module Cap
   class Client
     # Fetch a single object from CAP server and test its response
     def self.working?
-      response = new.get_auth_profile(4176)
-      response.is_a?(Hash) && response['profileId'] == 4176
+      response = new.get_auth_profile(Settings.CAP.cap_profile_id_for_check)
+      response.is_a?(Hash) && response['profileId'] == Settings.CAP.cap_profile_id_for_check
     end
 
     def get_batch_from_cap_api(page_count = 1, page_size = 1000, since = '')


### PR DESCRIPTION
## Why was this change made?

The CAP health check is currently failing because the hard-coded `cap_profile_id` we currently use is returning a 404 from the CAP API (may be because that person's profile is archived).  This changes the cap_profile_id to one that is confirmed working and puts in the config in case we need to change it again.

Confirm separately with Profiles team that the 404 is expected from their API for this hardcoded profile id (4176 == https://profiles.stanford.edu/intranet/richard-lewis)

## How was this change tested?

Deploy to UAT to confirm

## Which documentation and/or configurations were updated?

Added code comments.

