### PR TITLE
Rejigger cap stages for cap-dev-a and cap-uat VMs

### DIFF
--- a/config/deploy/cap-dev.rb
+++ b/config/deploy/cap-dev.rb
@@ -1,8 +1,0 @@
-# see https://github.com/sul-dlss/sul_pub/wiki/Servers-Deployment-environment
-server 'sul-pub-cap-dev-a.stanford.edu', user: 'pub', roles: %w(web db harvester_dev app)
-
-Capistrano::OneTimeKey.generate_one_time_key!
-
-set :rails_env, 'production'
-
-set :bundle_without, %w(development test).join(' ')

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,10 +1,8 @@
 # see https://github.com/sul-dlss/sul_pub/wiki/Servers-Deployment-environment
-server 'sul-pub-cap-uat.stanford.edu', user: 'pub', roles: %w(web db app harvester_qa external_monitor)
+server 'sul-pub-cap-dev-a.stanford.edu', user: 'pub', roles: %w(web db harvester_dev app)
 
 Capistrano::OneTimeKey.generate_one_time_key!
 
 set :rails_env, 'production'
 
-set :bundle_without, %w(test development).join(' ')
-
-set :log_level, :info
+set :bundle_without, %w(development test).join(' ')

--- a/config/deploy/uat.rb
+++ b/config/deploy/uat.rb
@@ -1,0 +1,10 @@
+# see https://github.com/sul-dlss/sul_pub/wiki/Servers-Deployment-environment
+server 'sul-pub-cap-uat.stanford.edu', user: 'pub', roles: %w(web db app harvester_uat external_monitor)
+
+Capistrano::OneTimeKey.generate_one_time_key!
+
+set :rails_env, 'production'
+
+set :bundle_without, %w(test development).join(' ')
+
+set :log_level, :info

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -12,32 +12,32 @@ end
 
 set :output, 'log/cron.log'
 
-# bi-weekly harvest at 5pm in qa, on the 8th and 23rd of the month
-every "0 17 7,23 * *", roles: [:harvester_qa] do
+# bi-weekly harvest at 5pm in UAT, on the 8th and 23rd of the month
+every "0 17 7,23 * *", roles: [:harvester_uat] do
   set :check_in, Settings.honeybadger_checkins.harvest_all_authors
   rake_hb 'harvest:all_authors_update'
 end
 
-# every three day harvest at 5pm in prod, don't overlap with qa
+# every three day harvest at 5pm in prod, don't overlap with UAT
 every "0 17 1,5,9,13,17,21,25,29 * *", roles: [:harvester_prod] do
   set :check_in, Settings.honeybadger_checkins.harvest_all_authors
   rake_hb 'harvest:all_authors_update'
 end
 
-# poll cap for new authorship information nightly at 4am-ish in prod, qa and dev
-every 1.day, at: stagger(4), roles: [:harvester_dev, :harvester_qa, :harvester_prod] do
+# poll cap for new authorship information nightly at 4am-ish in prod, UAT and dev
+every 1.day, at: stagger(4), roles: [:harvester_dev, :harvester_uat, :harvester_prod] do
   set :check_in, Settings.honeybadger_checkins.cap_poll
   rake_hb 'cap:poll[1]'
 end
 
-# poll mais for new ORCID information nightly at 5am-ish in prod, qa and dev
-every 1.day, at: stagger(5), roles: [:harvester_dev, :harvester_qa, :harvester_prod] do
+# poll mais for new ORCID information nightly at 5am-ish in prod, UAT and dev
+every 1.day, at: stagger(5), roles: [:harvester_dev, :harvester_uat, :harvester_prod] do
   set :check_in, Settings.honeybadger_checkins.mais_update_authors
   rake_hb 'mais:update_authors'
 end
 
-# send publications to ORCID profiles for all authorized users at 8am-ish every 7 days in qa
-every 7.days, at: stagger(8), roles: [:harvester_qa] do
+# send publications to ORCID profiles for all authorized users at 8am-ish every 7 days in UAT
+every 7.days, at: stagger(8), roles: [:harvester_uat] do
   set :check_in, Settings.honeybadger_checkins.orcid_all_all_works
   rake_hb 'orcid:add_all_works'
 end


### PR DESCRIPTION
## Why was this change made?

This commit makes a capistrano-oriented change such that the new "QA" box is one that is more resettable (UAT is not easily resettable). It effectively special-cases the cap-uat box instead of the cap-dev-a box, which we think may be more appropriate.

## How was this change tested?

N/A
