### PR TITLE
fix report output of cron job

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -14,7 +14,7 @@ set :output, 'log/cron.log'
 
 # weekly orcid integration stats in prod output to time stamped log file
 every :monday, at: '1am', roles: [:harvester_prod] do
-  rake 'sul:orcid_integration_stats > log/orcid_stats_`date +\%Y\%m\%d`.log'
+  rake 'sul:orcid_integration_stats', output: "log/orcid_stats_`date +\%Y\%m\%d`.log"
 end
 
 # bi-weekly harvest at 5pm in UAT, on the 8th and 23rd of the month


### PR DESCRIPTION
## Why was this change made?

A recent PR added a new cron job for a rake task with the output directed to the file, but I realized the output was still going to cron.log due to how whenever gem creates cron jobs.  This fixes it to allow this particular cron job to direct it's output to a specific file.   See https://github.com/javan/whenever/wiki/Output-redirection-aka-logging-your-cron-jobs

## How was this change tested?

localhost


## Which documentation and/or configurations were updated?



