### PR TITLE
update correct active author orcidid

### DIFF
--- a/lib/mais/update_authors_orcid.rb
+++ b/lib/mais/update_authors_orcid.rb
@@ -13,7 +13,7 @@ module Mais
     def update
       count = 0
       sunetids.each do |sunetid|
-        author = Author.find_by(sunetid:)
+        author = Author.find_by(sunetid:, active_in_cap: true)
         next if author.nil?
 
         logger&.info("#{self.class} - author #{author.id} - updating orcid id to #{sunetid_to_orcidid[sunetid]}")

--- a/lib/orcid/add_works.rb
+++ b/lib/orcid/add_works.rb
@@ -21,8 +21,8 @@ module Orcid
     def add_for_orcid_user(orcid_user)
       return 0 unless orcid_user.update?
 
-      author = Author.find_by(sunetid: orcid_user.sunetid)
-      return 0 if author.nil? || author.cap_visibility != 'public'
+      author = Author.find_by(sunetid: orcid_user.sunetid, active_in_cap: true, cap_visibility: 'public')
+      return 0 if author.nil?
 
       logger&.info("#{self.class} - author #{author.id} - adding publications to #{orcid_user.orcidid}")
 

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -68,6 +68,7 @@ namespace :cleanup do
 
     puts 'Authorship rebuilt in all publications associated with the primary profile'
 
+    primary_author.update(orcidid: duped_author.orcidid)
     duped_author.cap_import_enabled = false
     duped_author.active_in_cap = false
     duped_author.save


### PR DESCRIPTION
## Why was this change made?

In some cases an author can have more than one row in the authors table, with one being inactive and the other being active.  This sometimes happens if the author had a previous association with Stanford and then wasn't correctly matched up when they joined Stanford again.  We have a rake task to merge authors if this happens, but even after we do this, our ORCID update task may still find the inactive author row.  This fixes the issue by ensuring we only look for authors with ORCIDs that are active.

Discovered when dealing with a support request for author with a SUNet ID of `edehaan` who wasn't seeing their publications pushed to ORCID.  It turns out it is because they have two author rows and the ones with approved publications and that is marked as active is not that was associated with the ORCID and being found by the push process.

This also updates the "merge authors" rake task to ensure it moves over the ORCID if needed.

I will also manually fix the new correct author row to associate with the ORCID.

