### PR TITLE
do not update primary author's orcidid if it has a value already

### DIFF
--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -68,7 +68,7 @@ namespace :cleanup do
 
     puts 'Authorship rebuilt in all publications associated with the primary profile'
 
-    primary_author.update(orcidid: duped_author.orcidid)
+    primary_author.update(orcidid: duped_author.orcidid) if primary_author.orcidid.blank?
     duped_author.cap_import_enabled = false
     duped_author.active_in_cap = false
     duped_author.save


### PR DESCRIPTION
## Why was this change made?

Follow on from #1643 -- after more thought, realized the rake task should not blindly update the primary author's ORCID from the duped author when merging authors',  but instead only do this if the primary author doesn't have an ORCIDID set already
