### PR TITLE
allow a user to request custom batch sizes

### DIFF
--- a/lib/web_of_science/queries.rb
+++ b/lib/web_of_science/queries.rb
@@ -15,9 +15,9 @@ module WebOfScience
     # Convenience method, does the params_for_search expansion
     # @param query [String] Query string like 'TS=particle swarm AND PY=(2007 OR 2008)'
     # @return [WebOfScience::UserQueryRestRetriever]
-    def user_query(query_string, query_params: nil)
+    def user_query(query_string, query_params: nil, batch_size: WebOfScience::BaseRestRetriever::MAX_RECORDS)
       query = WebOfScience::UserQueryRestRetriever::Query.new(user_query: query_string)
-      WebOfScience::UserQueryRestRetriever.new(query, query_params:)
+      WebOfScience::UserQueryRestRetriever.new(query, query_params:, batch_size:)
     end
 
     def user_query_options_to_params(options)

--- a/spec/lib/web_of_science/queries_spec.rb
+++ b/spec/lib/web_of_science/queries_spec.rb
@@ -31,9 +31,18 @@ describe WebOfScience::Queries do
       allow(WebOfScience::UserQueryRestRetriever).to receive(:new).and_return(retriever)
     end
 
-    it 'returns a retriever' do
-      expect(wos_queries.user_query(user_query, query_params:)).to eq retriever
-      expect(WebOfScience::UserQueryRestRetriever).to have_received(:new).with(query, query_params:)
+    context 'with no batch_size passed in' do
+      it 'returns a retriever with default batch_size' do
+        expect(wos_queries.user_query(user_query, query_params:)).to eq retriever
+        expect(WebOfScience::UserQueryRestRetriever).to have_received(:new).with(query, query_params:, batch_size: WebOfScience::BaseRestRetriever::MAX_RECORDS)
+      end
+    end
+
+    context 'with a specific batch_size passed in' do
+      it 'returns a retriever with user supplied batch_size' do
+        expect(wos_queries.user_query(user_query, query_params:, batch_size: 0)).to eq retriever
+        expect(WebOfScience::UserQueryRestRetriever).to have_received(:new).with(query, query_params:, batch_size: 0)
+      end
     end
   end
 


### PR DESCRIPTION
## Why was this change made?

Allow a user to request a custom batch when users the 'queries' method.  This can be useful if you only want to get the number of results and the queryID back (and not all of the results).  Used in some custom rialto queries and also could be used in later refactor to first request WOS_UIDs and then later full records in small batches (to deal with #1642)

## How was this change tested?

Updated spec