### PR TITLE
add some extra error logging

### DIFF
--- a/lib/web_of_science/xml_parser.rb
+++ b/lib/web_of_science/xml_parser.rb
@@ -28,7 +28,12 @@ module WebOfScience
 
         HTMLEntities.new.decode(encoded_xml)
       end
-      Nokogiri::XML(xml) { |config| config.strict.noblanks }
+      begin
+        Nokogiri::XML(xml) { |config| config.strict.noblanks }
+      rescue StandardError => e
+        Honeybadger.notify(e, context: { message: 'Error processing XML record from WoS', xml:, encoded_xml: })
+        raise e
+      end
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

Add some extra error logging when a WoS error occurs during parsing (may be useful when dealing with #1642



