### PR TITLE
strip MEDLINE prefix when adding publications via PMID

### DIFF
--- a/app/controllers/authorships_controller.rb
+++ b/app/controllers/authorships_controller.rb
@@ -220,7 +220,7 @@ class AuthorshipsController < ApplicationController
   # @param [String] pmid PubMed ID
   # @return [Publication]
   def get_publication_via_pubmed!(pmid)
-    pub = Publication.find_or_create_by_pmid(pmid)
+    pub = Publication.find_or_create_by_pmid(pmid.delete_prefix('MEDLINE:'))
     unless pub
       log_and_error!("The PMID:#{pmid} was not found either locally or at PubMed.")
       false

--- a/fixtures/vcr_cassettes/AuthorshipsController/Create_new_authorship_records_via_a_POST/for_a_new_PubMed_publication_with_the_WoS_MEDLINE_prefix/adds_new_publication.yml
+++ b/fixtures/vcr_cassettes/AuthorshipsController/Create_new_authorship_records_via_a_POST/for_a_new_PubMed_publication_with_the_WoS_MEDLINE_prefix/adds_new_publication.yml
@@ -1,0 +1,70 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=Settings.PUBMED.API_KEY&db=pubmed&retmode=xml
+    body:
+      encoding: UTF-8
+      string: "&id=&id=23684686"
+    headers:
+      User-Agent:
+      - stanford-library-sul-pub
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 18 Oct 2023 03:13:02 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 18 Oct 2023 03:13:02 GMT
+      Server:
+      - Finatra
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Ncbi-Sid:
+      - 19C31FA26B1E0874_2C23SID
+      Ncbi-Phid:
+      - 939B7494D675AB450000169C562584C6.1.1.m_3
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Cache-Control:
+      - private
+      Content-Encoding:
+      - gzip
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '7'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Set-Cookie:
+      - ncbi_sid=19C31FA26B1E0874_2C23SID; domain=.nih.gov; path=/; expires=Fri, 18
+        Oct 2024 03:13:02 GMT
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" ?>
+        <!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2023//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_230101.dtd">
+        <PubmedArticleSet>
+        <PubmedArticle><MedlineCitation Status="MEDLINE" Owner="NLM"><PMID Version="1">23684686</PMID><DateCompleted><Year>2013</Year><Month>10</Month><Day>31</Day></DateCompleted><DateRevised><Year>2022</Year><Month>04</Month><Day>08</Day></DateRevised><Article PubModel="Print-Electronic"><Journal><ISSN IssnType="Electronic">1558-3597</ISSN><JournalIssue CitedMedium="Internet"><Volume>62</Volume><Issue>6</Issue><PubDate><Year>2013</Year><Month>Aug</Month><Day>06</Day></PubDate></JournalIssue><Title>Journal of the American College of Cardiology</Title><ISOAbbreviation>J Am Coll Cardiol</ISOAbbreviation></Journal><ArticleTitle>Subtle post-procedural cognitive dysfunction after atrial fibrillation ablation.</ArticleTitle><Pagination><StartPage>531</StartPage><EndPage>539</EndPage><MedlinePgn>531-9</MedlinePgn></Pagination><ELocationID EIdType="doi" ValidYN="Y">10.1016/j.jacc.2013.03.073</ELocationID><ELocationID EIdType="pii" ValidYN="Y">S0735-1097(13)01882-2</ELocationID><Abstract><AbstractText Label="OBJECTIVES" NlmCategory="OBJECTIVE">This study sought to determine whether post-operative neurocognitive dysfunction (POCD) occurs after ablation for atrial fibrillation (AF).</AbstractText><AbstractText Label="BACKGROUND" NlmCategory="BACKGROUND">Ablation for AF is a highly effective strategy; however, the risk of transient ischemic attack and stroke is approximately 0.5% to 1%. In addition, magnetic resonance imaging studies report a 7% to 14% prevalence of silent cerebral infarction. Whether cerebral ischemia results in POCD after ablation for AF is not well established.</AbstractText><AbstractText Label="METHODS" NlmCategory="METHODS">The study included 150 patients; 60 patients undergoing ablation for paroxysmal atrial fibrillation (PAF), 30 patients undergoing ablation for persistent atrial fibrillation (PeAF), and 30 patients undergoing ablation for supraventricular tachycardia (SVT) were compared with&#xa0;a matched nonoperative control group of patients with AF awaiting radiofrequency ablation (n&#xa0;= 30). Eight neuropsychological tests were administered at baseline and at 2 days and 90 days post-operatively. The tests were administered at the same&#xa0;time&#xa0;points to the nonoperative control group. The reliable change index was used to calculate POCD.</AbstractText><AbstractText Label="RESULTS" NlmCategory="RESULTS">The prevalences of POCD at day 2 post-procedure were 28% in patients with PAF, 27% in patients with PeAF, 13% in patients with SVT, and 0% in control patients with AF (p&#xa0;= 0.007). At day 90, the prevalences of POCD were 13% in patients with PAF, 20% in patients with PeAF, 3% in patients with SVT, and 0% in control patients with AF (p&#xa0;= 0.03). When analyzing the 3 procedural groups together, 29 of 120 patients (24%) manifested POCD at day 2 and 15 of 120 patients (13%) at day 90 post-procedure (p&#xa0;= 0.029). On univariate analysis, increasing left atrial access time was associated with POCD at day 2 (p&#xa0;= 0.04) and day 90 (p&#xa0;= 0.03).</AbstractText><AbstractText Label="CONCLUSIONS" NlmCategory="CONCLUSIONS">Ablation for AF is associated with a 13% to 20% prevalence of POCD in patients with AF at long-term follow-up. These results were seen in a patient population with predominant CHADS2 (Congestive heart failure, Hypertension, Age&#xa0;&#x2265;75 years, Diabetes mellitus, previous Stroke/transient ischemic attack) scores of 0 to 1, representing the majority of patients undergoing ablation for AF. The long-term implications of these subtle changes require further study.</AbstractText><CopyrightInformation>Copyright &#xa9; 2013 American College of Cardiology Foundation. Published by Elsevier Inc. All rights reserved.</CopyrightInformation></Abstract><AuthorList CompleteYN="Y"><Author ValidYN="Y"><LastName>Medi</LastName><ForeName>Caroline</ForeName><Initials>C</Initials><AffiliationInfo><Affiliation>Department of Cardiology, The Royal Melbourne Hospital, Melbourne, Australia.</Affiliation></AffiliationInfo></Author><Author ValidYN="Y"><LastName>Evered</LastName><ForeName>Lisbeth</ForeName><Initials>L</Initials></Author><Author ValidYN="Y"><LastName>Silbert</LastName><ForeName>Brendan</ForeName><Initials>B</Initials></Author><Author ValidYN="Y"><LastName>Teh</LastName><ForeName>Andrew</ForeName><Initials>A</Initials></Author><Author ValidYN="Y"><LastName>Halloran</LastName><ForeName>Karen</ForeName><Initials>K</Initials></Author><Author ValidYN="Y"><LastName>Morton</LastName><ForeName>Joseph</ForeName><Initials>J</Initials></Author><Author ValidYN="Y"><LastName>Kistler</LastName><ForeName>Peter</ForeName><Initials>P</Initials></Author><Author ValidYN="Y"><LastName>Kalman</LastName><ForeName>Jonathan</ForeName><Initials>J</Initials></Author></AuthorList><Language>eng</Language><PublicationTypeList><PublicationType UI="D016428">Journal Article</PublicationType></PublicationTypeList><ArticleDate DateType="Electronic"><Year>2013</Year><Month>05</Month><Day>15</Day></ArticleDate></Article><MedlineJournalInfo><Country>United States</Country><MedlineTA>J Am Coll Cardiol</MedlineTA><NlmUniqueID>8301365</NlmUniqueID><ISSNLinking>0735-1097</ISSNLinking></MedlineJournalInfo><CitationSubset>IM</CitationSubset><CommentsCorrectionsList><CommentsCorrections RefType="CommentIn"><RefSource>J Am Coll Cardiol. 2013 Aug 6;62(6):540-2</RefSource><PMID Version="1">23684681</PMID></CommentsCorrections></CommentsCorrectionsList><MeshHeadingList><MeshHeading><DescriptorName UI="D000328" MajorTopicYN="N">Adult</DescriptorName></MeshHeading><MeshHeading><DescriptorName UI="D000368" MajorTopicYN="N">Aged</DescriptorName></MeshHeading><MeshHeading><DescriptorName UI="D001281" MajorTopicYN="N">Atrial Fibrillation</DescriptorName><QualifierName UI="Q000145" MajorTopicYN="N">classification</QualifierName><QualifierName UI="Q000601" MajorTopicYN="Y">surgery</QualifierName></MeshHeading><MeshHeading><DescriptorName UI="D016022" MajorTopicYN="N">Case-Control Studies</DescriptorName></MeshHeading><MeshHeading><DescriptorName UI="D017115" MajorTopicYN="Y">Catheter Ablation</DescriptorName></MeshHeading><MeshHeading><DescriptorName UI="D003072" MajorTopicYN="N">Cognition Disorders</DescriptorName><QualifierName UI="Q000453" MajorTopicYN="N">epidemiology</QualifierName><QualifierName UI="Q000209" MajorTopicYN="Y">etiology</QualifierName></MeshHeading><MeshHeading><DescriptorName UI="D005260" MajorTopicYN="N">Female</DescriptorName></MeshHeading><MeshHeading><DescriptorName UI="D005500" MajorTopicYN="N">Follow-Up Studies</DescriptorName></MeshHeading><MeshHeading><DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName></MeshHeading><MeshHeading><DescriptorName UI="D008297" MajorTopicYN="N">Male</DescriptorName></MeshHeading><MeshHeading><DescriptorName UI="D008875" MajorTopicYN="N">Middle Aged</DescriptorName></MeshHeading><MeshHeading><DescriptorName UI="D009483" MajorTopicYN="N">Neuropsychological Tests</DescriptorName></MeshHeading><MeshHeading><DescriptorName UI="D011183" MajorTopicYN="Y">Postoperative Complications</DescriptorName></MeshHeading><MeshHeading><DescriptorName UI="D015995" MajorTopicYN="N">Prevalence</DescriptorName></MeshHeading><MeshHeading><DescriptorName UI="D013617" MajorTopicYN="N">Tachycardia, Supraventricular</DescriptorName><QualifierName UI="Q000601" MajorTopicYN="N">surgery</QualifierName></MeshHeading></MeshHeadingList><KeywordList Owner="NOTNLM"><Keyword MajorTopicYN="N">ACT</Keyword><Keyword MajorTopicYN="N">AF</Keyword><Keyword MajorTopicYN="N">CERAD</Keyword><Keyword MajorTopicYN="N">CHADS(2)</Keyword><Keyword MajorTopicYN="N">CI</Keyword><Keyword MajorTopicYN="N">Congestive heart failure, Hypertension, Age&#xa0;&#x2265;75 years, Diabetes mellitus, previous Stroke/transient ischemic attack</Keyword><Keyword MajorTopicYN="N">Consortium to Establish a Registry for Alzheimer's Disease</Keyword><Keyword MajorTopicYN="N">IQ</Keyword><Keyword MajorTopicYN="N">MRI</Keyword><Keyword MajorTopicYN="N">OR</Keyword><Keyword MajorTopicYN="N">PAF</Keyword><Keyword MajorTopicYN="N">POCD</Keyword><Keyword MajorTopicYN="N">PeAF</Keyword><Keyword MajorTopicYN="N">RCI</Keyword><Keyword MajorTopicYN="N">RFA</Keyword><Keyword MajorTopicYN="N">SVT</Keyword><Keyword MajorTopicYN="N">ablation</Keyword><Keyword MajorTopicYN="N">activated clotting time</Keyword><Keyword MajorTopicYN="N">atrial fibrillation</Keyword><Keyword MajorTopicYN="N">confidence interval</Keyword><Keyword MajorTopicYN="N">intelligence quotient</Keyword><Keyword MajorTopicYN="N">magnetic resonance imaging</Keyword><Keyword MajorTopicYN="N">neurocognitive dysfunction</Keyword><Keyword MajorTopicYN="N">odds ratio</Keyword><Keyword MajorTopicYN="N">outcomes</Keyword><Keyword MajorTopicYN="N">paroxysmal atrial fibrillation</Keyword><Keyword MajorTopicYN="N">persistent atrial fibrillation</Keyword><Keyword MajorTopicYN="N">post-operative cognitive dysfunction</Keyword><Keyword MajorTopicYN="N">radiofrequency ablation</Keyword><Keyword MajorTopicYN="N">reliable change index</Keyword><Keyword MajorTopicYN="N">supraventricular tachycardia</Keyword></KeywordList></MedlineCitation><PubmedData><History><PubMedPubDate PubStatus="received"><Year>2012</Year><Month>11</Month><Day>1</Day></PubMedPubDate><PubMedPubDate PubStatus="revised"><Year>2013</Year><Month>3</Month><Day>12</Day></PubMedPubDate><PubMedPubDate PubStatus="accepted"><Year>2013</Year><Month>3</Month><Day>19</Day></PubMedPubDate><PubMedPubDate PubStatus="entrez"><Year>2013</Year><Month>5</Month><Day>21</Day><Hour>6</Hour><Minute>0</Minute></PubMedPubDate><PubMedPubDate PubStatus="pubmed"><Year>2013</Year><Month>5</Month><Day>21</Day><Hour>6</Hour><Minute>0</Minute></PubMedPubDate><PubMedPubDate PubStatus="medline"><Year>2013</Year><Month>11</Month><Day>1</Day><Hour>6</Hour><Minute>0</Minute></PubMedPubDate></History><PublicationStatus>ppublish</PublicationStatus><ArticleIdList><ArticleId IdType="pubmed">23684686</ArticleId><ArticleId IdType="doi">10.1016/j.jacc.2013.03.073</ArticleId><ArticleId IdType="pii">S0735-1097(13)01882-2</ArticleId></ArticleIdList></PubmedData></PubmedArticle></PubmedArticleSet>
+  recorded_at: Wed, 18 Oct 2023 03:13:02 GMT
+recorded_with: VCR 6.2.0

--- a/fixtures/vcr_cassettes/AuthorshipsController/Create_new_authorship_records_via_a_POST/for_a_new_PubMed_publication_with_the_WoS_MEDLINE_prefix/adds_proper_identifiers_section.yml
+++ b/fixtures/vcr_cassettes/AuthorshipsController/Create_new_authorship_records_via_a_POST/for_a_new_PubMed_publication_with_the_WoS_MEDLINE_prefix/adds_proper_identifiers_section.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=Settings.PUBMED.API_KEY&db=pubmed&retmode=xml
+    body:
+      encoding: UTF-8
+      string: "&id=&id=23684686"
+    headers:
+      User-Agent:
+      - stanford-library-sul-pub
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 18 Oct 2023 03:13:02 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Cookie:
+      - ncbi_sid=19C31FA26B1E0874_2C23SID
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 18 Oct 2023 03:13:02 GMT
+      Server:
+      - Finatra
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Ncbi-Sid:
+      - 19C31FA26B1E0874_2C23SID
+      Ncbi-Phid:
+      - 939B7494D675AB450000289C59AF6737.1.1.m_3
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Cache-Control:
+      - private
+      Content-Encoding:
+      - gzip
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '6'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Set-Cookie:
+      - ncbi_sid=19C31FA26B1E0874_2C23SID; domain=.nih.gov; path=/; expires=Fri, 18
+        Oct 2024 03:13:03 GMT
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" ?>
+        <!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2023//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_230101.dtd">
+        <PubmedArticleSet>
+        <PubmedArticle><MedlineCitation Status="MEDLINE" Owner="NLM"><PMID Version="1">23684686</PMID><DateCompleted><Year>2013</Year><Month>10</Month><Day>31</Day></DateCompleted><DateRevised><Year>2022</Year><Month>04</Month><Day>08</Day></DateRevised><Article PubModel="Print-Electronic"><Journal><ISSN IssnType="Electronic">1558-3597</ISSN><JournalIssue CitedMedium="Internet"><Volume>62</Volume><Issue>6</Issue><PubDate><Year>2013</Year><Month>Aug</Month><Day>06</Day></PubDate></JournalIssue><Title>Journal of the American College of Cardiology</Title><ISOAbbreviation>J Am Coll Cardiol</ISOAbbreviation></Journal><ArticleTitle>Subtle post-procedural cognitive dysfunction after atrial fibrillation ablation.</ArticleTitle><Pagination><StartPage>531</StartPage><EndPage>539</EndPage><MedlinePgn>531-9</MedlinePgn></Pagination><ELocationID EIdType="doi" ValidYN="Y">10.1016/j.jacc.2013.03.073</ELocationID><ELocationID EIdType="pii" ValidYN="Y">S0735-1097(13)01882-2</ELocationID><Abstract><AbstractText Label="OBJECTIVES" NlmCategory="OBJECTIVE">This study sought to determine whether post-operative neurocognitive dysfunction (POCD) occurs after ablation for atrial fibrillation (AF).</AbstractText><AbstractText Label="BACKGROUND" NlmCategory="BACKGROUND">Ablation for AF is a highly effective strategy; however, the risk of transient ischemic attack and stroke is approximately 0.5% to 1%. In addition, magnetic resonance imaging studies report a 7% to 14% prevalence of silent cerebral infarction. Whether cerebral ischemia results in POCD after ablation for AF is not well established.</AbstractText><AbstractText Label="METHODS" NlmCategory="METHODS">The study included 150 patients; 60 patients undergoing ablation for paroxysmal atrial fibrillation (PAF), 30 patients undergoing ablation for persistent atrial fibrillation (PeAF), and 30 patients undergoing ablation for supraventricular tachycardia (SVT) were compared with&#xa0;a matched nonoperative control group of patients with AF awaiting radiofrequency ablation (n&#xa0;= 30). Eight neuropsychological tests were administered at baseline and at 2 days and 90 days post-operatively. The tests were administered at the same&#xa0;time&#xa0;points to the nonoperative control group. The reliable change index was used to calculate POCD.</AbstractText><AbstractText Label="RESULTS" NlmCategory="RESULTS">The prevalences of POCD at day 2 post-procedure were 28% in patients with PAF, 27% in patients with PeAF, 13% in patients with SVT, and 0% in control patients with AF (p&#xa0;= 0.007). At day 90, the prevalences of POCD were 13% in patients with PAF, 20% in patients with PeAF, 3% in patients with SVT, and 0% in control patients with AF (p&#xa0;= 0.03). When analyzing the 3 procedural groups together, 29 of 120 patients (24%) manifested POCD at day 2 and 15 of 120 patients (13%) at day 90 post-procedure (p&#xa0;= 0.029). On univariate analysis, increasing left atrial access time was associated with POCD at day 2 (p&#xa0;= 0.04) and day 90 (p&#xa0;= 0.03).</AbstractText><AbstractText Label="CONCLUSIONS" NlmCategory="CONCLUSIONS">Ablation for AF is associated with a 13% to 20% prevalence of POCD in patients with AF at long-term follow-up. These results were seen in a patient population with predominant CHADS2 (Congestive heart failure, Hypertension, Age&#xa0;&#x2265;75 years, Diabetes mellitus, previous Stroke/transient ischemic attack) scores of 0 to 1, representing the majority of patients undergoing ablation for AF. The long-term implications of these subtle changes require further study.</AbstractText><CopyrightInformation>Copyright &#xa9; 2013 American College of Cardiology Foundation. Published by Elsevier Inc. All rights reserved.</CopyrightInformation></Abstract><AuthorList CompleteYN="Y"><Author ValidYN="Y"><LastName>Medi</LastName><ForeName>Caroline</ForeName><Initials>C</Initials><AffiliationInfo><Affiliation>Department of Cardiology, The Royal Melbourne Hospital, Melbourne, Australia.</Affiliation></AffiliationInfo></Author><Author ValidYN="Y"><LastName>Evered</LastName><ForeName>Lisbeth</ForeName><Initials>L</Initials></Author><Author ValidYN="Y"><LastName>Silbert</LastName><ForeName>Brendan</ForeName><Initials>B</Initials></Author><Author ValidYN="Y"><LastName>Teh</LastName><ForeName>Andrew</ForeName><Initials>A</Initials></Author><Author ValidYN="Y"><LastName>Halloran</LastName><ForeName>Karen</ForeName><Initials>K</Initials></Author><Author ValidYN="Y"><LastName>Morton</LastName><ForeName>Joseph</ForeName><Initials>J</Initials></Author><Author ValidYN="Y"><LastName>Kistler</LastName><ForeName>Peter</ForeName><Initials>P</Initials></Author><Author ValidYN="Y"><LastName>Kalman</LastName><ForeName>Jonathan</ForeName><Initials>J</Initials></Author></AuthorList><Language>eng</Language><PublicationTypeList><PublicationType UI="D016428">Journal Article</PublicationType></PublicationTypeList><ArticleDate DateType="Electronic"><Year>2013</Year><Month>05</Month><Day>15</Day></ArticleDate></Article><MedlineJournalInfo><Country>United States</Country><MedlineTA>J Am Coll Cardiol</MedlineTA><NlmUniqueID>8301365</NlmUniqueID><ISSNLinking>0735-1097</ISSNLinking></MedlineJournalInfo><CitationSubset>IM</CitationSubset><CommentsCorrectionsList><CommentsCorrections RefType="CommentIn"><RefSource>J Am Coll Cardiol. 2013 Aug 6;62(6):540-2</RefSource><PMID Version="1">23684681</PMID></CommentsCorrections></CommentsCorrectionsList><MeshHeadingList><MeshHeading><DescriptorName UI="D000328" MajorTopicYN="N">Adult</DescriptorName></MeshHeading><MeshHeading><DescriptorName UI="D000368" MajorTopicYN="N">Aged</DescriptorName></MeshHeading><MeshHeading><DescriptorName UI="D001281" MajorTopicYN="N">Atrial Fibrillation</DescriptorName><QualifierName UI="Q000145" MajorTopicYN="N">classification</QualifierName><QualifierName UI="Q000601" MajorTopicYN="Y">surgery</QualifierName></MeshHeading><MeshHeading><DescriptorName UI="D016022" MajorTopicYN="N">Case-Control Studies</DescriptorName></MeshHeading><MeshHeading><DescriptorName UI="D017115" MajorTopicYN="Y">Catheter Ablation</DescriptorName></MeshHeading><MeshHeading><DescriptorName UI="D003072" MajorTopicYN="N">Cognition Disorders</DescriptorName><QualifierName UI="Q000453" MajorTopicYN="N">epidemiology</QualifierName><QualifierName UI="Q000209" MajorTopicYN="Y">etiology</QualifierName></MeshHeading><MeshHeading><DescriptorName UI="D005260" MajorTopicYN="N">Female</DescriptorName></MeshHeading><MeshHeading><DescriptorName UI="D005500" MajorTopicYN="N">Follow-Up Studies</DescriptorName></MeshHeading><MeshHeading><DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName></MeshHeading><MeshHeading><DescriptorName UI="D008297" MajorTopicYN="N">Male</DescriptorName></MeshHeading><MeshHeading><DescriptorName UI="D008875" MajorTopicYN="N">Middle Aged</DescriptorName></MeshHeading><MeshHeading><DescriptorName UI="D009483" MajorTopicYN="N">Neuropsychological Tests</DescriptorName></MeshHeading><MeshHeading><DescriptorName UI="D011183" MajorTopicYN="Y">Postoperative Complications</DescriptorName></MeshHeading><MeshHeading><DescriptorName UI="D015995" MajorTopicYN="N">Prevalence</DescriptorName></MeshHeading><MeshHeading><DescriptorName UI="D013617" MajorTopicYN="N">Tachycardia, Supraventricular</DescriptorName><QualifierName UI="Q000601" MajorTopicYN="N">surgery</QualifierName></MeshHeading></MeshHeadingList><KeywordList Owner="NOTNLM"><Keyword MajorTopicYN="N">ACT</Keyword><Keyword MajorTopicYN="N">AF</Keyword><Keyword MajorTopicYN="N">CERAD</Keyword><Keyword MajorTopicYN="N">CHADS(2)</Keyword><Keyword MajorTopicYN="N">CI</Keyword><Keyword MajorTopicYN="N">Congestive heart failure, Hypertension, Age&#xa0;&#x2265;75 years, Diabetes mellitus, previous Stroke/transient ischemic attack</Keyword><Keyword MajorTopicYN="N">Consortium to Establish a Registry for Alzheimer's Disease</Keyword><Keyword MajorTopicYN="N">IQ</Keyword><Keyword MajorTopicYN="N">MRI</Keyword><Keyword MajorTopicYN="N">OR</Keyword><Keyword MajorTopicYN="N">PAF</Keyword><Keyword MajorTopicYN="N">POCD</Keyword><Keyword MajorTopicYN="N">PeAF</Keyword><Keyword MajorTopicYN="N">RCI</Keyword><Keyword MajorTopicYN="N">RFA</Keyword><Keyword MajorTopicYN="N">SVT</Keyword><Keyword MajorTopicYN="N">ablation</Keyword><Keyword MajorTopicYN="N">activated clotting time</Keyword><Keyword MajorTopicYN="N">atrial fibrillation</Keyword><Keyword MajorTopicYN="N">confidence interval</Keyword><Keyword MajorTopicYN="N">intelligence quotient</Keyword><Keyword MajorTopicYN="N">magnetic resonance imaging</Keyword><Keyword MajorTopicYN="N">neurocognitive dysfunction</Keyword><Keyword MajorTopicYN="N">odds ratio</Keyword><Keyword MajorTopicYN="N">outcomes</Keyword><Keyword MajorTopicYN="N">paroxysmal atrial fibrillation</Keyword><Keyword MajorTopicYN="N">persistent atrial fibrillation</Keyword><Keyword MajorTopicYN="N">post-operative cognitive dysfunction</Keyword><Keyword MajorTopicYN="N">radiofrequency ablation</Keyword><Keyword MajorTopicYN="N">reliable change index</Keyword><Keyword MajorTopicYN="N">supraventricular tachycardia</Keyword></KeywordList></MedlineCitation><PubmedData><History><PubMedPubDate PubStatus="received"><Year>2012</Year><Month>11</Month><Day>1</Day></PubMedPubDate><PubMedPubDate PubStatus="revised"><Year>2013</Year><Month>3</Month><Day>12</Day></PubMedPubDate><PubMedPubDate PubStatus="accepted"><Year>2013</Year><Month>3</Month><Day>19</Day></PubMedPubDate><PubMedPubDate PubStatus="entrez"><Year>2013</Year><Month>5</Month><Day>21</Day><Hour>6</Hour><Minute>0</Minute></PubMedPubDate><PubMedPubDate PubStatus="pubmed"><Year>2013</Year><Month>5</Month><Day>21</Day><Hour>6</Hour><Minute>0</Minute></PubMedPubDate><PubMedPubDate PubStatus="medline"><Year>2013</Year><Month>11</Month><Day>1</Day><Hour>6</Hour><Minute>0</Minute></PubMedPubDate></History><PublicationStatus>ppublish</PublicationStatus><ArticleIdList><ArticleId IdType="pubmed">23684686</ArticleId><ArticleId IdType="doi">10.1016/j.jacc.2013.03.073</ArticleId><ArticleId IdType="pii">S0735-1097(13)01882-2</ArticleId></ArticleIdList></PubmedData></PubmedArticle></PubmedArticleSet>
+  recorded_at: Wed, 18 Oct 2023 03:13:03 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## Why was this change made?

Fixes #1653 - see the analysis in the issue description.  Basically the new WoS API is returning PMIDs in the record now, and the Profiles team is preferentially picking the PMID in the result and sending that when adding publications via the manual title search (I verified both of these).  The WOS records adds a MEDINE: prefix to PMIDs, but when we get a request to add a publication for a specific PMID, we go straight to the Pubmed API to look for that PMID, and to do this, we do NOT want the MEDLINE: prefix.  So we should strip it in this case for any incoming PMID we are sent.

## How was this change tested?

cap-dev-a and new specs
