### PR TITLE
fix issue with certain citation rendering

### DIFF
--- a/lib/csl/mapper.rb
+++ b/lib/csl/mapper.rb
@@ -75,7 +75,7 @@ module Csl
         # this overrides the sciencewire fields above if both exist, which they shouldn't.
         if pub_hash.key?(:conference)
           cit_data_hash['event'] = pub_hash[:conference][:name] if pub_hash[:conference][:name].present?
-          cit_data_hash['event-date'] = pub_hash[:conference][:startdate] if pub_hash[:conference][:startdate].present?
+          cit_data_hash['event-date'] = { 'date-parts' => [[pub_hash[:conference][:startdate]]] } if pub_hash[:conference][:startdate].present?
           # override the startdate if there is a year:
           if pub_hash[:conference][:year].present?
             cit_data_hash['event-date'] =

--- a/spec/factories/user_submitted_source_records.rb
+++ b/spec/factories/user_submitted_source_records.rb
@@ -521,6 +521,62 @@ FactoryBot.define do
     }'
     end
   end
+  factory :conference_proceeding_without_event_year, parent: :user_submitted_source_record do
+    pmid { nil }
+    lock_version { 0 }
+    source_fingerprint { 'fc74b1f712626c6f26d094d06408cfdcf1de013b956c7c837814bb87007707d3' }
+    title { 'Preservation and discovery for GIS data' }
+    year { 1997 }
+    is_active { true }
+    source_data do
+      '{
+      "identifier": [],
+      "title": "Preservation and discovery for GIS data",
+      "authorship": [
+        {
+          "sul_author_id": null,
+          "cap_profile_id": 62029,
+          "featured": false,
+          "status": "APPROVED",
+          "visibility": "PUBLIC",
+          "additionalProperties": {}
+        }
+      ],
+      "year": "1997",
+      "abstract_restricted": "",
+      "type": "inproceedings",
+      "provenance": "CAP",
+      "allAuthors": "",
+      "author": [
+        {
+          "name": "Reed  Jack",
+          "alternate": [],
+          "lastname": "Reed",
+          "firstname": "Jack",
+          "middlename": "",
+          "role": "author",
+          "additionalProperties": {}
+        }
+      ],
+      "etal": false,
+      "howpublished": "monograph",
+      "pages": "",
+      "publisher": "Esri",
+      "articlenumber": "",
+      "conference": {
+        "name": "Esri User Conference",
+        "location": "San Diego, California",
+        "number": "",
+        "organization": "",
+        "startdate": "1997-06-02T00:00:00",
+        "enddate": "1997-06-04T00:00:00",
+        "doi": "",
+        "additionalProperties": {}
+      },
+      "additionalProperties": {}
+    }'
+    end
+  end
   factory :journal_article, parent: :user_submitted_source_record do
     pmid { nil }
     lock_version { 0 }

--- a/spec/lib/csl/citation_spec.rb
+++ b/spec/lib/csl/citation_spec.rb
@@ -631,6 +631,26 @@ describe Csl::Citation do
       end
     end
 
+    context 'conference proceeding without a year but with an start date' do
+      let(:source_data_key) { :conference_proceeding_without_event_year }
+
+      it 'keeps inproceedings type' do
+        expect(pub_hash.csl_doc).to include('type' => 'inproceedings')
+      end
+
+      it 'creates a Chicago citation' do
+        expect(pub_hash.to_chicago_citation).to eq 'Reed, Jack. 1997. “Preservation and Discovery for GIS Data.” Esri.'
+      end
+
+      it 'creates a MLA citation' do
+        expect(pub_hash.to_mla_citation).to eq 'Reed, Jack. “Preservation and Discovery for GIS Data.” 1997: n. pag. Print.'
+      end
+
+      it 'creates a APA citation' do
+        expect(pub_hash.to_apa_citation).to eq 'Reed, J. (1997). Preservation and discovery for GIS data. Presented at the Esri User Conference, San Diego, California: Esri.'
+      end
+    end
+
     context 'conference proceeding without city' do
       let(:source_data) do
         h = JSON.parse(create(:conference_proceeding).source_data, symbolize_names: true)


### PR DESCRIPTION
## Why was this change made?

Fixes #1651 - citation generation for certain publications was failing due to an issue with how we were generating data for the citeproc gem

## How was this change tested?

Localhost and new spec

(I verified the new spec fails with expected exception without fix, and then passes with fix)
