### PR TITLE
fix issue with pub export task

### DIFF
--- a/lib/tasks/sul.rake
+++ b/lib/tasks/sul.rake
@@ -197,7 +197,7 @@ namespace :sul do
           puts "#{message} : #{contributions.size} publications"
           contributions.each do |contribution|
             pub = contribution.publication
-            next unless !pub_years.empty? && pub_years.include?(pub.year)
+            next unless pub_years.empty? || (pub_years.present? && pub_years.include?(pub.year))
 
             total_pubs += 1
             author_list = if pub.pub_hash[:author]


### PR DESCRIPTION
## Why was this change made?

We need to be able to export publications for all publication years with this rake task ... this rake task had a bug which was preventing this, and this fixes it.

## How was this change tested?

Using the modified rake task for a report right now.