### PR TITLE
send bad request for csv format for all authors

### DIFF
--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -47,7 +47,11 @@ class PublicationsController < ApplicationController
         render json: wrap_as_bibjson_collection(description, matching_records, page, per)
       end
       format.csv do
-        send_data(generate_csv_report(author), filename: 'author_report.csv')
+        if author
+          send_data(generate_csv_report(author), filename: 'author_report.csv')
+        else # this format doesn't work except for a single author
+          render plain: 'CSV not available for all publications; must select single author', status: :bad_request
+        end
       end
     end
   end

--- a/spec/controllers/publications_controller_spec.rb
+++ b/spec/controllers/publications_controller_spec.rb
@@ -216,6 +216,16 @@ describe PublicationsController, :vcr do
                                     "status_for_this_author,created_at,updated_at,contributor_cap_profile_ids\n"
       end
     end
+
+    context 'with no capProfileId supplied in csv format' do
+      before { allow(Author).to receive(:find_by).with(cap_profile_id: cap_id).and_return(author) }
+
+      it 'returns a bad request response' do
+        get :index, params: { format: 'csv' }
+        expect(response).to have_http_status :bad_request
+        expect(response.body).to eq 'CSV not available for all publications; must select single author'
+      end
+    end
   end
 
   describe 'search for publications (GET sourcelookup)' do


### PR DESCRIPTION
## Why was this change made?

You can only request csv format for a single author's publications currently.  This prevents an [HB alert ](https://app.honeybadger.io/projects/50046/faults/105701954)from happening if you try to get CSV for all authors.


## How was this change tested?

New spec

## Which documentation and/or configurations were updated?



