### PR TITLE
Remove unicode gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gem 'activerecord-import'
 gem 'bibtex-ruby'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'citeproc-ruby', '~> 1.1'
-gem 'unicode' # CiteProc requires the `unicode_utils` or `unicode` Gem on Ruby 2.3
 gem 'config'
 
 gem 'csl-styles', '1.0.1.8' # See https://github.com/sul-dlss/sul_pub/issues/1019 before updating

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -515,7 +515,6 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.9.1)
-    unicode (0.4.4.4)
     unicode-display_width (2.5.0)
     uri (0.13.0)
     urn (2.0.2)
@@ -600,7 +599,6 @@ DEPENDENCIES
   sqlite3 (~> 1.7)
   sul_orcid_client
   thin
-  unicode
   vcr
   webmock
   whenever


### PR DESCRIPTION
## Why was this change made?
It doesn't seem necessary and doesn't compile on new Macs.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?



