### PR TITLE
Comment out ancient settings that are no longer needed

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,9 +1,9 @@
 # see https://github.com/sul-dlss/sul_pub/wiki/Servers-Deployment-environment
 set :application, 'sul-pub'
 set :repo_url, "git@github.com:sul-dlss/sul_pub.git"
-set :ssh_options,   keys: [Capistrano::OneTimeKey.temporary_ssh_private_key_path],
-                    forward_agent: true,
-                    auth_methods: %w(publickey password)
+# set :ssh_options,   keys: [Capistrano::OneTimeKey.temporary_ssh_private_key_path],
+#                     forward_agent: true,
+#                     auth_methods: %w(publickey password)
 
 set :deploy_to, "/opt/app/pub/#{fetch(:application)}"
 


### PR DESCRIPTION
Also, this will break deploys when we move off of the Capistrano-OneTimeKey gem.
