### PR TITLE
Add csv dependency to bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,8 @@ gem 'bibtex-ruby'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'citeproc-ruby', '~> 1.1'
 gem 'config'
-
 gem 'csl-styles', '1.0.1.8' # See https://github.com/sul-dlss/sul_pub/issues/1019 before updating
+gem 'csv'
 gem 'daemons'
 gem 'dotiw'
 gem 'faraday'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,6 +167,7 @@ GEM
       rexml
     csl-styles (1.0.1.8)
       csl (~> 1.0)
+    csv (3.2.8)
     daemons (1.4.1)
     database_cleaner (2.0.2)
       database_cleaner-active_record (>= 2, < 3)
@@ -557,6 +558,7 @@ DEPENDENCIES
   citeproc-ruby (~> 1.1)
   config
   csl-styles (= 1.0.1.8)
+  csv
   daemons
   database_cleaner
   dlss-capistrano

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'csv'
-
 class PublicationsController < ApplicationController
   before_action :check_authorization
   before_action :ensure_json_request, except: [:index]

--- a/lib/smci_report.rb
+++ b/lib/smci_report.rb
@@ -54,8 +54,6 @@
 
 # NOTE: This borrowed some code from the 'export_pubs_for_authors_csv' rake task in lib/tasks/sul.rake
 
-require 'csv'
-
 class SmciReport
   # rubocop:disable Metrics/CyclomaticComplexity
   def initialize(args)

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'csv'
-
 namespace :cleanup do
   desc 'Merge contributions FROM duped_cap_profile_id INTO primary_cap_profile_id'
   # Use case: a single author has two author rows with publications associated with each.

--- a/lib/tasks/sul.rake
+++ b/lib/tasks/sul.rake
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'csv'
 require 'json'
 require 'fileutils'
 

--- a/script/delete_missing_auths.rb
+++ b/script/delete_missing_auths.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'csv'
-
 class DeleteMissingAuths
   def initialize
     @logger = Logger.new(Rails.root.join('log/delete_missing_auths.log'))

--- a/script/dup_report.rb
+++ b/script/dup_report.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'csv'
-
 class Reporter
   def initialize(swids_file, pmids_file, wos_file)
     @swids = build_id_set swids_file

--- a/script/merge_duplicate_authors.rb
+++ b/script/merge_duplicate_authors.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'csv'
-
 class MergeDuplicateAuths
   CONTRIB_CHECK = true
 

--- a/script/repair_mixed_auths.rb
+++ b/script/repair_mixed_auths.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'csv'
-
 class RepairMixedAuths
   def initialize
     @logger = Logger.new(Rails.root.join('log/repair_mixed_auths.log'))

--- a/script/title_report.rb
+++ b/script/title_report.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'csv'
 require 'pathname'
 
 ActiveRecord::Base.logger.level = 1


### PR DESCRIPTION
# Why was this change made?

This dependency is moving out of stdlib in Ruby 3.4 so it must be managed by bundler.

# How was this change tested?

CI
