### PR TITLE
turn on harvesting jobs in new dev-temp environment

### DIFF
--- a/config/deploy/qa-temp.rb
+++ b/config/deploy/qa-temp.rb
@@ -1,5 +1,5 @@
 # see https://github.com/sul-dlss/sul_pub/wiki/Servers-Deployment-environment
-server 'sul-pub-cap-dev-temp.stanford.edu', user: 'pub', roles: %w(web db app)
+server 'sul-pub-cap-dev-temp.stanford.edu', user: 'pub', roles: %w(web db harvester_dev app)
 
 Capistrano::OneTimeKey.generate_one_time_key!
 


### PR DESCRIPTION
## Why was this change made?

New Profiles dev-temp environment is ready.  This is paired with https://github.com/sul-dlss/shared_configs/pull/2265 to enable it.

I verified the new Profiles URL is responding.

## How was this change tested?

Rails console