### PR TITLE
turn on harvesting jobs in new uat-temp environment

### DIFF
--- a/config/deploy/uat-temp.rb
+++ b/config/deploy/uat-temp.rb
@@ -1,5 +1,5 @@
 # see https://github.com/sul-dlss/sul_pub/wiki/Servers-Deployment-environment
-server 'sul-pub-cap-uat-temp.stanford.edu', user: 'pub', roles: %w(web db app external_monitor)
+server 'sul-pub-cap-uat-temp.stanford.edu', user: 'pub', roles: %w(web db app harvester_uat external_monitor)
 
 Capistrano::OneTimeKey.generate_one_time_key!
 


### PR DESCRIPTION
## Why was this change made?

New Profiles uat-temp environment is ready. This is paired with https://github.com/sul-dlss/shared_configs/pull/2273 to enable it.

I verified the new Profiles URL is responding.

## How was this change tested?

Rails console

## Which documentation and/or configurations were updated?



