### PR TITLE
can disable harvesting on uat for now

### DIFF
--- a/config/deploy/uat.rb
+++ b/config/deploy/uat.rb
@@ -1,5 +1,5 @@
 # see https://github.com/sul-dlss/sul_pub/wiki/Servers-Deployment-environment
-server 'sul-pub-cap-uat.stanford.edu', user: 'pub', roles: %w(web db app harvester_uat external_monitor)
+server 'sul-pub-cap-uat.stanford.edu', user: 'pub', roles: %w(web db app external_monitor)
 
 Capistrano::OneTimeKey.generate_one_time_key!
 


### PR DESCRIPTION
## Why was this change made?

As Profiles team continues with their migration, they tell us we do not need to have harvesting running on UAT environment for now.  This disables it.

Eventually, servers will re-shuffled and we will renable, as shown in https://docs.google.com/document/d/14K09NJG1O6Zo8u0LfrxK5g8ADLTBZ_HzkAnEr_YAsS8/edit?tab=t.0

