### PR TITLE
setup deploy for new prod-temp environment

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -12,7 +12,6 @@ ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }.call
 
 # Default value for :linked_files is []
 set :linked_files, fetch(:linked_files, []).push(
-  'config/secrets.yml',
   'config/database.yml',
   'config/honeybadger.yml'
 )

--- a/config/deploy/prod-temp.rb
+++ b/config/deploy/prod-temp.rb
@@ -1,0 +1,12 @@
+# see https://github.com/sul-dlss/sul_pub/wiki/Servers-Deployment-environment
+# see https://github.com/sul-dlss/operations-tasks/issues/3951
+# and https://docs.google.com/document/d/14K09NJG1O6Zo8u0LfrxK5g8ADLTBZ_HzkAnEr_YAsS8
+server 'sul-pub-prod-temp.stanford.edu', user: 'pub', roles: %w(web db app)
+
+Capistrano::OneTimeKey.generate_one_time_key!
+
+set :rails_env, 'production'
+
+set :bundle_without, %w(test development).join(' ')
+
+set :log_level, :info

--- a/config/deploy/qa-temp.rb
+++ b/config/deploy/qa-temp.rb
@@ -1,4 +1,6 @@
 # see https://github.com/sul-dlss/sul_pub/wiki/Servers-Deployment-environment
+# see https://github.com/sul-dlss/operations-tasks/issues/3879
+# see https://docs.google.com/document/d/14K09NJG1O6Zo8u0LfrxK5g8ADLTBZ_HzkAnEr_YAsS8
 server 'sul-pub-cap-dev-temp.stanford.edu', user: 'pub', roles: %w(web db harvester_dev app)
 
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,5 +1,5 @@
 # see https://github.com/sul-dlss/sul_pub/wiki/Servers-Deployment-environment
-server 'sul-pub-cap-dev-a.stanford.edu', user: 'pub', roles: %w(web db harvester_dev app)
+server 'sul-pub-cap-dev-a.stanford.edu', user: 'pub', roles: %w(web db app)
 
 Capistrano::OneTimeKey.generate_one_time_key!
 

--- a/config/deploy/uat-temp.rb
+++ b/config/deploy/uat-temp.rb
@@ -1,4 +1,6 @@
 # see https://github.com/sul-dlss/sul_pub/wiki/Servers-Deployment-environment
+# see https://github.com/sul-dlss/operations-tasks/issues/3879
+# see https://docs.google.com/document/d/14K09NJG1O6Zo8u0LfrxK5g8ADLTBZ_HzkAnEr_YAsS8
 server 'sul-pub-cap-uat-temp.stanford.edu', user: 'pub', roles: %w(web db app harvester_uat external_monitor)
 
 Capistrano::OneTimeKey.generate_one_time_key!


### PR DESCRIPTION
## Why was this change made?

See https://github.com/sul-dlss/operations-tasks/issues/3951

- We are spinning up a temporary prod environment for Profile's use.
- Add some links to related tickets in code documentation.
- Disable harvesting in uat and dev environment for now (not needed per discussion with Profiles, we will be replacing the data on these servers with the -temp counterparts at some point)
- Remove unnecessary linking of secrets.yml file for all environments (noticed when deploying to prod-temp, this comes from vault now anyway)

## How was this change tested?



## Which documentation and/or configurations were updated?



