### PR TITLE
Remove misleading usage of `protected` keyword

### DIFF
--- a/lib/csl/author_name.rb
+++ b/lib/csl/author_name.rb
@@ -49,7 +49,7 @@ module Csl
         middle == other.middle
     end
 
-    protected
+    private
 
     def as_string(param)
       param.to_s.strip


### PR DESCRIPTION
## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



