### PR TITLE
[HOLD] remove scheduled tasks temporarily

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,5 +1,5 @@
 # see https://github.com/sul-dlss/sul_pub/wiki/Servers-Deployment-environment
-server 'sul-pub-prod.stanford.edu', user: 'pub', roles: %w(web db app harvester_prod external_monitor)
+server 'sul-pub-prod.stanford.edu', user: 'pub', roles: %w(web db app)
 
 Capistrano::OneTimeKey.generate_one_time_key!
 


### PR DESCRIPTION
## Why was this change made?

Temporarily turn off all scheduled tasks in production.

Used for Profiles cutover 2025

Re-deploy main to turn tasks back on.

Verify on server with `crontab -l`

Should be blank after this deploy.
Should have several tasks again after main deployed.
