### PR TITLE
no need for harvesting in qa and deve temp

### DIFF
--- a/config/deploy/qa-temp.rb
+++ b/config/deploy/qa-temp.rb
@@ -1,7 +1,7 @@
 # see https://github.com/sul-dlss/sul_pub/wiki/Servers-Deployment-environment
 # see https://github.com/sul-dlss/operations-tasks/issues/3879
 # see https://docs.google.com/document/d/14K09NJG1O6Zo8u0LfrxK5g8ADLTBZ_HzkAnEr_YAsS8
-server 'sul-pub-cap-dev-temp.stanford.edu', user: 'pub', roles: %w(web db harvester_dev app)
+server 'sul-pub-cap-dev-temp.stanford.edu', user: 'pub', roles: %w(web db app)
 
 Capistrano::OneTimeKey.generate_one_time_key!
 

--- a/config/deploy/uat-temp.rb
+++ b/config/deploy/uat-temp.rb
@@ -1,7 +1,7 @@
 # see https://github.com/sul-dlss/sul_pub/wiki/Servers-Deployment-environment
 # see https://github.com/sul-dlss/operations-tasks/issues/3879
 # see https://docs.google.com/document/d/14K09NJG1O6Zo8u0LfrxK5g8ADLTBZ_HzkAnEr_YAsS8
-server 'sul-pub-cap-uat-temp.stanford.edu', user: 'pub', roles: %w(web db app harvester_uat external_monitor)
+server 'sul-pub-cap-uat-temp.stanford.edu', user: 'pub', roles: %w(web db app external_monitor)
 
 Capistrano::OneTimeKey.generate_one_time_key!
 


### PR DESCRIPTION
## Why was this change made?

The production migration will result in us restoring a prod database over the qa and dev environments once complete (as noted by the Profiles team).  This means we can turn off harvesting in the temp dev and UAT environments, as these databases will soon be overwritten by prod anyway.  See https://github.com/sul-dlss/operations-tasks/issues/3952 for the upcoming plan.
