### PR TITLE
Float sqlite version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ group :development, :test do
   gem 'rubocop-rspec_rails'
   gem 'rspec'
   gem 'rspec-rails'
-  gem 'sqlite3', '~> 1.7' # sqlite3 2.0.0 is not currently compatible with Rails 7.1; unpin when new rails release: https://github.com/rails/rails/pull/51636
+  gem 'sqlite3'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -632,7 +632,7 @@ DEPENDENCIES
   rubocop-rspec_rails
   ruby-prof
   simplecov (~> 0.13)
-  sqlite3 (~> 1.7)
+  sqlite3
   sul_orcid_client
   thin
   vcr


### PR DESCRIPTION
We've been seeing some strange deadlock errors during dependency updates and were wondering if they were related to the version of sqlite that is being used in the Jenkins environment.

```
Some locked specs have possibly been yanked (sqlite3-1.7.3-x86_64-linux). Ignoring them...
```

At one time we pinned sqlite back because of a Rails incompatibility issue. However that issue has since been merged. This PR lets sqlite version float again. It is only used in development (tests) and MySQL is used in production.
