### PR TITLE
pin mais-orcid-client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'identifiers', '~> 0.12' # Altmetric utilities related to the extraction, va
 gem 'jbuilder' # To use Jbuilder templates for JSON
 gem 'json_schemer'
 gem 'kaminari'
-gem 'mais_orcid_client'
+gem 'mais_orcid_client', '< 1' # MAIS ORCID Client will have breaking changes in v1.0, see https://github.com/sul-dlss/mais_orcid_client/issues/108
 gem 'mutex_m'  # needed because httpclient depends on it and is unmaintained
 gem 'okcomputer' # for monitoring
 gem 'oauth2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -607,7 +607,7 @@ DEPENDENCIES
   json_schemer
   kaminari
   listen (~> 3.7)
-  mais_orcid_client
+  mais_orcid_client (< 1)
   mutex_m
   mysql2 (>= 0.5.3)
   nokogiri (>= 1.7.1)


### PR DESCRIPTION
## Why was this change made?

We need to pin the mais-orcid-client so that the changes in the new API do not go into effect until we do the new gem release and update the codebase.
