### PR TITLE
Switch default database from MySQL to Postgres

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,63 +1,13 @@
 version: 2.1
-
 orbs:
-  codecov: codecov/codecov@5.2.0
-
-parameters:
-  ruby-version:
-    type: string
-    default: "3.4.1"
-
-jobs:
-  test:
-    docker:
-    - image: 'cimg/ruby:<< pipeline.parameters.ruby-version >>-node'
-      environment:
-        BUNDLE_JOBS: 3
-        BUNDLE_RETRY: 3
-        BUNDLE_PATH: vendor/bundle
-        RAILS_ENV: test
-        NOKOGIRI_USE_SYSTEM_LIBRARIES: true
-    - image: circleci/mysql:8
-      # https://discuss.circleci.com/t/solved-mysql-8-0-without-mysql2-authentication-plugin-caching-sha2-password-cannot-be-loaded/25791
-      command: [--default-authentication-plugin=mysql_native_password]
-      environment:
-        MYSQL_DATABASE: sulbib_test
-    steps:
-    - checkout
-    - run:
-        name: Install/Upgrade Bundler
-        command: gem install bundler
-    - run:
-        name: Which bundler?
-        command: bundle -v
-    - restore_cache:
-        keys:
-        - sul_pub-bundle-v2-{{ checksum "Gemfile.lock" }}
-        - sul_pub-bundle-v2-
-    - run:
-        name: Bundle Install
-        command: bundle check || bundle install
-    - save_cache:
-        key: sul_pub-bundle-v2-{{ checksum "Gemfile.lock" }}
-        paths:
-        - vendor/bundle
-    - run:
-        name: Check styles using rubocop
-        command: bundle exec rubocop
-    - run:
-        name: Wait for DB
-        command: dockerize -wait tcp://localhost:3306 -timeout 1m
-    - run:
-        name: Database setup
-        command: bin/rails db:test:prepare
-    - run:
-        name: Run rspec
-        command: bundle exec rspec
-    - codecov/upload
-
+  ruby-rails: sul-dlss/ruby-rails@4.6.0
 workflows:
-  version: 2
-  test:
+  build:
     jobs:
-    - test
+      - ruby-rails/lint:
+          name: lint
+          context: dlss
+      - ruby-rails/test-rails:
+          name: test
+          context: dlss
+          api-only: true # do not try to muck with JavaScript

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'rails', '~> 7.2.0'
-
-gem 'nokogiri', '>= 1.7.1'
-
 gem 'activerecord-import'
 gem 'bibtex-ruby'
 gem 'bootsnap', '>= 1.1.0', require: false
@@ -16,6 +12,8 @@ gem 'dotiw'
 gem 'faraday'
 gem 'faraday-httpclient'
 gem 'faraday-retry'
+gem 'hashie' # this used to be part of grape, but we still need it since we believe pub_hashes may still be seralized in the database this way 9/10/2018
+gem 'honeybadger'
 gem 'htmlentities', '~> 4.3'
 gem 'httpclient', '~> 2.8'
 gem 'identifiers', '~> 0.12' # Altmetric utilities related to the extraction, validation and normalization of various scholarly identifiers
@@ -24,19 +22,20 @@ gem 'json_schemer'
 gem 'kaminari'
 gem 'mais_orcid_client', '>= 1.0'
 gem 'mutex_m'  # needed because httpclient depends on it and is unmaintained
-gem 'okcomputer' # for monitoring
+gem 'nokogiri', '>= 1.7.1'
 gem 'oauth2'
+gem 'okcomputer' # for monitoring
 gem 'paper_trail'
 gem 'parallel'
+gem 'pg'
 gem 'pry' # make it possible to use pry for IRB
+gem 'rails', '~> 7.2.0'
 gem 'rake'
+gem 'retina_tag'
 gem 'StreetAddress', '~> 1.0', '>= 1.0.6'
 gem 'sul_orcid_client'
 gem 'whenever', require: false
 gem 'yaml_db'
-gem 'hashie' # this used to be part of grape, but we still need it since we believe pub_hashes may still be seralized in the database this way 9/10/2018
-gem 'honeybadger'
-gem 'retina_tag'
 
 group :development, :test do
   gem 'rubocop'
@@ -47,8 +46,8 @@ group :development, :test do
   gem 'rubocop-rspec'
   gem 'rubocop-rspec_rails'
   gem 'rspec'
+  gem 'rspec_junit_formatter' # used by CircleCI
   gem 'rspec-rails'
-  gem 'sqlite3'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -370,6 +370,7 @@ GEM
       racc
     patience_diff (1.2.0)
       optimist (~> 3.0)
+    pg (1.5.9)
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
@@ -462,6 +463,8 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.3)
+    rspec_junit_formatter (0.6.0)
+      rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (1.75.5)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -511,10 +514,6 @@ GEM
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
-    sqlite3 (2.6.0)
-      mini_portile2 (~> 2.8.0)
-    sqlite3 (2.6.0-x86_64-darwin)
-    sqlite3 (2.6.0-x86_64-linux-gnu)
     sshkit (1.24.0)
       base64
       logger
@@ -618,6 +617,7 @@ DEPENDENCIES
   okcomputer
   paper_trail
   parallel
+  pg
   pry
   pry-doc
   rails (~> 7.2.0)
@@ -626,6 +626,7 @@ DEPENDENCIES
   retina_tag
   rspec
   rspec-rails
+  rspec_junit_formatter
   rubocop
   rubocop-capybara
   rubocop-factory_bot
@@ -635,7 +636,6 @@ DEPENDENCIES
   rubocop-rspec_rails
   ruby-prof
   simplecov (~> 0.13)
-  sqlite3
   sul_orcid_client
   thin
   vcr

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Legacy configuration files to review are:
 - https://github.com/sul-dlss/sul_pub/blob/main/config/application.yml
   - Application configuration parameters (may not require any changes)
 - https://github.com/sul-dlss/sul_pub/blob/main/config/database.yml
-  - MySQL connection parameters
+  - PostgreSQL connection parameters
 
 # Developer Setup
 
@@ -34,26 +34,10 @@ bundle install
 
 ## Database Setup
 
-The application uses MySQL in production only, it uses Sqlite3 in development and test.  To create the initial databases:
+The application uses PostgreSQL in all environments. As a convenience, you may spin up a local Postgres instance using `docker compose up -d postgres`, and then:
 
 ```sh
-bundle exec rake db:create
-bundle exec rake db:migrate
-```
-
-There are some small differences between sqlite3 and mysql, notably mysql uses case insensitive string queries and sqlite3 does not.
-However, for development purposes, sqlite3 should be fine and the differences should not matter.
-
-If you'd like to use mysql locally too, you can, but you'll need to install the mysql2 gem and update the database.yml file.  You can use Docker or a local mysql install.
-
-For docker:
-```
-docker run --rm -e MYSQL_ALLOW_EMPTY_PASSWORD=true -p 3306:3306 -d mysql:8
-```
-and then:
-```
-RAILS_ENV=test bundle exec rake db:create
-RAILS_ENV=test bundle exec rake db:migrate
+bin/rake db:prepare
 ```
 
 ## Running the Test Suite
@@ -64,16 +48,16 @@ To run the test suite:
 
 ```sh
 # If necessary, use private configuration files.
-bundle exec rake ci
+bin/rake ci
 ```
 
 To run specific tests, use `rspec` directly, e.g.
 
 ```sh
 # Run only the publications_api_spec:
-RAILS_ENV=test bundle exec rspec spec/api/publications_api_spec.rb
+bundle exec rspec spec/api/publications_api_spec.rb
 # Run only a subset of the publications_api_spec:
-RAILS_ENV=test bundle exec rspec spec/api/publications_api_spec.rb:157
+bundle exec rspec spec/api/publications_api_spec.rb:157
 ```
 
 ### Running integration tests
@@ -83,7 +67,7 @@ This repository also uses the RSpec tag `data-integration` to define tests that 
 To run the `data-integration` tests, make sure that your private credentials are appropriately configured. There is a convenient rake task to use for running the specs:
 
 ```sh
-bundle exec rake spec:data-integration
+bin/rake spec:data-integration
 ```
 
 ### Private Configuration Files (and VCR Cassette generation)
@@ -122,7 +106,7 @@ Then remove the relevant VCR cassettes if needed, run the test suite and commit 
 ```sh
 # See commands above for using private configuration files.
 rm -rf fixtures/vcr_cassettes/*
-bundle exec rake ci
+bin/rake ci
 git add fixtures/vcr_cassettes/
 git commit -m "Update VCR cassettes"
 git reset --hard  # cleanup the private configuration files

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,16 +1,19 @@
 services:
-  mysqldb:
-   image: mysql
-   command: --default-authentication-plugin=mysql_native_password
+  mariadb:
+   image: mariadb:10.3 # the version installed on prod
    ports:
      - 3306:3306
    environment:
-     MYSQL_DATABASE: sulbib_development
-     MYSQL_ALLOW_EMPTY_PASSWORD: 'true'
-   volumes:
-     - mysql:/var/lib/mysql
-     - mysql_config:/etc/mysql
+     MARIADB_DATABASE: sul-pub # same DB name as prod
+     MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 1
+  postgres:
+    image: postgres:11
+    ports:
+      - 5432:5432
+    environment:
+      - POSTGRES_PASSWORD=sekret
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
 
 volumes:
-  mysql:
-  mysql_config:
+  postgres-data:

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,39 +1,24 @@
-# Derived from https://github.com/rails/rails/blob/v4.2.5.2/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml
-#
-# MySQL.  Versions 5.0+ are recommended.
-#
-# Install the MYSQL driver
-#   gem install mysql2
-#
-# Ensure the MySQL gem is defined in your Gemfile
-#   gem 'mysql2'
-#
-# And be sure to use new-style password hashing:
-#   http://dev.mysql.com/doc/refman/5.0/en/old-client.html
-#
 default: &default
-  adapter: sqlite3
-  pool: 5
+  adapter: postgresql
+  encoding: unicode
+  username: "<%= ENV.fetch('DATABASE_USERNAME', 'postgres') %>"
+  password: "<%= ENV.fetch('DATABASE_PASSWORD', 'sekret') %>"
+  host: "<%= ENV.fetch('DATABASE_HOSTNAME', 'localhost') %>"
+  port: "<%= ENV.fetch('DATABASE_PORT', 5432) %>"
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
 
-  # If you want to use mysql, e.g. with docker, use this instead of the adapter above
-  #  and change database names below for development and test:
-  # adapter: mysql2
-  # encoding: utf8
-  # username: root
-  # password:
-  # host: "<%= ENV.fetch('DATABASE_HOSTNAME', '127.0.0.1') %>"
-  # port: "<%= ENV.fetch('DATABASE_PORT', 3306) %>"
+production:
+  <<: *default
+  database: "<%= ENV.fetch('DATABASE_NAME', 'sul-pub') %>"
 
 development:
   <<: *default
-  database: db/development.sqlite3
-  # database: sulbib_development
+  database: "<%= ENV.fetch('DATABASE_NAME', 'sul-pub_development') %>"
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
-  # database: sulbib_test
+  database: "<%= ENV.fetch('DATABASE_NAME', 'sul-pub_test') %>"

--- a/db/migrate/20130703222701_change_pub_hash_to_medium_text.rb
+++ b/db/migrate/20130703222701_change_pub_hash_to_medium_text.rb
@@ -1,5 +1,5 @@
 class ChangePubHashToMediumText < ActiveRecord::Migration[4.2]
   def change
-    change_column :publications, :pub_hash, :text, limit: 16_777_215
+    change_column :publications, :pub_hash, :text, limit: 16_777_215 if ActiveRecord::Base.connection.adapter_name.match?(/mysql/i)
   end
 end

--- a/db/migrate/20160405194617_switch_to_medium_text.rb
+++ b/db/migrate/20160405194617_switch_to_medium_text.rb
@@ -3,23 +3,44 @@
 #
 class SwitchToMediumText < ActiveRecord::Migration[4.2]
   def change
-    # changing batch_uploaded_source_records
-    change_column :batch_uploaded_source_records, :bibtex_source_data, :text, limit: 16_777_215
-    change_column :batch_uploaded_source_records, :error_message, :text, limit: 16_777_215
+    if ActiveRecord::Base.connection.adapter_name.match?(/mysql/i)
+      # changing batch_uploaded_source_records
+      change_column :batch_uploaded_source_records, :bibtex_source_data, :text, limit: 16_777_215
+      change_column :batch_uploaded_source_records, :error_message, :text, limit: 16_777_215
 
-    # changing publications
-    change_column :publications, :xml, :text, limit: 16_777_215
+      # changing publications
+      change_column :publications, :xml, :text, limit: 16_777_215
 
-    # changing pubmed_source_records
-    change_column :pubmed_source_records, :source_data, :text, limit: 16_777_215
+      # changing pubmed_source_records
+      change_column :pubmed_source_records, :source_data, :text, limit: 16_777_215
 
-    # changing sciencewire_source_records
-    change_column :sciencewire_source_records, :source_data, :text, limit: 16_777_215
+      # changing sciencewire_source_records
+      change_column :sciencewire_source_records, :source_data, :text, limit: 16_777_215
 
-    # changing user_submitted_source_records
-    change_column :user_submitted_source_records, :source_data, :text, limit: 16_777_215
+      # changing user_submitted_source_records
+      change_column :user_submitted_source_records, :source_data, :text, limit: 16_777_215
 
-    # changing versions
-    change_column :versions, :object, :text, limit: 16_777_215
+      # changing versions
+      change_column :versions, :object, :text, limit: 16_777_215
+    else
+      # changing batch_uploaded_source_records
+      change_column :batch_uploaded_source_records, :bibtex_source_data, :text
+      change_column :batch_uploaded_source_records, :error_message, :text
+
+      # changing publications
+      change_column :publications, :xml, :text
+
+      # changing pubmed_source_records
+      change_column :pubmed_source_records, :source_data, :text
+
+      # changing sciencewire_source_records
+      change_column :sciencewire_source_records, :source_data, :text
+
+      # changing user_submitted_source_records
+      change_column :user_submitted_source_records, :source_data, :text
+
+      # changing versions
+      change_column :versions, :object, :text
+    end
   end
 end

--- a/db/migrate/20171213201429_wos_src_record_medium_text.rb
+++ b/db/migrate/20171213201429_wos_src_record_medium_text.rb
@@ -1,6 +1,10 @@
 class WosSrcRecordMediumText < ActiveRecord::Migration[4.2]
   def up
-    change_column :web_of_science_source_records, :source_data, :mediumtext
+    if ActiveRecord::Base.connection.adapter_name.match?(/mysql/i)
+      change_column :web_of_science_source_records, :source_data, :mediumtext
+    else
+      change_column :web_of_science_source_records, :source_data, :text
+    end
   end
 
   def down

--- a/db/migrate/20171215001732_wos_source_record_integer_pmid.rb
+++ b/db/migrate/20171215001732_wos_source_record_integer_pmid.rb
@@ -1,6 +1,10 @@
 class WosSourceRecordIntegerPmid < ActiveRecord::Migration[4.2]
   def up
-    change_column :web_of_science_source_records, :pmid, :integer
+    if ActiveRecord::Base.connection.adapter_name.match?(/mysql/i)
+      change_column :web_of_science_source_records, :pmid, :integer
+    else
+      change_column :web_of_science_source_records, :pmid, :integer, using: 'pmid::integer'
+    end
   end
 
   def down

--- a/db/migrate/20210520185112_create_orcid_source_records.rb
+++ b/db/migrate/20210520185112_create_orcid_source_records.rb
@@ -1,8 +1,12 @@
 class CreateOrcidSourceRecords < ActiveRecord::Migration[6.0]
-  # `:text` column with 16MB is the same as MySQL's MEDIUMTEXT but works on sqlite3
   def change
     create_table :orcid_source_records do |t|
-      t.text :source_data, limit: 16_777_215
+      if ActiveRecord::Base.connection.adapter_name.match?(/mysql/i)
+        # `:text` column with 16MB is the same as MySQL's MEDIUMTEXT but works on sqlite3
+        t.text :source_data, limit: 16_777_215
+      else
+        t.text :source_data
+      end
       t.bigint :last_modified_date
       t.string :orcidid
       t.string :put_code

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_18_164661) do
-  create_table "author_identities", force: :cascade do |t|
+ActiveRecord::Schema[7.2].define(version: 2022_07_18_164661) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "author_identities", id: :serial, force: :cascade do |t|
     t.integer "author_id", null: false
     t.string "first_name", limit: 255, null: false
     t.string "middle_name", limit: 255
@@ -25,11 +28,11 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_18_164661) do
     t.index ["author_id"], name: "index_author_identities_on_author_id"
   end
 
-  create_table "authors", force: :cascade do |t|
-    t.integer "cap_profile_id", limit: 4
+  create_table "authors", id: :serial, force: :cascade do |t|
+    t.integer "cap_profile_id"
     t.boolean "active_in_cap"
     t.string "sunetid", limit: 255
-    t.integer "university_id", limit: 4
+    t.integer "university_id"
     t.string "email", limit: 255
     t.string "cap_first_name", limit: 255
     t.string "cap_last_name", limit: 255
@@ -56,21 +59,21 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_18_164661) do
     t.index ["university_id"], name: "index_authors_on_university_id"
   end
 
-  create_table "batch_uploaded_source_records", force: :cascade do |t|
+  create_table "batch_uploaded_source_records", id: :serial, force: :cascade do |t|
     t.string "sunet_id", limit: 255
-    t.integer "author_id", limit: 4
-    t.integer "cap_profile_id", limit: 4
+    t.integer "author_id"
+    t.integer "cap_profile_id"
     t.boolean "successful_import"
-    t.text "bibtex_source_data", limit: 16777215
+    t.text "bibtex_source_data"
     t.string "source_fingerprint", limit: 255
     t.boolean "is_active"
-    t.text "title", limit: 65535
-    t.integer "year", limit: 4
+    t.text "title"
+    t.integer "year"
     t.string "batch_name", limit: 255
-    t.text "error_message", limit: 16777215
+    t.text "error_message"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
-    t.integer "publication_id", limit: 4
+    t.integer "publication_id"
     t.index ["author_id"], name: "index_batch_uploaded_source_records_on_author_id"
     t.index ["batch_name"], name: "index_batch_uploaded_source_records_on_batch_name"
     t.index ["cap_profile_id"], name: "index_batch_uploaded_source_records_on_cap_profile_id"
@@ -78,10 +81,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_18_164661) do
     t.index ["title"], name: "index_batch_uploaded_source_records_on_title"
   end
 
-  create_table "contributions", force: :cascade do |t|
-    t.integer "author_id", limit: 4, null: false
-    t.integer "cap_profile_id", limit: 4
-    t.integer "publication_id", limit: 4, null: false
+  create_table "contributions", id: :serial, force: :cascade do |t|
+    t.integer "author_id", null: false
+    t.integer "cap_profile_id"
+    t.integer "publication_id", null: false
     t.string "status", limit: 255
     t.boolean "featured"
     t.string "visibility", limit: 255
@@ -96,8 +99,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_18_164661) do
   end
 
   create_table "orcid_source_records", force: :cascade do |t|
-    t.text "source_data", limit: 16777215
-    t.integer "last_modified_date"
+    t.text "source_data"
+    t.bigint "last_modified_date"
     t.string "orcidid"
     t.string "put_code"
     t.string "source_fingerprint"
@@ -108,8 +111,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_18_164661) do
     t.index ["publication_id"], name: "index_orcid_source_records_on_publication_id", unique: true
   end
 
-  create_table "publication_identifiers", force: :cascade do |t|
-    t.integer "publication_id", limit: 4
+  create_table "publication_identifiers", id: :serial, force: :cascade do |t|
+    t.integer "publication_id"
     t.string "identifier_type", limit: 255
     t.string "identifier_value", limit: 255
     t.string "identifier_uri", limit: 255
@@ -123,16 +126,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_18_164661) do
     t.index ["publication_id"], name: "index_publication_identifiers_on_publication_id"
   end
 
-  create_table "publications", force: :cascade do |t|
-    t.integer "same_as_publications_id", limit: 4
+  create_table "publications", id: :serial, force: :cascade do |t|
+    t.integer "same_as_publications_id"
     t.boolean "active"
     t.boolean "deleted"
-    t.text "title", limit: 65535
-    t.integer "year", limit: 4
-    t.integer "lock_version", limit: 4
-    t.text "pub_hash", limit: 16777215
-    t.integer "pmid", limit: 4
-    t.integer "sciencewire_id", limit: 4
+    t.text "title"
+    t.integer "year"
+    t.integer "lock_version"
+    t.text "pub_hash"
+    t.integer "pmid"
+    t.integer "sciencewire_id"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "pages", limit: 255
@@ -149,10 +152,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_18_164661) do
     t.index ["year"], name: "index_publications_on_year"
   end
 
-  create_table "pubmed_source_records", force: :cascade do |t|
-    t.text "source_data", limit: 16777215
-    t.integer "pmid", limit: 4
-    t.integer "lock_version", limit: 4
+  create_table "pubmed_source_records", id: :serial, force: :cascade do |t|
+    t.text "source_data"
+    t.integer "pmid"
+    t.integer "lock_version"
     t.string "source_fingerprint", limit: 255
     t.boolean "is_active"
     t.datetime "created_at", precision: nil
@@ -160,11 +163,11 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_18_164661) do
     t.index ["pmid"], name: "index_pubmed_source_records_on_pmid"
   end
 
-  create_table "sciencewire_source_records", force: :cascade do |t|
-    t.text "source_data", limit: 16777215
-    t.integer "pmid", limit: 4
-    t.integer "sciencewire_id", limit: 4
-    t.integer "lock_version", limit: 4
+  create_table "sciencewire_source_records", id: :serial, force: :cascade do |t|
+    t.text "source_data"
+    t.integer "pmid"
+    t.integer "sciencewire_id"
+    t.integer "lock_version"
     t.string "source_fingerprint", limit: 255
     t.boolean "is_active"
     t.datetime "created_at", precision: nil
@@ -173,32 +176,32 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_18_164661) do
     t.index ["sciencewire_id"], name: "index_sciencewire_source_records_on_sciencewire_id"
   end
 
-  create_table "user_submitted_source_records", force: :cascade do |t|
-    t.text "source_data", limit: 16777215
-    t.integer "pmid", limit: 4
-    t.integer "lock_version", limit: 4
+  create_table "user_submitted_source_records", id: :serial, force: :cascade do |t|
+    t.text "source_data"
+    t.integer "pmid"
+    t.integer "lock_version"
     t.string "source_fingerprint", limit: 255
-    t.text "title", limit: 65535
-    t.integer "year", limit: 4
+    t.text "title"
+    t.integer "year"
     t.boolean "is_active"
-    t.integer "publication_id", limit: 4
-    t.integer "author_id", limit: 4
+    t.integer "publication_id"
+    t.integer "author_id"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.index ["source_fingerprint"], name: "index_user_submitted_source_records_on_source_fingerprint", unique: true
   end
 
-  create_table "versions", force: :cascade do |t|
+  create_table "versions", id: :serial, force: :cascade do |t|
     t.string "item_type", limit: 255, null: false
-    t.integer "item_id", limit: 4, null: false
+    t.integer "item_id", null: false
     t.string "event", limit: 255, null: false
     t.string "whodunnit", limit: 255
-    t.text "object", limit: 16777215
+    t.text "object"
     t.datetime "created_at", precision: nil
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
-  create_table "web_of_science_source_records", force: :cascade do |t|
+  create_table "web_of_science_source_records", id: :serial, force: :cascade do |t|
     t.boolean "active"
     t.string "database"
     t.text "source_data"


### PR DESCRIPTION
# Why was this change made?

Connects to #1783

Includes:
* Change DB config to use Postgres for all envs
* Remove MySQL-isms from DB migrations and allow `db:migrate` to function with Postgres underneath
* Remove unnecessary customization from CI config and use the ruby-rails-orb instead
* Add Postgres container to `docker compose`
* Reflect above changes in README

# How was this change tested?

`bin/rake db:drop db:create db:migrate`
