### PR TITLE
Remove explicit one-time key setup

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,7 +1,6 @@
 # see https://github.com/sul-dlss/sul_pub/wiki/Servers-Deployment-environment
 server 'sul-pub-prod.stanford.edu', user: 'pub', roles: %w(web db app harvester_prod external_monitor)
 
-Capistrano::OneTimeKey.generate_one_time_key!
 
 set :rails_env, 'production'
 

--- a/config/deploy/qa-temp.rb
+++ b/config/deploy/qa-temp.rb
@@ -3,7 +3,6 @@
 # see https://docs.google.com/document/d/14K09NJG1O6Zo8u0LfrxK5g8ADLTBZ_HzkAnEr_YAsS8
 server 'sul-pub-cap-dev-temp.stanford.edu', user: 'pub', roles: %w(web db app)
 
-Capistrano::OneTimeKey.generate_one_time_key!
 
 set :rails_env, 'production'
 

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,7 +1,6 @@
 # see https://github.com/sul-dlss/sul_pub/wiki/Servers-Deployment-environment
 server 'sul-pub-cap-dev-a.stanford.edu', user: 'pub', roles: %w(web db app)
 
-Capistrano::OneTimeKey.generate_one_time_key!
 
 set :rails_env, 'production'
 

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,7 +1,6 @@
 # see https://github.com/sul-dlss/sul_pub/wiki/Servers-Deployment-environment
 server 'sul-pub-stage.stanford.edu', user: 'pub', roles: %w(web db app)
 
-Capistrano::OneTimeKey.generate_one_time_key!
 
 set :rails_env, 'production'
 

--- a/config/deploy/uat-temp.rb
+++ b/config/deploy/uat-temp.rb
@@ -3,7 +3,6 @@
 # see https://docs.google.com/document/d/14K09NJG1O6Zo8u0LfrxK5g8ADLTBZ_HzkAnEr_YAsS8
 server 'sul-pub-cap-uat-temp.stanford.edu', user: 'pub', roles: %w(web db app external_monitor)
 
-Capistrano::OneTimeKey.generate_one_time_key!
 
 set :rails_env, 'production'
 

--- a/config/deploy/uat.rb
+++ b/config/deploy/uat.rb
@@ -1,7 +1,6 @@
 # see https://github.com/sul-dlss/sul_pub/wiki/Servers-Deployment-environment
 server 'sul-pub-cap-uat.stanford.edu', user: 'pub', roles: %w(web db app external_monitor)
 
-Capistrano::OneTimeKey.generate_one_time_key!
 
 set :rails_env, 'production'
 


### PR DESCRIPTION
This line has been a no-op since dlss-capistrano 5.2.0. Setting up the one-time key is done automatically in dlss-capistrano now.