### PR TITLE
Clean-up unnecessary references to MySQL/MariaDB

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,11 +69,6 @@ group :test do
   gem 'webmock'
 end
 
-group :production do
-  # mysql 0.5.3 is required for ruby 3 and is supported on latest OS in use: Oracle Linux (as of Jan 2022)
-  gem 'mysql2', '>= 0.5.3'
-end
-
 group :deployment do
   gem 'capistrano'
   gem 'capistrano-passenger'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -318,7 +318,6 @@ GEM
     multi_xml (0.7.2)
       bigdecimal (~> 3.1)
     mutex_m (0.3.0)
-    mysql2 (0.5.6)
     namae (1.2.0)
       racc (~> 1.7)
     net-http (0.6.0)
@@ -611,7 +610,6 @@ DEPENDENCIES
   listen (~> 3.7)
   mais_orcid_client (>= 1.0)
   mutex_m
-  mysql2 (>= 0.5.3)
   nokogiri (>= 1.7.1)
   oauth2
   okcomputer

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,13 +1,6 @@
 services:
-  mariadb:
-   image: mariadb:10.3 # the version installed on prod
-   ports:
-     - 3306:3306
-   environment:
-     MARIADB_DATABASE: sul-pub # same DB name as prod
-     MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 1
   postgres:
-    image: postgres:11
+    image: postgres:16 # use the same version as deployed environments
     ports:
       - 5432:5432
     environment:

--- a/db/migrate/20130703222701_change_pub_hash_to_medium_text.rb
+++ b/db/migrate/20130703222701_change_pub_hash_to_medium_text.rb
@@ -1,5 +1,10 @@
 class ChangePubHashToMediumText < ActiveRecord::Migration[4.2]
   def change
-    change_column :publications, :pub_hash, :text, limit: 16_777_215 if ActiveRecord::Base.connection.adapter_name.match?(/mysql/i)
+    # This migration was created when Argo ran on MySQL. The :text datatype is
+    # unlimited in Postgres so it does not need its limit bumped up. This
+    # migration is a no-op. Left the former migration commented out for
+    # posterity.
+    #
+    # change_column :publications, :pub_hash, :text, limit: 16_777_215
   end
 end

--- a/db/migrate/20160405194617_switch_to_medium_text.rb
+++ b/db/migrate/20160405194617_switch_to_medium_text.rb
@@ -1,46 +1,22 @@
-#
-# Switch our data-oriented `:text` columns to 16MBs (MySQL's MEDIUMTEXT)
-#
 class SwitchToMediumText < ActiveRecord::Migration[4.2]
   def change
-    if ActiveRecord::Base.connection.adapter_name.match?(/mysql/i)
-      # changing batch_uploaded_source_records
-      change_column :batch_uploaded_source_records, :bibtex_source_data, :text, limit: 16_777_215
-      change_column :batch_uploaded_source_records, :error_message, :text, limit: 16_777_215
+    # changing batch_uploaded_source_records
+    change_column :batch_uploaded_source_records, :bibtex_source_data, :text
+    change_column :batch_uploaded_source_records, :error_message, :text
 
-      # changing publications
-      change_column :publications, :xml, :text, limit: 16_777_215
+    # changing publications
+    change_column :publications, :xml, :text
 
-      # changing pubmed_source_records
-      change_column :pubmed_source_records, :source_data, :text, limit: 16_777_215
+    # changing pubmed_source_records
+    change_column :pubmed_source_records, :source_data, :text
 
-      # changing sciencewire_source_records
-      change_column :sciencewire_source_records, :source_data, :text, limit: 16_777_215
+    # changing sciencewire_source_records
+    change_column :sciencewire_source_records, :source_data, :text
 
-      # changing user_submitted_source_records
-      change_column :user_submitted_source_records, :source_data, :text, limit: 16_777_215
+    # changing user_submitted_source_records
+    change_column :user_submitted_source_records, :source_data, :text
 
-      # changing versions
-      change_column :versions, :object, :text, limit: 16_777_215
-    else
-      # changing batch_uploaded_source_records
-      change_column :batch_uploaded_source_records, :bibtex_source_data, :text
-      change_column :batch_uploaded_source_records, :error_message, :text
-
-      # changing publications
-      change_column :publications, :xml, :text
-
-      # changing pubmed_source_records
-      change_column :pubmed_source_records, :source_data, :text
-
-      # changing sciencewire_source_records
-      change_column :sciencewire_source_records, :source_data, :text
-
-      # changing user_submitted_source_records
-      change_column :user_submitted_source_records, :source_data, :text
-
-      # changing versions
-      change_column :versions, :object, :text
-    end
+    # changing versions
+    change_column :versions, :object, :text
   end
 end

--- a/db/migrate/20160412224434_create_author_identities.rb
+++ b/db/migrate/20160412224434_create_author_identities.rb
@@ -1,9 +1,6 @@
 class CreateAuthorIdentities < ActiveRecord::Migration[4.2]
   def change
-    # On MySQL, foreign keys require the InnoDB storage engine, and we need to ensure UTF8 charsets for strings
-    options = ActiveRecord::Base.connection.adapter_name.downcase.starts_with?('mysql') ? 'ENGINE=InnoDB DEFAULT CHARSET=utf8' : ''
-
-    create_table :author_identities, options: options do |t|
+    create_table :author_identities do |t|
       t.belongs_to :author,       index: true, foreign_key: true, null: false
       t.integer :identity_type,   limit: 1, default: 0, null: false # enum: :alternate = 0, :official, :preferred, or :primary
       t.string :first_name,       limit: 255, null: false

--- a/db/migrate/20171213201429_wos_src_record_medium_text.rb
+++ b/db/migrate/20171213201429_wos_src_record_medium_text.rb
@@ -1,13 +1,13 @@
+# This migration was created when Argo ran on MySQL. The :mediumtext datatype
+# does not exist in Postgres, and this field is now an unlimited :text field.
+# This migration is a no-op. Left the former migrations commented out for
+# posterity.
 class WosSrcRecordMediumText < ActiveRecord::Migration[4.2]
   def up
-    if ActiveRecord::Base.connection.adapter_name.match?(/mysql/i)
-      change_column :web_of_science_source_records, :source_data, :mediumtext
-    else
-      change_column :web_of_science_source_records, :source_data, :text
-    end
+    # change_column :web_of_science_source_records, :source_data, :mediumtext
   end
 
   def down
-    change_column :web_of_science_source_records, :source_data, :text
+    # change_column :web_of_science_source_records, :source_data, :text
   end
 end

--- a/db/migrate/20171215001732_wos_source_record_integer_pmid.rb
+++ b/db/migrate/20171215001732_wos_source_record_integer_pmid.rb
@@ -1,10 +1,6 @@
 class WosSourceRecordIntegerPmid < ActiveRecord::Migration[4.2]
   def up
-    if ActiveRecord::Base.connection.adapter_name.match?(/mysql/i)
-      change_column :web_of_science_source_records, :pmid, :integer
-    else
-      change_column :web_of_science_source_records, :pmid, :integer, using: 'pmid::integer'
-    end
+    change_column :web_of_science_source_records, :pmid, :integer, using: 'pmid::integer'
   end
 
   def down

--- a/db/migrate/20210520185112_create_orcid_source_records.rb
+++ b/db/migrate/20210520185112_create_orcid_source_records.rb
@@ -1,12 +1,7 @@
 class CreateOrcidSourceRecords < ActiveRecord::Migration[6.0]
   def change
     create_table :orcid_source_records do |t|
-      if ActiveRecord::Base.connection.adapter_name.match?(/mysql/i)
-        # `:text` column with 16MB is the same as MySQL's MEDIUMTEXT but works on sqlite3
-        t.text :source_data, limit: 16_777_215
-      else
-        t.text :source_data
-      end
+      t.text :source_data
       t.bigint :last_modified_date
       t.string :orcidid
       t.string :put_code


### PR DESCRIPTION
sul_pub is now a Postgres app in all envs and in containerland.

## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



