### PR TITLE
adjust whenever syntax so standard out is written to file

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -14,7 +14,7 @@ set :output, 'log/cron.log'
 
 # weekly orcid integration stats in prod output to time stamped log file
 every :monday, at: '1am', roles: [:harvester_prod] do
-  rake 'sul:orcid_integration_stats', output: "log/orcid_stats_`date +\%Y\%m\%d`.log"
+  rake 'sul:orcid_integration_stats', output: { standard: "log/orcid_stats_$(date +%Y%m%d).log" }
 end
 
 # bi-weekly harvest at 5pm in UAT, on the 8th and 23rd of the month


### PR DESCRIPTION
## Why was this change made?

Noticed the recent orcid output stats from the scheduled rake task were just empty files.  i think the syntax for redirecting standard out in whenever gem changed at some point.  Looked at documentation, adjusted code, and looked at what whenever gem will produce, and seems better now.  Tested on prod and produced output to file as expected.

Also adjusted filename production format to avoid potential shelling out issues.

See https://github.com/javan/whenever/wiki/Output-redirection-aka-logging-your-cron-jobs
